### PR TITLE
Player head skins

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -1,20 +1,23 @@
 package se.llbit.chunky.block;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Base64;
 import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.entity.HeadEntity;
 import se.llbit.chunky.entity.SkullEntity;
+import se.llbit.chunky.entity.SkullEntity.Kind;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.EntityTexture;
+import se.llbit.json.JsonParser;
+import se.llbit.json.JsonParser.SyntaxError;
+import se.llbit.log.Log;
 import se.llbit.math.Ray;
-import se.llbit.math.Transform;
 import se.llbit.math.Vector3;
-import se.llbit.math.primitive.Box;
-import se.llbit.math.primitive.Primitive;
-
-import java.util.Collection;
-import java.util.LinkedList;
+import se.llbit.nbt.CompoundTag;
 
 public class Head extends MinecraftBlockTranslucent {
+
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;
@@ -28,19 +31,48 @@ public class Head extends MinecraftBlockTranslucent {
     this.rotation = rotation;
   }
 
-  @Override public boolean intersect(Ray ray, Scene scene) {
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
     return false;
   }
 
-  @Override public String description() {
+  @Override
+  public String description() {
     return description;
   }
 
-  @Override public boolean isEntity() {
-    return true;
+  @Override
+  public boolean isEntity() {
+    return type != Kind.PLAYER;
   }
 
-  @Override public Entity toEntity(Vector3 position) {
+  @Override
+  public Entity toEntity(Vector3 position) {
     return new SkullEntity(position, type, rotation, 1);
+  }
+
+  @Override
+  public boolean isBlockEntity() {
+    return type == Kind.PLAYER;
+  }
+
+  @Override
+  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+    String textureUrl = getTextureUrl(entityTag);
+    return textureUrl != null ? new HeadEntity(position, textureUrl, rotation, 1)
+        : new SkullEntity(position, type, rotation, 1);
+  }
+
+  public static String getTextureUrl(CompoundTag entityTag) {
+    String textureBase64 = entityTag.get("SkullOwner").get("Properties").get("textures").get(0)
+        .get("Value").stringValue();
+    try (JsonParser parser = new JsonParser(
+        new ByteArrayInputStream(Base64.getDecoder().decode(textureBase64)))) {
+      return parser.parse().asObject().get("textures").asObject().get("SKIN").asObject().get("url")
+          .stringValue(null);
+    } catch (IOException | SyntaxError e) {
+      Log.warn("Could not get skull texture", e);
+    }
+    return null;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/WallHead.java
+++ b/chunky/src/java/se/llbit/chunky/block/WallHead.java
@@ -1,13 +1,17 @@
 package se.llbit.chunky.block;
 
 import se.llbit.chunky.entity.Entity;
+import se.llbit.chunky.entity.HeadEntity;
 import se.llbit.chunky.entity.SkullEntity;
+import se.llbit.chunky.entity.SkullEntity.Kind;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.EntityTexture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
+import se.llbit.nbt.CompoundTag;
 
 public class WallHead extends MinecraftBlockTranslucent {
+
   private final String description;
   private final int facing;
   private final SkullEntity.Kind type;
@@ -35,19 +39,35 @@ public class WallHead extends MinecraftBlockTranslucent {
     }
   }
 
-  @Override public boolean intersect(Ray ray, Scene scene) {
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
     return false;
   }
 
-  @Override public String description() {
+  @Override
+  public String description() {
     return description;
   }
 
-  @Override public boolean isEntity() {
-    return true;
+  @Override
+  public boolean isEntity() {
+    return type != Kind.PLAYER;
   }
 
-  @Override public Entity toEntity(Vector3 position) {
+  @Override
+  public Entity toEntity(Vector3 position) {
     return new SkullEntity(position, type, 0, facing);
+  }
+
+  @Override
+  public boolean isBlockEntity() {
+    return type == Kind.PLAYER;
+  }
+
+  @Override
+  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+    String textureUrl = Head.getTextureUrl(entityTag);
+    return textureUrl != null ? new HeadEntity(position, textureUrl, 0, facing)
+        : new SkullEntity(position, type, 0, facing);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -63,6 +63,8 @@ abstract public class Entity {
         return WallSignEntity.fromJson(json);
       case "skull":
         return SkullEntity.fromJson(json);
+      case "head":
+        return HeadEntity.fromJson(json);
       case "player":
         return PlayerEntity.fromJson(json);
       case "standing_banner":

--- a/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
@@ -82,6 +82,7 @@ public class HeadEntity extends Entity {
         .translate(position.x + offset.x + 0.5, position.y + offset.y + 4 / 16.,
             position.z + offset.z + 0.5);
     Box head = new Box(-4 / 16., 4 / 16., -4 / 16., 4 / 16., -4 / 16., 4 / 16.);
+    Box hat = new Box(-4.2 / 16., 4.2 / 16., -4.2 / 16., 4.2 / 16., -4.2 / 16., 4.2 / 16.);
     switch (placement) {
       case 0:
         // Unused.
@@ -89,25 +90,33 @@ public class HeadEntity extends Entity {
       case 1:
         // On floor.
         head.transform(Transform.NONE.rotateY(-rotation * Math.PI / 8));
+        hat.transform(Transform.NONE.rotateY(-rotation * Math.PI / 8));
         break;
       case 2:
         // Facing north.
         head.transform(Transform.NONE.translate(0, 0, 4 / 16.));
+        hat.transform(Transform.NONE.translate(0, 0, 4 / 16.));
         break;
       case 3:
         // Facing south.
         head.transform(Transform.NONE.translate(0, 0, 4 / 16.));
+        hat.transform(Transform.NONE.translate(0, 0, 4 / 16.));
         head.transform(Transform.NONE.rotateY(Math.PI));
+        hat.transform(Transform.NONE.rotateY(Math.PI));
         break;
       case 4:
         // Facing west.
         head.transform(Transform.NONE.translate(0, 0, 4 / 16.));
+        hat.transform(Transform.NONE.translate(0, 0, 4 / 16.));
         head.transform(Transform.NONE.rotateY(QuickMath.HALF_PI));
+        hat.transform(Transform.NONE.rotateY(QuickMath.HALF_PI));
         break;
       case 5:
         // Facing east.
         head.transform(Transform.NONE.translate(0, 0, 4 / 16.));
+        hat.transform(Transform.NONE.translate(0, 0, 4 / 16.));
         head.transform(Transform.NONE.rotateY(-QuickMath.HALF_PI));
+        hat.transform(Transform.NONE.rotateY(-QuickMath.HALF_PI));
         break;
     }
     head.transform(transform);
@@ -117,6 +126,13 @@ public class HeadEntity extends Entity {
     head.addBottomFaces(faces, texture, texture.headBottom);
     head.addRightFaces(faces, texture, texture.headRight);
     head.addLeftFaces(faces, texture, texture.headLeft);
+    hat.transform(transform);
+    hat.addFrontFaces(faces, texture, texture.hatFront);
+    hat.addBackFaces(faces, texture, texture.hatBack);
+    hat.addLeftFaces(faces, texture, texture.hatLeft);
+    hat.addRightFaces(faces, texture, texture.hatRight);
+    hat.addTopFaces(faces, texture, texture.hatTop);
+    hat.addBottomFaces(faces, texture, texture.hatBottom);
     return faces;
   }
 


### PR DESCRIPTION
This PR adds player head blocks with custom skins. The skins are only downloaded once and then cached. The scene file contains the URL for portability.

![image](https://user-images.githubusercontent.com/5544859/90341707-095f0500-e002-11ea-85c3-03400673c663.png)

Fixes #70