### PR TITLE
Fix DoubleAdjuster value clamping.

### DIFF
--- a/lib/src/se/llbit/chunky/ui/DoubleAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/DoubleAdjuster.java
@@ -22,26 +22,17 @@ import javafx.beans.property.SimpleDoubleProperty;
  * A double adjuster stores double precision floating point values.
  */
 public class DoubleAdjuster extends SliderAdjuster<Double> {
-  private double min = Double.MIN_VALUE;
-  private double max = Double.MAX_VALUE;
-
   public DoubleAdjuster() {
     super(new SimpleDoubleProperty());
-  }
-
-  @Override public void setRange(double min, double max) {
-    super.setRange(min, max);
-    this.min = min;
-    this.max = max;
   }
 
   @Override protected Double clamp(Number value) {
     double result = value.doubleValue();
     if (clampMax) {
-      result = Math.min(result, max);
+      result = Math.min(result, getMax());
     }
     if (clampMin) {
-      result = Math.max(result, min);
+      result = Math.max(result, getMin());
     }
     return result;
   }

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -64,6 +64,14 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     }
   }
 
+  public double getMin() {
+    return min;
+  }
+
+  public double getMax() {
+    return max;
+  }
+
   /**
    * Make the adjuster use a logarithmic mapping for the slider position.
    */


### PR DESCRIPTION
Fixes setting logarithmic sliders to zero not resulting in a value of zero (e.g. for fog).

This bug was caused by overriding only one of the two `setRange` methods. While looking through the code I saw that `min` and `max` are defined twice, resulting in unneeded overrides to update them in the subclass.

Supersedes #666