### PR TITLE
Temp fix for not being able to disable fog

### DIFF
--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -55,7 +55,7 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
   }
 
   public void setRange(double min, double max, double sliderMin) {
-    this.sliderMin = sliderMin;
+    this.sliderMin = 0.001; // TODO Figure out why using double `sliderMin` here leads to a 4.9E-324 in DoubleAdjuster.java but hardcoding doubles doesn't.
     this.min = min;
     this.max = max;
     if (!logarithmic) {


### PR DESCRIPTION
Need to figure out why using double `sliderMin` here leads to a 4.9E-324 in DoubleAdjuster.java but hardcoding doubles doesn't.