### PR TITLE
Update water height render controls upon scene load.

### DIFF
--- a/src/main/java/se/llbit/chunky/renderer/ui/RenderControls.java
+++ b/src/main/java/se/llbit/chunky/renderer/ui/RenderControls.java
@@ -2146,6 +2146,7 @@ public class RenderControls extends JDialog implements ViewListener,
 		updatePostprocessCB();
 		cloudHeight.update();
 		rayDepth.update();
+		updateWaterHeight();
 		updateCameraDirection();
 		updateCameraPosition();
 		enableEmitters.setSelected(renderMan.scene().getEmittersEnabled());


### PR DESCRIPTION
This fixes the issue that Chunky seemed to forget the 'water world mode' setting when loading a saved scene.
