### PR TITLE
Emitter sampling

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/EmitterSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/EmitterSamplingStrategy.java
@@ -1,0 +1,5 @@
+package se.llbit.chunky.renderer;
+
+public enum EmitterSamplingStrategy {
+  None, One, All
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/EmitterSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/EmitterSamplingStrategy.java
@@ -1,5 +1,5 @@
 package se.llbit.chunky.renderer;
 
 public enum EmitterSamplingStrategy {
-  None, One, All
+  NONE, ONE, ALL
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -166,9 +166,9 @@ public class PathTracer implements RayTracer {
               ray.emittance.z = ray.color.z * ray.color.z *
                   currentMat.emittance * scene.emitterIntensity;
               hit = true;
-            } else if(scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.None) {
+            } else if(scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.NONE) {
               // Sample emitter
-              boolean sampleOne = scene.emitterSamplingStrategy == EmitterSamplingStrategy.One;
+              boolean sampleOne = scene.emitterSamplingStrategy == EmitterSamplingStrategy.ONE;
               if(sampleOne) {
                 Grid.EmitterPosition pos = scene.getEmitterGrid().sampleEmitterPosition((int) ray.o.x, (int) ray.o.y, (int) ray.o.z, random);
                 if(pos != null) {
@@ -402,6 +402,15 @@ public class PathTracer implements RayTracer {
     return hit;
   }
 
+  /**
+   * Cast a shadow ray from the intersection point (given by ray) to the emitter
+   * at position pos. Returns the contribution of this emitter (0 if the emitter is occluded)
+   * @param scene The scene being rendered
+   * @param ray The ray that generated the intersection
+   * @param pos The position of the emitter to sample
+   * @param random RNG
+   * @return The contribution of the emitter
+   */
   private static Vector4 sampleEmitter(Scene scene, Ray ray, Grid.EmitterPosition pos, Random random) {
     Vector4 indirectEmitterColor = new Vector4();
     Ray emitterRay = new Ray();

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -751,7 +751,7 @@ public class Scene implements JsonSerializable, Refreshable {
       palette = new BlockPalette();
       worldOctree = new Octree(octreeImplementation, requiredDepth);
       waterOctree = new Octree(octreeImplementation, requiredDepth);
-      emitterGrid = new Grid(requiredDepth, 32); // TODO Make configurable
+      emitterGrid = new Grid(requiredDepth, 10); // TODO Make configurable
 
       // Parse the regions first - force chunk lists to be populated!
       Set<ChunkPosition> regions = new HashSet<>();

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -28,13 +28,7 @@ import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.entity.PaintingEntity;
 import se.llbit.chunky.entity.PlayerEntity;
-import se.llbit.chunky.renderer.OutputMode;
-import se.llbit.chunky.renderer.Postprocess;
-import se.llbit.chunky.renderer.Refreshable;
-import se.llbit.chunky.renderer.RenderContext;
-import se.llbit.chunky.renderer.RenderMode;
-import se.llbit.chunky.renderer.ResetReason;
-import se.llbit.chunky.renderer.WorkerState;
+import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.resources.OctreeFileFormat;
@@ -193,6 +187,8 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean saveSnapshots = false;
   protected boolean emittersEnabled = DEFAULT_EMITTERS_ENABLED;
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
+  protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.None;
+
   protected boolean sunEnabled = true;
   /**
    * Water opacity modifier.
@@ -410,6 +406,7 @@ public class Scene implements JsonSerializable, Refreshable {
     sunEnabled = other.sunEnabled;
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
+    emitterSamplingStrategy = other.emitterSamplingStrategy;
     transparentSky = other.transparentSky;
     fogDensity = other.fogDensity;
     skyFogDensity = other.skyFogDensity;
@@ -2454,6 +2451,7 @@ public class Scene implements JsonSerializable, Refreshable {
       json.add("actors", actorArray);
     }
     json.add("octreeImplementation", octreeImplementation);
+    json.add("emitterSamplingStrategy", emitterSamplingStrategy.name());
 
     return json;
   }
@@ -2740,6 +2738,8 @@ public class Scene implements JsonSerializable, Refreshable {
     }
 
     octreeImplementation = json.get("octreeImplementation").asString(PersistentSettings.getOctreeImplementation());
+
+    emitterSamplingStrategy = EmitterSamplingStrategy.valueOf(json.get("emitterSamplingStrategy").asString("None"));
   }
 
   /**
@@ -2993,4 +2993,14 @@ public class Scene implements JsonSerializable, Refreshable {
     this.octreeImplementation = octreeImplementation;
   }
 
+  public EmitterSamplingStrategy getEmitterSamplingStrategy() {
+    return emitterSamplingStrategy;
+  }
+
+  public void setEmitterSamplingStrategy(EmitterSamplingStrategy emitterSamplingStrategy) {
+    if(this.emitterSamplingStrategy != emitterSamplingStrategy) {
+      this.emitterSamplingStrategy = emitterSamplingStrategy;
+      refresh();
+    }
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -187,7 +187,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean saveSnapshots = false;
   protected boolean emittersEnabled = DEFAULT_EMITTERS_ENABLED;
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
-  protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.None;
+  protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
   protected boolean sunEnabled = true;
   /**
@@ -464,7 +464,7 @@ public class Scene implements JsonSerializable, Refreshable {
       saveGrassTexture(context, taskTracker);
       saveFoliageTexture(context, taskTracker);
       saveDump(context, taskTracker);
-      saveGrid(context, taskTracker);
+      saveEmitterGrid(context, taskTracker);
     }
   }
 
@@ -507,10 +507,10 @@ public class Scene implements JsonSerializable, Refreshable {
     }
 
     // Try loading the grid unconditionally for now
-    boolean gridLoaded = loadGrid(context, taskTracker);
+    boolean emiiterGridLoaded = loadEmitterGrid(context, taskTracker);
     boolean octreeLoaded = loadOctree(context, taskTracker);
-    if (!gridLoaded || !octreeLoaded) {
-      // Could not load stored octree.
+    if (!emiiterGridLoaded || !octreeLoaded) {
+      // Could not load stored octree or emitter grid.
       // Load the chunks from the world.
       if (loadedWorld == EmptyWorld.INSTANCE) {
         Log.warn("Could not load chunks (no world found for scene)");
@@ -1789,8 +1789,8 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
-  private synchronized void saveGrid(RenderContext context, TaskTracker progress) {
-    String filename = name + ".grid";
+  private synchronized void saveEmitterGrid(RenderContext context, TaskTracker progress) {
+    String filename = name + ".emittergrid";
     // TODO Not save when unchanged?
     try(TaskTracker.Task task = progress.task("Saving Grid")) {
       Log.info("Saving Grig " + filename);
@@ -1893,8 +1893,8 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
-  private synchronized boolean loadGrid(RenderContext context, TaskTracker progress) {
-    String filename = name + ".grid";
+  private synchronized boolean loadEmitterGrid(RenderContext context, TaskTracker progress) {
+    String filename = name + ".emittergrid";
     try(TaskTracker.Task task = progress.task("Loading grid")) {
       Log.info("Load grid " + filename);
       try(DataInputStream in = new DataInputStream(new GZIPInputStream(context.getSceneFileInputStream(filename)))) {
@@ -2739,7 +2739,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
     octreeImplementation = json.get("octreeImplementation").asString(PersistentSettings.getOctreeImplementation());
 
-    emitterSamplingStrategy = EmitterSamplingStrategy.valueOf(json.get("emitterSamplingStrategy").asString("None"));
+    emitterSamplingStrategy = EmitterSamplingStrategy.valueOf(json.get("emitterSamplingStrategy").asString("NONE"));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
@@ -22,9 +22,11 @@ import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.paint.Color;
+import se.llbit.chunky.renderer.EmitterSamplingStrategy;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.renderer.scene.Sky;
 import se.llbit.chunky.renderer.scene.Sun;
@@ -51,6 +53,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private CheckBox enableSunlight;
   @FXML private CheckBox drawSun;
   @FXML private LuxColorPicker sunColor;
+  @FXML private ChoiceBox<EmitterSamplingStrategy> emitterSamplingStrategy;
 
   private ChangeListener<Color> sunColorListener = (observable, oldValue, newValue) ->
       scene.sun().setColor(ColorUtil.fromFx(newValue));
@@ -101,6 +104,13 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     drawSun.setTooltip(new Tooltip("Draws the sun texture on top of the skymap."));
 
     sunColor.colorProperty().addListener(sunColorListener);
+
+    emitterSamplingStrategy.getItems().addAll(EmitterSamplingStrategy.values());
+    emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
+            .addListener((observable, oldvalue, newvalue) -> {
+              scene.setEmitterSamplingStrategy(newvalue);
+            });
+    emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce"));
   }
 
   @Override public void setController(RenderControlsFxController controller) {
@@ -119,6 +129,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunColor.colorProperty().removeListener(sunColorListener);
     sunColor.setColor(ColorUtil.toFx(scene.sun().getColor()));
     sunColor.colorProperty().addListener(sunColorListener);
+    emitterSamplingStrategy.getSelectionModel().select(scene.getEmitterSamplingStrategy());
   }
 
   @Override public String getTabTitle() {

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -1,0 +1,92 @@
+package se.llbit.math;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class Grid {
+  /**
+   * TODO Add an explanation
+   */
+  public static class EmitterPosition {
+    public EmitterPosition(int x, int y, int z) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+    }
+
+    public int x, y, z;
+  }
+
+  private final int cellSize;
+  private List<EmitterPosition> emitterPositions = new ArrayList<>(); // Stored as an object array, may need to be flattened later to improve memory usage
+
+  // Instead of each Cell storing its indexes, we could have a single flat array
+  // that is the concatenation of each of those arrays and each cell would have to only
+  // store the start and end (or size) of their subarray
+  // This would also mean that Cells would only be 2 ints and could be stored directly in a flat array
+  // But this would make the implementation more complex so we'll se later
+  private static class Cell {
+    public List<Integer> indexes = new ArrayList<>();
+  }
+
+  private final int gridSize;
+  private Cell[] grid;
+
+  public Grid(int octreeDepth, int cellSize) {
+    this.cellSize = cellSize;
+    long totalSize = (1L << octreeDepth);
+    this.gridSize = (int) ((totalSize + (cellSize-1)) / cellSize);
+  }
+
+  public void addEmitter(int x, int y, int z) {
+    emitterPositions.add(new EmitterPosition(x, y, z));
+  }
+
+  private int cellIndex(int x, int y, int z) {
+    return ((y * gridSize) + x) * gridSize + z;
+  }
+
+  public void prepare() {
+    grid = new Cell[gridSize*gridSize*gridSize];
+    for(int i = 0; i < grid.length; ++i) {
+      grid[i] = new Cell();
+    }
+
+    for(int i = 0; i < emitterPositions.size(); ++i) {
+      EmitterPosition pos = emitterPositions.get(i);
+      int gridX = pos.x / cellSize;
+      int gridY = pos.y / cellSize;
+      int gridZ = pos.z / cellSize;
+      // Add the emitter to its cell and all neighboring cells
+      for(int dy = -1; dy <= 1; ++dy) {
+        for(int dx = -1; dx <= 1; ++dx) {
+          for(int dz = -1; dz <= 1; ++dz) {
+            int index = cellIndex(gridX+dx, gridY+dy, gridZ+dz);
+            grid[index].indexes.add(i);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the position of an emitter not far from the point given in world coordinates
+   * or null if no such emitter exist
+   * @param x
+   * @param y
+   * @param z
+   * @param random
+   * @return
+   */
+  EmitterPosition sampleEmitterPosition(int x, int y, int z, Random random) {
+    int gridX = x / cellSize;
+    int gridY = y / cellSize;
+    int gridZ = z / cellSize;
+    int index = cellIndex(gridX, gridY, gridZ);
+    Cell cell = grid[index];
+    int randomIndex = random.nextInt(cell.indexes.size());
+    int emitterIndex = cell.indexes.get(randomIndex);
+    return emitterPositions.get(emitterIndex);
+  }
+}

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -62,8 +62,13 @@ public class Grid {
       for(int dy = -1; dy <= 1; ++dy) {
         for(int dx = -1; dx <= 1; ++dx) {
           for(int dz = -1; dz <= 1; ++dz) {
-            int index = cellIndex(gridX+dx, gridY+dy, gridZ+dz);
-            grid[index].indexes.add(i);
+            int x = gridX+dx;
+            int y = gridY+dy;
+            int z = gridZ+dz;
+            if(x >= 0 && x < gridSize && y>= 0 && y < gridSize && z >= 0 && z < gridSize) {
+              int index = cellIndex(x, y, z);
+              grid[index].indexes.add(i);
+            }
           }
         }
       }
@@ -79,12 +84,14 @@ public class Grid {
    * @param random
    * @return
    */
-  EmitterPosition sampleEmitterPosition(int x, int y, int z, Random random) {
+  public EmitterPosition sampleEmitterPosition(int x, int y, int z, Random random) {
     int gridX = x / cellSize;
     int gridY = y / cellSize;
     int gridZ = z / cellSize;
     int index = cellIndex(gridX, gridY, gridZ);
     Cell cell = grid[index];
+    if(cell.indexes.size() == 0)
+      return null;
     int randomIndex = random.nextInt(cell.indexes.size());
     int emitterIndex = cell.indexes.get(randomIndex);
     return emitterPositions.get(emitterIndex);

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -96,4 +96,17 @@ public class Grid {
     int emitterIndex = cell.indexes.get(randomIndex);
     return emitterPositions.get(emitterIndex);
   }
+
+  public List<EmitterPosition> getEmitterPositions(int x, int y, int z) {
+    int gridX = x / cellSize;
+    int gridY = y / cellSize;
+    int gridZ = z / cellSize;
+    int index = cellIndex(gridX, gridY, gridZ);
+    Cell cell = grid[index];
+    List<EmitterPosition> pos = new ArrayList<>();
+    for(Integer i : cell.indexes) {
+      pos.add(emitterPositions.get(i));
+    }
+    return pos;
+  }
 }

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -1,12 +1,24 @@
 package se.llbit.math;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 public class Grid {
+  private static final int GRID_FORMAT_VERSION = 0;
+
   /**
-   * TODO Add an explanation
+   * Holds a 3D grid of blocks cube
+   * Each cell of the grid holds the position of the emitters present in this cell and in neighboring cells
+   * As such when we want to sample emitters close from an intersection point, we only have to look at
+   * the cell where this intersection falls in and we will find every emitters we are interested in.
+   * The reason we need to hold emitter of neighboring cells is because emitters a fex block away from the intersection point
+   * to have an effect even if it falls in a different cell.
+   * With this every emitters away for cellSize or less blocks from the intersection points will always be found.
+   * The maximum distance where an emitter can be found in some cases is 2*cellSize-1 blocks away.
    */
   public static class EmitterPosition {
     public EmitterPosition(int x, int y, int z) {
@@ -39,6 +51,12 @@ public class Grid {
     this.gridSize = (int) ((totalSize + (cellSize-1)) / cellSize);
   }
 
+  // Constructor used by the load method
+  private Grid(int gridSize, int cellSize, int overloadSelectFlag /*unused*/) {
+    this.gridSize = gridSize;
+    this.cellSize = cellSize;
+  }
+
   public void addEmitter(int x, int y, int z) {
     emitterPositions.add(new EmitterPosition(x, y, z));
   }
@@ -47,6 +65,10 @@ public class Grid {
     return ((y * gridSize) + x) * gridSize + z;
   }
 
+  /**
+   * Needs to be call when every emitter has been added
+   * Builds the grid itself
+   */
   public void prepare() {
     grid = new Cell[gridSize*gridSize*gridSize];
     for(int i = 0; i < grid.length; ++i) {
@@ -78,11 +100,6 @@ public class Grid {
   /**
    * Returns the position of an emitter not far from the point given in world coordinates
    * or null if no such emitter exist
-   * @param x
-   * @param y
-   * @param z
-   * @param random
-   * @return
    */
   public EmitterPosition sampleEmitterPosition(int x, int y, int z, Random random) {
     int gridX = x / cellSize;
@@ -97,6 +114,9 @@ public class Grid {
     return emitterPositions.get(emitterIndex);
   }
 
+  /**
+   * Get the list of emitters position close from a given point
+   */
   public List<EmitterPosition> getEmitterPositions(int x, int y, int z) {
     int gridX = x / cellSize;
     int gridY = y / cellSize;
@@ -108,5 +128,71 @@ public class Grid {
       pos.add(emitterPositions.get(i));
     }
     return pos;
+  }
+
+  /**
+   * Stores the grid in the given stream
+   * @param out The output stream
+   */
+  public void store(DataOutputStream out) throws IOException {
+    out.writeInt(GRID_FORMAT_VERSION);
+
+    out.writeInt(gridSize);
+    out.writeInt(cellSize);
+
+    // Write every emitter position
+    out.writeInt(emitterPositions.size());
+    for(EmitterPosition pos : emitterPositions) {
+      out.writeInt(pos.x);
+      out.writeInt(pos.y);
+      out.writeInt(pos.z);
+    }
+
+    // Write, for each cell, how many emitters are contained and their indexes in the array written earlier
+    for(Cell cell : grid) {
+      out.writeInt(cell.indexes.size());
+      for(int index : cell.indexes) {
+        out.writeInt(index);
+      }
+    }
+  }
+
+  /**
+   * Load the grid from the given input stream
+   * @param in The input stream to read the grid from
+   * @return The grid
+   */
+  public static Grid load(DataInputStream in) throws IOException {
+    int version = in.readInt();
+    if(version != GRID_FORMAT_VERSION) {
+      throw new RuntimeException("Unknown grid format version, can't load the grid");
+    }
+
+    int gridSize = in.readInt();
+    int cellSize = in.readInt();
+    Grid grid = new Grid(gridSize, cellSize, 0);
+
+    // Read emitter positions
+    int emitterNo = in.readInt();
+    grid.emitterPositions = new ArrayList<>(emitterNo);
+    for(int i = 0; i < emitterNo; ++i) {
+      int x = in.readInt();
+      int y = in.readInt();
+      int z = in.readInt();
+      grid.emitterPositions.add(new EmitterPosition(x, y, z));
+    }
+
+    grid.grid = new Cell[gridSize*gridSize*gridSize];
+    for(int cellIndex = 0; cellIndex < grid.grid.length; ++cellIndex) {
+      Cell cell = new Cell();
+      int posNo = in.readInt();
+      for(int posIndex = 0; posIndex < posNo; ++posIndex) {
+        int index = in.readInt();
+        cell.indexes.add(index);
+      }
+      grid.grid[cellIndex] = cell;
+    }
+
+    return grid;
   }
 }

--- a/chunky/src/res/se/llbit/chunky/ui/render/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/LightingTab.fxml
@@ -10,12 +10,19 @@
 
 <?import se.llbit.chunky.ui.AngleAdjuster?>
 <?import se.llbit.fx.LuxColorPicker?>
+<?import javafx.scene.control.ChoiceBox?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
     <VBox spacing="10.0">
       <children>
         <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
         <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
         <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
+        <HBox alignment="CENTER_LEFT" spacing="10.0">
+          <children>
+            <Label text="Emitter Sampling Strategy:" />
+            <ChoiceBox fx:id="emitterSamplingStrategy"/>
+          </children>
+        </HBox>
         <CheckBox fx:id="enableSunlight" mnemonicParsing="false" text="Enable sunlight" />
         <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
         <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />


### PR DESCRIPTION
This PR is what i showed yesterday on discord, i'm making a draft PR to get some feedback if some of you have ideas on how to improve that.

So, what's that?
This adds emitter sampling to the renderer to greatly increase convergence of scene with emitters. The reason usually scenes lit up only by sun and sky converge quickly is because at every intersection, the sun is sampled, adding its contribution to the ray without the need of a ray randomly hitting it. On the other hand emitters are not sampled so to contribute to the ray, we need to randomly hit them and, especially with small emitters like torches, the probability is low.
The idea is then to sample emitter the same way we sample the sun so as to need solely relying on this low probability.
But whereas there is only one sun in the scene, they could be a lot of emitters. Additionally, emitters that are far away don't contribute a lot. Given that it wouldn't be practical to sample every emitter and the fact we only really care about the close ones, i added a new data structure, the `Grid` that holds the position of emitters in each of its cell (let's say a cell is 16*16*16 blocks) (and the position of the emitters that are in neighboring cells to prevent having a block close to an emitter not being lit up by it because they are in different cells)

I tried two sampling strategies. The first ones is to, for each intersection, sample a single emitter, and the second one is to sample every emitters.

One emitter sample for every intersection, at 50SPP:
![night-test-50-sample-one-same-view](https://user-images.githubusercontent.com/23342398/88956070-1a3b1700-d29d-11ea-8775-39182ded68d1.png)

All emitter sample for every intersection, at 50SPP:
![night-test-50-sample-all](https://user-images.githubusercontent.com/23342398/88956077-1c04da80-d29d-11ea-83d4-6d97b6e6b45e.png)

Obviously sampling every emitters gives a much better render but it has a big cost. Indeed for every emitter we want to sample, we need to cast a ray from the intersection point to emitter (called a "shadow ray") to check if there is nothing in-between hiding the light. This operation is complex so doing it for every emitter increases drastically the time required for one SPP ( = SPS is very low).
I haven't done enough testing to know what is the best solution but i'll surely do is let the user choose between those strategy (and the no emitter sampling strategy).


For now, this is highly experimental, here is a list of what i need to do before this is complete (sorted by importance i think):
 - Allow saving and loading the `Grid`, i haven't implemented  atm so i need to reload chunks everytime
 - Add ui option to choose the sampling strategy
 - Take fog into account. For now the effects of the fog on the distance traveled from the emitter to the intersection are not accounted for. Although the distance is usually short, this is incorrect

Things i should do but are not mandatory:
 - Improve the `Grid` implementation to be more memory efficient (the same way `PackedOctree` is done)
 - Allow the user to choose the grid's cells size. This is hardcoded for now but it could be interesting for some users to be able to change it as it  would offer different trade-offs
 - Allow the user to indicate that they doesn't want this additional data structure when making a render without emitters (or with emitters but no sampling but i really think this is superior) so as to not waste memory

Things that would be ideal to do but i'm not sure i'm able to:
 - Implement this so it work with every rays, not only rays generated from diffuse reflexion