### PR TITLE
Remove static registries

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/BlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockProvider.java
@@ -7,7 +7,7 @@ import se.llbit.nbt.Tag;
 import java.util.Collection;
 
 public interface BlockProvider {
-  Block getBlockByTag(String name, Tag tag);
+  Block getBlockByTag(String name, Tag tag, BlockProviderRegistry blockProviders);
 
   /**
    *

--- a/chunky/src/java/se/llbit/chunky/block/BlockProviderRegistry.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockProviderRegistry.java
@@ -1,0 +1,10 @@
+package se.llbit.chunky.block;
+
+import java.util.Collection;
+
+public interface BlockProviderRegistry {
+
+  void registerBlockProvider(BlockProvider blockProvider);
+
+  Collection<BlockProvider> getBlockProviders();
+}

--- a/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
@@ -3,16 +3,12 @@ package se.llbit.chunky.block;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
 import se.llbit.util.NbtUtil;
 import se.llbit.util.NotNull;
 
 public class BlockSpec {
-
-  public static final List<BlockProvider> blockProviders = new LinkedList<>();
 
   private final Tag tag;
 
@@ -44,11 +40,13 @@ public class BlockSpec {
 
   /**
    * Converts NBT block data to Chunky block object.
+   *
+   * @param blockProviders
    */
-  public Block toBlock() {
+  public Block toBlock(BlockProviderRegistry blockProviders) {
     String name = tag.get("Name").stringValue("unknown:unknown");
-    for (BlockProvider provider : blockProviders) {
-      Block block = provider.getBlockByTag(name, tag);
+    for (BlockProvider provider : blockProviders.getBlockProviders()) {
+      Block block = provider.getBlockByTag(name, tag, blockProviders);
       if (block != null) {
         return maybeWaterlogged(block);
       }

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -926,7 +926,7 @@ public class MinecraftBlockProvider implements BlockProvider {
   }
 
   @Override
-  public Block getBlockByTag(String namespacedName, Tag tag) {
+  public Block getBlockByTag(String namespacedName, Tag tag, BlockProviderRegistry blockProviders) {
     String name = namespacedName.substring(10); // drop the minecraft: prefix
     switch (name) {
       case "air":

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyMinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyMinecraftBlockProvider.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockProvider;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.legacy.blocks.*;
 import se.llbit.log.Log;
 import se.llbit.nbt.CompoundTag;
@@ -12,7 +13,7 @@ import se.llbit.nbt.Tag;
 public class LegacyMinecraftBlockProvider implements BlockProvider {
 
   @Override
-  public Block getBlockByTag(String name, Tag tag) {
+  public Block getBlockByTag(String name, Tag tag, BlockProviderRegistry blockProviders) {
     if (!name.startsWith("#legacy_minecraft:")) {
       return null;
     }
@@ -26,16 +27,16 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "grass_block":
       case "mycelium":
       case "podzol":
-        return new LegacySnowCoverableBlock(name, ctag);
+        return new LegacySnowCoverableBlock(name, ctag, blockProviders);
       case "vine":
-        return new LegacyVine(name, ctag);
+        return new LegacyVine(name, ctag, blockProviders);
       case "pumpkin_stem":
-        return new LegacyPumpkinStem(name, ctag);
+        return new LegacyPumpkinStem(name, ctag, blockProviders);
       case "melon_stem":
-        return new LegacyMelonStem(name, ctag);
+        return new LegacyMelonStem(name, ctag, blockProviders);
       case "chest":
       case "trapped_chest":
-        return new LegacyChest(name, ctag);
+        return new LegacyChest(name, ctag, blockProviders);
       case "oak_door":
       case "iron_door":
       case "spruce_door":
@@ -43,7 +44,7 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "jungle_door":
       case "acacia_door":
       case "dark_oak_door":
-        return new LegacyDoorPart(name, ctag);
+        return new LegacyDoorPart(name, ctag, blockProviders);
       case "oak_stairs":
       case "cobblestone_stairs":
       case "brick_stairs":
@@ -58,27 +59,27 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "dark_oak_stairs":
       case "red_sandstone_stairs":
       case "purpur_stairs":
-        return new LegacyStairs(name, ctag);
+        return new LegacyStairs(name, ctag, blockProviders);
       case "iron_bars":
-        return new LegacyIronBars(name, ctag);
+        return new LegacyIronBars(name, ctag, blockProviders);
       case "redstone_wire":
-        return new LegacyRedstoneWire(name, ctag);
+        return new LegacyRedstoneWire(name, ctag, blockProviders);
       case "oak_fence_gate":
       case "spruce_fence_gate":
       case "birch_fence_gate":
       case "jungle_fence_gate":
       case "dark_oak_fence_gate":
       case "acacia_fence_gate":
-        return new LegacyFenceGate(name, ctag);
+        return new LegacyFenceGate(name, ctag, blockProviders);
       case "chorus_plant":
-        return new LegacyChorusPlant(name, ctag);
+        return new LegacyChorusPlant(name, ctag, blockProviders);
       case "sunflower":
       case "lilac":
       case "tall_grass":
       case "large_fern":
       case "rose_bush":
       case "peony":
-        return new LegacyLargeFlower(name, ctag);
+        return new LegacyLargeFlower(name, ctag, blockProviders);
       case "glass_pane":
       case "white_stained_glass_pane":
       case "orange_stained_glass_pane":
@@ -96,9 +97,9 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "green_stained_glass_pane":
       case "red_stained_glass_pane":
       case "black_stained_glass_pane":
-        return new LegacyGlassPane(name, ctag);
+        return new LegacyGlassPane(name, ctag, blockProviders);
       case "red_bed":
-        return new LegacyBed(name, ctag);
+        return new LegacyBed(name, ctag, blockProviders);
       case "oak_fence":
       case "nether_brick_fence":
       case "spruce_fence":
@@ -106,12 +107,12 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "jungle_fence":
       case "dark_oak_fence":
       case "acacia_fence":
-        return new LegacyFence(name, ctag);
+        return new LegacyFence(name, ctag, blockProviders);
       case "flower_pot":
-        return new LegacyFlowerPot(name, ctag);
+        return new LegacyFlowerPot(name, ctag, blockProviders);
       case "cobblestone_wall":
       case "mossy_cobblestone_wall":
-        return new LegacyCobblestoneWall(name, ctag);
+        return new LegacyCobblestoneWall(name, ctag, blockProviders);
       case "skull":
         return new LegacySkull(name, ctag);
       case "banner":
@@ -119,11 +120,11 @@ public class LegacyMinecraftBlockProvider implements BlockProvider {
       case "wall_banner":
         return new LegacyWallBanner(name, ctag);
       case "tripwire":
-        return new LegacyTripwire(name, ctag);
+        return new LegacyTripwire(name, ctag, blockProviders);
       case "nether_portal":
-        return new LegacyNetherPortal(name, ctag);
+        return new LegacyNetherPortal(name, ctag, blockProviders);
       case "fire":
-        return new LegacyFire(name, ctag);
+        return new LegacyFire(name, ctag, blockProviders);
     }
     Log.warn("Unsupported legacy block: " + name);
     return null;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/UnfinalizedLegacyBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/UnfinalizedLegacyBlock.java
@@ -1,6 +1,8 @@
 package se.llbit.chunky.block.legacy;
 
 import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.BlockProvider;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.BlockSpec;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.renderer.scene.Scene;
@@ -37,8 +39,8 @@ public abstract class UnfinalizedLegacyBlock extends Block {
    */
   protected final CompoundTag tag;
 
-  public UnfinalizedLegacyBlock(String name, CompoundTag tag) {
-    this(name, new BlockSpec(tag.get("Block")).toBlock(), tag);
+  public UnfinalizedLegacyBlock(String name, CompoundTag tag, BlockProviderRegistry blockProviders) {
+    this(name, new BlockSpec(tag.get("Block")).toBlock(blockProviders), tag);
     solid = block.solid;
     opaque = block.opaque;
     localIntersect = true;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyBed.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyBed.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -8,8 +9,9 @@ import se.llbit.nbt.Tag;
 
 public class LegacyBed extends UnfinalizedLegacyBlock {
 
-  public LegacyBed(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyBed(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChest.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChest.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -8,8 +9,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyChest extends UnfinalizedLegacyBlock {
 
-  public LegacyChest(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyChest(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChorusPlant.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChorusPlant.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -9,8 +10,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyChorusPlant extends UnfinalizedLegacyBlock {
 
-  public LegacyChorusPlant(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyChorusPlant(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyCobblestoneWall.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyCobblestoneWall.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyCobblestoneWall extends UnfinalizedLegacyBlock {
 
-  public LegacyCobblestoneWall(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyCobblestoneWall(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyDoorPart.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyDoorPart.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.Door;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyDoorPart extends UnfinalizedLegacyBlock {
 
-  public LegacyDoorPart(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyDoorPart(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
@@ -65,10 +67,10 @@ public class LegacyDoorPart extends UnfinalizedLegacyBlock {
   }
 
   private static final BlockFace[] bottomFacingMap = new BlockFace[]{
-    BlockFace.EAST,
-    BlockFace.SOUTH,
-    BlockFace.WEST,
-    BlockFace.NORTH
+      BlockFace.EAST,
+      BlockFace.SOUTH,
+      BlockFace.WEST,
+      BlockFace.NORTH
   };
 
   private static BlockFace getFacing(int bottomData) {

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFence.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFence.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyFence extends UnfinalizedLegacyBlock {
 
-  public LegacyFence(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyFence(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFenceGate.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFenceGate.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -8,8 +9,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyFenceGate extends UnfinalizedLegacyBlock {
 
-  public LegacyFenceGate(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyFenceGate(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFire.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -15,8 +16,9 @@ import se.llbit.nbt.CompoundTag;
  */
 public class LegacyFire extends UnfinalizedLegacyBlock {
 
-  public LegacyFire(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyFire(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
@@ -27,9 +29,11 @@ public class LegacyFire extends UnfinalizedLegacyBlock {
         state.getY() > state.getYMin() && isTopBurnable(state.getMaterial(BlockFace.DOWN));
 
     // a side is burning if the adjacent block at that side is flammable
-    LegacyBlocks.boolTag(tag, "north", !floorFire && isFlammable(state.getMaterial(BlockFace.NORTH)));
+    LegacyBlocks
+        .boolTag(tag, "north", !floorFire && isFlammable(state.getMaterial(BlockFace.NORTH)));
     LegacyBlocks.boolTag(tag, "east", !floorFire && isFlammable(state.getMaterial(BlockFace.EAST)));
-    LegacyBlocks.boolTag(tag, "south", !floorFire && isFlammable(state.getMaterial(BlockFace.SOUTH)));
+    LegacyBlocks
+        .boolTag(tag, "south", !floorFire && isFlammable(state.getMaterial(BlockFace.SOUTH)));
     LegacyBlocks.boolTag(tag, "west", !floorFire && isFlammable(state.getMaterial(BlockFace.WEST)));
 
     // the up side is visible if this burning on top of the bottom below and the block above is flammable
@@ -51,7 +55,8 @@ public class LegacyFire extends UnfinalizedLegacyBlock {
         (name.endsWith("_fence") && !name.equals("nether_brick_fence")) ||
         name.endsWith("_fence_gate") ||
         name.equals("oak_stairs") || name.equals("spruce_stairs") || name.equals("birch_stairs") ||
-        name.equals("jungle_stairs") || name.equals("acacia_stairs") || name.equals("dark_oak_stairs") ||
+        name.equals("jungle_stairs") || name.equals("acacia_stairs") || name
+        .equals("dark_oak_stairs") ||
         name.equals("tnt") ||
         name.equals("vine") ||
         name.equals("bookshelf") ||

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -8,8 +9,9 @@ import se.llbit.nbt.Tag;
 
 public class LegacyFlowerPot extends UnfinalizedLegacyBlock {
 
-  public LegacyFlowerPot(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyFlowerPot(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyGlassPane.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyGlassPane.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyGlassPane extends UnfinalizedLegacyBlock {
 
-  public LegacyGlassPane(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyGlassPane(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyIronBars.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyIronBars.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyIronBars extends UnfinalizedLegacyBlock {
 
-  public LegacyIronBars(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyIronBars(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyLargeFlower.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyLargeFlower.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -9,15 +10,16 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyLargeFlower extends UnfinalizedLegacyBlock {
 
-  public LegacyLargeFlower(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyLargeFlower(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
   public void finalizeBlock(FinalizationState state) {
     CompoundTag newTag;
 
-    if ((this.data&8) != 0) {
+    if ((this.data & 8) != 0) {
       Material bottom = state.getMaterial(0, -1, 0);
 
       if (bottom instanceof LegacyLargeFlower) {

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyMelonStem.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyMelonStem.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -12,9 +13,11 @@ public class LegacyMelonStem extends UnfinalizedLegacyBlock {
       BlockFace.WEST, BlockFace.EAST, BlockFace.NORTH, BlockFace.SOUTH
   };
 
-  public LegacyMelonStem(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyMelonStem(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
+
 
   @Override
   public void finalizeBlock(FinalizationState state) {

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyNetherPortal.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyNetherPortal.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -16,8 +17,9 @@ import se.llbit.nbt.Tag;
  */
 public class LegacyNetherPortal extends UnfinalizedLegacyBlock {
 
-  public LegacyNetherPortal(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyNetherPortal(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyPumpkinStem.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyPumpkinStem.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -12,8 +13,8 @@ public class LegacyPumpkinStem extends UnfinalizedLegacyBlock {
       BlockFace.WEST, BlockFace.EAST, BlockFace.NORTH, BlockFace.SOUTH
   };
 
-  public LegacyPumpkinStem(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyPumpkinStem(String name, CompoundTag tag, BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyRedstoneWire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyRedstoneWire.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Repeater;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyRedstoneWire extends UnfinalizedLegacyBlock {
 
-  public LegacyRedstoneWire(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyRedstoneWire(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
@@ -20,35 +22,43 @@ public class LegacyRedstoneWire extends UnfinalizedLegacyBlock {
     String east, north, south, west;
     east = north = south = west = "none";
 
-    if (isRedstoneConnector(state.getMaterial(-1, 0, 0), 1))
+    if (isRedstoneConnector(state.getMaterial(-1, 0, 0), 1)) {
       west = "side";
-    else if (isAir(state.getMaterial(-1, 0, 0)) && isRedstone(state.getMaterial(-1, -1, 0)))
+    } else if (isAir(state.getMaterial(-1, 0, 0)) && isRedstone(state.getMaterial(-1, -1, 0))) {
       west = "side";
+    }
 
-    if (isRedstoneConnector(state.getMaterial(1, 0, 0), 1))
+    if (isRedstoneConnector(state.getMaterial(1, 0, 0), 1)) {
       east = "side";
-    else if (isAir(state.getMaterial(1, 0, 0)) && isRedstone(state.getMaterial(1, -1, 0)))
+    } else if (isAir(state.getMaterial(1, 0, 0)) && isRedstone(state.getMaterial(1, -1, 0))) {
       east = "side";
+    }
 
-    if (isRedstoneConnector(state.getMaterial(0, 0, -1), 0))
+    if (isRedstoneConnector(state.getMaterial(0, 0, -1), 0)) {
       north = "side";
-    else if (isAir(state.getMaterial(0, 0, -1)) && isRedstone(state.getMaterial(0, -1, -1)))
+    } else if (isAir(state.getMaterial(0, 0, -1)) && isRedstone(state.getMaterial(0, -1, -1))) {
       north = "side";
+    }
 
-    if (isRedstoneConnector(state.getMaterial(0, 0, 1), 0))
+    if (isRedstoneConnector(state.getMaterial(0, 0, 1), 0)) {
       south = "side";
-    else if (isAir(state.getMaterial(0, 0, 1)) && isRedstone(state.getMaterial(0, -1, 1)))
+    } else if (isAir(state.getMaterial(0, 0, 1)) && isRedstone(state.getMaterial(0, -1, 1))) {
       south = "side";
+    }
 
     if (state.getMaterial(0, 1, 0).name.equals("minecraft:air")) {
-      if (state.getMaterial(-1, 0, 0).solid && isRedstone(state.getMaterial(-1, 1, 0)))
+      if (state.getMaterial(-1, 0, 0).solid && isRedstone(state.getMaterial(-1, 1, 0))) {
         west = "up";
-      if (state.getMaterial(1, 0, 0).solid && isRedstone(state.getMaterial(1, 1, 0)))
+      }
+      if (state.getMaterial(1, 0, 0).solid && isRedstone(state.getMaterial(1, 1, 0))) {
         east = "up";
-      if (state.getMaterial(0, 0, -1).solid && isRedstone(state.getMaterial(0, 1, -1)))
+      }
+      if (state.getMaterial(0, 0, -1).solid && isRedstone(state.getMaterial(0, 1, -1))) {
         north = "up";
-      if (state.getMaterial(0, 0, 1).solid && isRedstone(state.getMaterial(0, 1, 1)))
+      }
+      if (state.getMaterial(0, 0, 1).solid && isRedstone(state.getMaterial(0, 1, 1))) {
         south = "up";
+      }
     }
 
     CompoundTag tag = LegacyBlocks.createTag("redstone_wire");
@@ -80,7 +90,7 @@ public class LegacyRedstoneWire extends UnfinalizedLegacyBlock {
 
       case "repeater":
         if (block instanceof Repeater) {
-          return ((Repeater) block).getFacing()%2 == side;
+          return ((Repeater) block).getFacing() % 2 == side;
         }
     }
     return false;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySnowCoverableBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySnowCoverableBlock.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Snow;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -9,8 +10,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacySnowCoverableBlock extends UnfinalizedLegacyBlock {
 
-  public LegacySnowCoverableBlock(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacySnowCoverableBlock(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
@@ -22,7 +24,7 @@ public class LegacySnowCoverableBlock extends UnfinalizedLegacyBlock {
         Material above = state.getMaterial(0, 1, 0);
         if (above instanceof Snow || above.name.equals("minecraft:snow_block")) {
           state.replaceCurrentBlock(LegacyBlocks
-              .boolTag(LegacyBlocks.createTag(block.name), "snowy", true));
+              .boolTag(LegacyBlocks.createTag(name), "snowy", true));
           return;
         }
       }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyStairs.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyStairs.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Stairs;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -10,8 +11,9 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyStairs extends UnfinalizedLegacyBlock {
 
-  public LegacyStairs(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyStairs(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override
@@ -232,10 +234,10 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
   }
 
   private static final BlockFace[] facingMap = new BlockFace[]{
-    BlockFace.EAST,
-    BlockFace.WEST,
-    BlockFace.SOUTH,
-    BlockFace.NORTH
+      BlockFace.EAST,
+      BlockFace.WEST,
+      BlockFace.SOUTH,
+      BlockFace.NORTH
   };
 
   /**

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyTripwire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyTripwire.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.block.legacy.blocks;
 
 import se.llbit.chunky.block.BlockFace;
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Tripwire;
 import se.llbit.chunky.block.TripwireHook;
@@ -12,8 +13,9 @@ import se.llbit.nbt.Tag;
 
 public class LegacyTripwire extends UnfinalizedLegacyBlock {
 
-  public LegacyTripwire(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyTripwire(String name, CompoundTag tag,
+      BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -8,8 +9,8 @@ import se.llbit.nbt.CompoundTag;
 
 public class LegacyVine extends UnfinalizedLegacyBlock {
 
-  public LegacyVine(String name, CompoundTag tag) {
-    super(name, tag);
+  public LegacyVine(String name, CompoundTag tag, BlockProviderRegistry blockProviders) {
+    super(name, tag, blockProviders);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -415,7 +415,8 @@ public class CommandLineOptions {
         return;
       }
       try {
-        Scene scene = new Scene();
+        Chunky chunky = new Chunky(options);
+        Scene scene = new Scene(chunky);
         try (FileInputStream in = new FileInputStream(sceneFile)) {
           scene.loadDescription(in);
         }

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -63,7 +63,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     // Start worker threads.
     RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", String.valueOf(PersistentSettings.getNumThreads())))];
     for (int i = 0; i < regionParsers.length; ++i) {
-      regionParsers[i] = new RegionParser(this, regionQueue, mapView);
+      regionParsers[i] = new RegionParser(this, regionQueue, mapView, controller.getChunky());
       regionParsers[i].start();
     }
     topographyUpdater.start();

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneFactory.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneFactory.java
@@ -18,15 +18,6 @@
 package se.llbit.chunky.renderer.scene;
 
 public interface SceneFactory {
-  SceneFactory DEFAULT = new SceneFactory() {
-    @Override public Scene newScene() {
-      return new Scene();
-    }
-
-    @Override public Scene copyScene(Scene scene) {
-      return new Scene(scene);
-    }
-  };
 
   /**
    * Creates a new scene with the default configuration.
@@ -34,11 +25,10 @@ public interface SceneFactory {
   Scene newScene();
 
   /**
-   * Creates a scene which copies the state of another scene.
-   * Some data like the sample buffer will be shared between the
-   * two scenes.
+   * Creates a scene which copies the state of another scene. Some data like the sample buffer will
+   * be shared between the two scenes.
+   *
    * @param scene the scene to copy
    */
   Scene copyScene(Scene scene);
-
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -110,8 +110,11 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
       synchronized (storedScene) {
         String sceneName = storedScene.name();
         Log.info("Saving scene " + sceneName);
-        File sceneDir = resolveSceneDirectory(sceneName);
-        context.setSceneDirectory(sceneDir);
+        File sceneDir = context.getSceneDirectory();
+        if (!sceneDir.isDirectory()) {
+          sceneDir = resolveSceneDirectory(sceneName);
+          context.setSceneDirectory(sceneDir);
+        }
         if (!sceneDir.isDirectory()) {
           boolean success = sceneDir.mkdirs();
           if (!success) {
@@ -143,7 +146,10 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
     // Lock order: scene -> storedScene.
     synchronized (scene) {
       try (TaskTracker.Task ignored = taskTracker.task("Loading scene", 1)) {
-        context.setSceneDirectory(resolveSceneDirectory(sceneName));
+        File sceneDirectory = resolveSceneDirectory(sceneName);
+        if (sceneDirectory.isDirectory()) {
+          context.setSceneDirectory(sceneDirectory);
+        }
         scene.loadScene(context, sceneName, taskTracker);
       }
 

--- a/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
+++ b/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
@@ -17,6 +17,11 @@
 package se.llbit.chunky.resources;
 
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
+import se.llbit.chunky.block.BlockProviderRegistry;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.world.WorldTexture;
+import se.llbit.math.Octree;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -25,10 +30,7 @@ import java.io.PipedOutputStream;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.Lava;
 import se.llbit.chunky.block.Water;
-import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.world.WorldTexture;
 import se.llbit.log.Log;
-import se.llbit.math.Octree;
 
 public class OctreeFileFormat {
 
@@ -46,8 +48,10 @@ public class OctreeFileFormat {
    *
    * @param in   input stream for the file to load the scene from.
    * @param impl The octree implementation to use
+   * @param blockProviders
    */
-  public static OctreeData load(DataInputStream in, String impl) throws IOException {
+  public static OctreeData load(DataInputStream in, String impl,
+      BlockProviderRegistry blockProviders) throws IOException {
     int version = in.readInt();
     if (version < MIN_OCTREE_VERSION || version > OCTREE_VERSION) {
       throw new IOException(String.format(
@@ -55,7 +59,7 @@ public class OctreeFileFormat {
           MIN_OCTREE_VERSION, OCTREE_VERSION, version));
     }
     OctreeData data = new OctreeData();
-    data.palette = BlockPalette.read(in);
+    data.palette = BlockPalette.read(in, blockProviders);
     data.worldTree = Octree.load(impl, version < 5 ? convertDataNodes(data.palette, in) : in);
     data.waterTree = Octree.load(impl, version < 5 ? convertDataNodes(data.palette, in) : in);
     data.grassColors = WorldTexture.load(in);

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -22,6 +22,11 @@ import java.util.Set;
 
 import se.llbit.chunky.block.*;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.BlockProviderRegistry;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.EmptyChunkData;
@@ -133,7 +138,7 @@ public class Chunk {
    * layer, surface and cave maps.
    * @return whether the input chunkdata was modified
    */
-  public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     if (!shouldReloadChunk()) {
       return false;
     }
@@ -151,7 +156,7 @@ public class Chunk {
 
     surfaceTimestamp = dataTimestamp;
     version = chunkVersion(data);
-    loadSurface(data, chunkData, yMin, yMax);
+    loadSurface(data, chunkData, yMin, yMax, blockProviders);
     biomesTimestamp = dataTimestamp;
     if (surface == IconLayer.MC_1_12) {
       biomes = IconLayer.MC_1_12;
@@ -162,7 +167,7 @@ public class Chunk {
     return true;
   }
 
-  private void loadSurface(Map<String, Tag> data, ChunkData chunkData, int yMin, int yMax) {
+  private void loadSurface(Map<String, Tag> data, ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     if (data == null) {
       surface = IconLayer.CORRUPT;
       return;
@@ -173,7 +178,7 @@ public class Chunk {
     if (sections.isList()) {
       extractBiomeData(data.get(LEVEL_BIOMES), chunkData);
       if (version.equals("1.13") || version.equals("1.12")) {
-        BlockPalette palette = new BlockPalette();
+        BlockPalette palette = new BlockPalette(blockProviders);
         palette.unsynchronize(); //only this RegionParser will use this palette
         loadBlockData(data, chunkData, palette, yMin, yMax);
         int[] heightmapData = extractHeightmapData(data, chunkData);

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.EmptyChunkData;
@@ -84,7 +85,7 @@ public class EmptyChunk extends Chunk {
     // Do nothing.
   }
 
-  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.EmptyChunkData;
@@ -84,7 +85,7 @@ public class EmptyRegionChunk extends Chunk {
     // do nothing
   }
 
-  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.block.BlockProviderRegistry;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
@@ -49,7 +50,8 @@ public class ImposterCubicChunk extends Chunk {
    * layer, surface and cave maps.
    * @return whether the input chunkdata was modified
    */
-  public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override
+  public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     if (!shouldReloadChunk()) {
       return false;
     }
@@ -65,7 +67,7 @@ public class ImposterCubicChunk extends Chunk {
     }
 
     surfaceTimestamp = dataTimestamp;
-    loadSurfaceCubic(data, chunkData, yMin, yMax);
+    loadSurfaceCubic(data, chunkData, yMin, yMax, blockProviders);
     biomes = IconLayer.UNKNOWN;
 
     biomesTimestamp = dataTimestamp;
@@ -79,14 +81,14 @@ public class ImposterCubicChunk extends Chunk {
     return true;
   }
 
-  private void loadSurfaceCubic(Map<Integer, Map<String, Tag>> data, ChunkData chunkData, int yMin, int yMax) {
+  private void loadSurfaceCubic(Map<Integer, Map<String, Tag>> data, ChunkData chunkData, int yMin, int yMax, BlockProviderRegistry blockProviders) {
     if (data == null) {
       surface = IconLayer.CORRUPT;
       return;
     }
 
     Heightmap heightmap = world.heightmap();
-    BlockPalette palette = new BlockPalette();
+    BlockPalette palette = new BlockPalette(blockProviders);
 
     for (Map.Entry<Integer, Map<String, Tag>> entry : data.entrySet()) {
       Integer yPos = entry.getKey();

--- a/chunky/src/java/se/llbit/chunky/world/MaterialStore.java
+++ b/chunky/src/java/se/llbit/chunky/world/MaterialStore.java
@@ -16,8 +16,8 @@
  */
 package se.llbit.chunky.world;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import se.llbit.chunky.block.Block;
@@ -25,5 +25,5 @@ import se.llbit.chunky.block.Block;
 // TODO: introduce block tags
 public class MaterialStore {
   public static final Map<String, Collection<Block>> collections = new LinkedHashMap<>();
-  public static final Collection<String> blockIds = new ArrayList<>();
+  public static final Collection<String> blockIds = new HashSet<>();
 }


### PR DESCRIPTION
For [ChunkyMap](https://github.com/leMaik/ChunkyMap) and the upcoming Render Service, I'm using Chunky as a library to render scenes. Having lots of shared (= static) but dynamic data between Chunky instances brings concurrency issues when rendering more than one scene at once.

This PR makes the block registry non-static. The goal is to have the `Chunky` class contain everything that is needed for rendering so that one `Chunky` class can be used per concurrent rendering without problems. Having less global static fields also helps to make the code easier to understand by making dependencies explicit by having to pass them through to other classes or methods.

---

Update: This branch somehow has turned into everything that I changed for use with ChunkyMap and the render service.