### PR TITLE
Make alpha computation for transparent sky faster.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -72,6 +72,9 @@ public class PreviewRayTracer implements RayTracer {
         break;
       } else {
         occlusion *= (1 - ray.color.w);
+        if (occlusion == 0) {
+          return 1; // occlusion can't become > 0 anymore
+        }
         ray.o.scaleAdd(Ray.OFFSET, ray.d);
       }
     }


### PR DESCRIPTION
Is this micro-optimization? Yes! But I actually measured and this optimization makes calculating the sky occlusion two to three times faster. Might not be a lot of time for most scenes but in ChunkyMap, scenes are tiny (128x128 pixels) and this change really makes a difference.