### PR TITLE
Improve the Open Scene Directory buttons

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -538,7 +538,9 @@ public class ChunkyFxController
       }
     });
 
-    openSceneDirBtn.setOnAction(e -> openSceneDirectory());
+    openSceneDirBtn.setTooltip(
+        new Tooltip("Open the directory where Chunky stores scene descriptions and renders."));
+    openSceneDirBtn.setOnAction(e -> openDirectory(chunky.options.sceneDir));
 
     changeSceneDirBtn.setOnAction(e -> SceneDirectoryPicker.changeSceneDirectory(chunky.options));
 
@@ -853,9 +855,8 @@ public class ChunkyFxController
     return mapLoader;
   }
 
-  public void openSceneDirectory() {
-    File sceneDir = chunky.options.sceneDir;
-    if (sceneDir != null) {
+  public void openDirectory(File directory) {
+    if (directory != null && directory.isDirectory()) {
       // Running Desktop.open() on the JavaFX application thread seems to
       // lock up the application on Linux, so we create a new thread to run that.
       // This StackOverflow question seems to ask about the same bug:
@@ -863,12 +864,12 @@ public class ChunkyFxController
       new Thread(() -> {
         try {
           if (Desktop.isDesktopSupported()) {
-            Desktop.getDesktop().open(sceneDir);
+            Desktop.getDesktop().open(directory);
           } else {
             Log.warn("Can not open system file browser.");
           }
         } catch (IOException e1) {
-          Log.warn("Failed to open scene directory.", e1);
+          Log.warn("Failed to open directory.", e1);
         }
       }).start();
     }

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -217,8 +217,8 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       renderControls.showPopup("Reload the chunks for this to take effect.", yMax);
     });
     openSceneDirBtn.setTooltip(
-        new Tooltip("Open the directory where Chunky stores scene descriptions and renders."));
-    openSceneDirBtn.setOnAction(e -> chunkyFxController.openSceneDirectory());
+        new Tooltip("Open the directory where Chunky stores the scene description and renders of this scene."));
+    openSceneDirBtn.setOnAction(e -> chunkyFxController.openDirectory(chunkyFxController.getRenderController().getContext().getSceneDirectory()));
     loadSelectedChunks
         .setTooltip(new Tooltip("Load the chunks that are currently selected in the map view"));
     loadSelectedChunks.setOnAction(e -> {

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -132,8 +132,8 @@
           <Button fx:id="editResourcePacks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Edit resource packs"/>
           <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures (needs restart)"/>
           <CheckBox fx:id="showLauncherBtn" mnemonicParsing="false" text="Show launcher when starting Chunky"/>
-          <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open Scene Directory"/>
-          <Button fx:id="changeSceneDirBtn" mnemonicParsing="false" text="Change Scene Directory"/>
+          <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open Scenes Directory"/>
+          <Button fx:id="changeSceneDirBtn" mnemonicParsing="false" text="Change Scenes Directory"/>
         </VBox>
       </Tab>
       <Tab fx:id="aboutTab" text="About">


### PR DESCRIPTION
Make open scene directory open the directory of the current scene instead of the directory of all scenes. Change labels to make the buttons more clear.