### PR TITLE
Fix corrupted chunk loading

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -58,7 +58,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     RegionChangeWatcher regionWatcher = new RegionChangeWatcher(this, mapView);
 
     // Start worker threads.
-    RegionParser[] regionParsers = new RegionParser[3];
+    RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", "3"))];
     for (int i = 0; i < regionParsers.length; ++i) {
       regionParsers[i] = new RegionParser(this, regionQueue, mapView);
       regionParsers[i].start();

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -153,7 +153,10 @@ public class Chunk {
     request.add(Chunk.LEVEL_BIOMES);
     request.add(Chunk.LEVEL_HEIGHTMAP);
     Map<String, Tag> data = getChunkData(request);
-
+    // TODO: improve error handling here.
+    if (data == null) {
+      return;
+    }
     surfaceTimestamp = dataTimestamp;
     version = chunkVersion(data);
     loadSurface(data);


### PR DESCRIPTION
Fixes #651 (for real this time, I tested it with that world) and adds a system property to customize the number of map loader threads (useful for large worlds, i.e. `-Dchunky.mapThreads=32`).