### PR TITLE
Allow Case insensitive matching for case sensitive file structures

### DIFF
--- a/src/main/java/se/llbit/chunky/main/Chunky.java
+++ b/src/main/java/se/llbit/chunky/main/Chunky.java
@@ -1034,7 +1034,15 @@ public class Chunky implements ChunkDiscoveryListener {
 	 * @return The minecraft.jar of the local Minecraft installation
 	 */
 	public static final File getMinecraftJar() {
-		return new File(Chunky.getMinecraftDirectory(), "bin/minecraft.jar");
+		File bin = new File(Chunky.getMinecraftDirectory(), "bin");
+		for (File file : bin.listFiles())
+		{
+			if (file.getName().equalsIgnoreCase("minecraft.jar"))
+			{
+				return new File(bin, file.getName());
+			}
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
I had the issue of Chunky generating an error that it couldn't load the default texture pack. Looking through the code, I see that you specifically look for a minecraft.jar, all lower case. On my linux machines, this would sometimes return an error because my jar would occasionally be named Minecraft.jar

This check allows for the minecraft.jar to be found, regardless of case.
