### PR TITLE
Adjust fogDensity slider to allow for light fog.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -102,9 +102,9 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudZ.onValueChange(value -> scene.sky().setCloudZOffset(value));
 
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");
-    fogDensity.setRange(0, 2);
-    fogDensity.clampMin();
+    fogDensity.setRange2(0, 1);
     fogDensity.makeLogarithmic();
+    fogDensity.clampMin();
     fogDensity.onValueChange(value -> scene.setFogDensity(value));
 
     skyFogDensity.setTooltip(

--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -102,7 +102,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudZ.onValueChange(value -> scene.sky().setCloudZOffset(value));
 
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");
-    fogDensity.setRange2(0, 1);
+    fogDensity.setRange(0, 1, 0.001);
     fogDensity.makeLogarithmic();
     fogDensity.clampMin();
     fogDensity.onValueChange(value -> scene.setFogDensity(value));

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -64,6 +64,12 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     }
   }
 
+  public void setRange2(double min, double max) {
+    sliderMin = 0.001;
+    this.min = min;
+    this.max = max;
+  }
+
   /**
    * Make the adjuster use a logarithmic mapping for the slider position.
    */

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -64,8 +64,8 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     }
   }
 
-  public void setRange2(double min, double max) {
-    sliderMin = 0.001;
+  public void setRange(double min, double max, double SliderMin) {
+    sliderMin = SliderMin;
     this.min = min;
     this.max = max;
   }

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -51,23 +51,17 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
   }
 
   public void setRange(double min, double max) {
-    if (min < 0.01 && min >= 0) {
-      sliderMin = 0.01;
-    } else {
-      sliderMin = min;
-    }
+    setRange(min, max, min < 0.01 && min >= 0 ? 0.01 : min);
+  }
+
+  public void setRange(double min, double max, double sliderMin) {
+    this.sliderMin = sliderMin;
     this.min = min;
     this.max = max;
     if (!logarithmic) {
       valueSlider.setMin(min);
       valueSlider.setMax(max);
     }
-  }
-
-  public void setRange(double min, double max, double SliderMin) {
-    sliderMin = SliderMin;
-    this.min = min;
-    this.max = max;
   }
 
   /**


### PR DESCRIPTION
First time coding Java, plus doing it blind...

fogDensity 0.01 is considered light fog & 0.1 heavy. Having a logarithmic slider here was an improvement but I do feel that offering fogDensity between [0.01 - 2] was not optimal.

Changed the fogDensity range to be [0.001 - 1]; covering from very light fog (0.001) > light fog (0.01) > heavy fog (0.1) > very heavy fog (1).

Opted to create setRange2() as to not break dependencies with setRange() and the 0.01 lower limit for logarithmic calculations (seems to work fine with the fogDensity mind you). - I would have used an optional arg here but I wasn't sure the best approach.. so new method?