### PR TITLE
Lectern book

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/block/Lectern.java
@@ -1,21 +1,20 @@
 package se.llbit.chunky.block;
 
 import se.llbit.chunky.entity.Entity;
-import se.llbit.chunky.entity.StandingBanner;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
-import se.llbit.json.Json;
-import se.llbit.json.JsonObject;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 import se.llbit.nbt.CompoundTag;
 
 public class Lectern extends MinecraftBlockTranslucent {
     private final String facing;
+    private final boolean hasBook;
 
-    public Lectern(String facing) {
+    public Lectern(String facing, boolean hasBook) {
         super("lectern", Texture.lecternFront);
         this.facing = facing;
+        this.hasBook = hasBook;
         invisible = true;
         opaque = false;
         localIntersect = true;
@@ -33,6 +32,6 @@ public class Lectern extends MinecraftBlockTranslucent {
 
     @Override
     public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
-        return new se.llbit.chunky.entity.Lectern(position, this.facing);
+        return new se.llbit.chunky.entity.Lectern(position, this.facing, this.hasBook);
     }
 }

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -2229,7 +2229,9 @@ public class MinecraftBlockProvider implements BlockProvider {
         return new Grindstone(
             tag.get("Properties").get("face").stringValue("floor"), BlockProvider.facing(tag));
       case "lectern":
-        return new Lectern(BlockProvider.facing(tag));
+        return new Lectern(
+            BlockProvider.facing(tag),
+            tag.get("Properties").get("has_book").stringValue("false").equals("true"));
       case "smithing_table":
         return new TexturedBlock(
             name,

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -1,0 +1,250 @@
+package se.llbit.chunky.entity;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import se.llbit.chunky.model.Model;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.chunky.world.material.TextureMaterial;
+import se.llbit.json.JsonObject;
+import se.llbit.json.JsonValue;
+import se.llbit.math.Quad;
+import se.llbit.math.Transform;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+import se.llbit.math.primitive.Primitive;
+
+public class Book extends Entity {
+
+  private static final Quad[] leftCover = new Quad[]{
+      // left cover
+      new Quad(
+          new Vector3(2 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(8 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(2 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(0, 6 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(2 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(8 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(6 / 64.0, 12 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+  };
+
+  private static final Quad[] leftPages = new Quad[]{
+      // left pages
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector4(1 / 64.0, 6 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(3 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector3(3 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(6 / 64.0, 11 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(3 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(3 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(0 / 64.0, 1 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(6 / 64.0, 7 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(3 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(7 / 64.0, 12 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(3 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(1 / 64.0, 6 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      )
+  };
+
+  private static final Quad[] middleCover = new Quad[]{
+      new Quad(
+          new Vector3(7 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(9 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(7 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(14 / 64.0, 16 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+      new Quad(
+          new Vector3(9 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(7 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(9 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(12 / 64.0, 14 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+  };
+
+  private static final Quad[] rightCover = new Quad[]{
+      // right cover
+      new Quad(
+          new Vector3(8 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(14 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(8 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(16 / 64.0, 22 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+      new Quad(
+          new Vector3(14 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(8 / 16.0, 13 / 16.0, 8 / 16.0),
+          new Vector3(14 / 16.0, 3 / 16.0, 8 / 16.0),
+          new Vector4(22 / 64.0, 28 / 64.0, 1, 1 - 10 / 32.0)
+      ),
+  };
+
+  private static final Quad[] rightPages = new Quad[]{
+      // right pages
+      new Quad(
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector4(13 / 64.0, 18 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(18 / 64.0, 23 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(12 / 64.0, 13 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(18 / 64.0, 19 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(13 / 64.0, 18 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+      new Quad(
+          new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
+          new Vector3(13 / 16.0, 4 / 16.0, 7.99 / 16.0),
+          new Vector4(19 / 64.0, 24 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+      ),
+  };
+
+  private static final Quad[] pageA = new Quad[]{
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(24 / 64.0, 29 / 64.0, 1 - 18 / 32.0, 1 - 10 / 32.0)
+      ),
+      new Quad(
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(34 / 64.0, 29 / 64.0, 1 - 18 / 32.0, 1 - 10 / 32.0)
+      ),
+  };
+
+  private static final Quad[] pageB = new Quad[]{
+      new Quad(
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(29 / 64.0, 24 / 64.0, 1 - 18 / 32.0, 1 - 10 / 32.0)
+      ),
+      new Quad(
+          new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
+          new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
+          new Vector4(29 / 64.0, 34 / 64.0, 1 - 18 / 32.0, 1 - 10 / 32.0)
+      ),
+  };
+
+  private double openAngle;
+  private double pageAngleA;
+  private double pageAngleB;
+
+  protected Book(Vector3 position, double openAngle, double pageAngleA, double pageAngleB) {
+    super(position);
+    this.openAngle = openAngle;
+    this.pageAngleA = pageAngleA;
+    this.pageAngleB = pageAngleB;
+  }
+
+  @Override
+  public Collection<Primitive> primitives(Vector3 offset) {
+    return primitives(Transform.NONE
+        .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z));
+  }
+
+  public Collection<Primitive> primitives(Transform transform) {
+    Collection<Primitive> faces = new LinkedList<>();
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(leftCover, -openAngle),
+            -1 / 16.0, 0,
+            0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(rightCover, openAngle),
+            1 / 16.0, 0,
+            0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(Model.translate(leftPages, 0, 0, 1.01 / 16.0), -openAngle),
+            0, 0, -1.01 / 16.0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(Model.translate(rightPages, 0, 0, 1.01 / 16.0), openAngle),
+            0, 0, -1.01 / 16.0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(Model.translate(pageA, 0, 0, 1.01 / 16.0), pageAngleA),
+            0, 0, -1.01 / 16.0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : Model
+        .translate(Model.rotateY(Model.translate(pageB, 0, 0, 1.01 / 16.0), pageAngleB),
+            0, 0, -1.01 / 16.0)) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    for (Quad quad : middleCover) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    }
+
+    return faces;
+  }
+
+  @Override
+  public JsonValue toJson() {
+    JsonObject json = new JsonObject();
+    json.add("kind", "book");
+    json.add("position", position.toJson());
+    json.add("openedAngle", openAngle);
+    json.add("pageAngleA", pageAngleA);
+    json.add("pageAngleB", pageAngleB);
+    return json;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/entity/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Lectern.java
@@ -1,5 +1,7 @@
 package se.llbit.chunky.entity;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import se.llbit.chunky.model.Model;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.world.material.TextureMaterial;
@@ -10,193 +12,214 @@ import se.llbit.math.Transform;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Primitive;
-import se.llbit.nbt.CompoundTag;
 import se.llbit.util.JsonUtil;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 public class Lectern extends Entity {
-    private static final Quad[] quadsNorth = new Quad[]{
-            new Quad(
-                    new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
-                    new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
-                    new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
-                    new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
-                    new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
-                    new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
-                    new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
-                    new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
-                    new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
-                    new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(4 / 16.0, 2 / 16.0, 12 / 16.0),
-                    new Vector3(4 / 16.0, 15 / 16.0, 12 / 16.0),
-                    new Vector3(4 / 16.0, 2 / 16.0, 4 / 16.0),
-                    new Vector4(15 / 16.0, 2 / 16.0, 8 / 16.0, 0 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(12 / 16.0, 2 / 16.0, 4 / 16.0),
-                    new Vector3(12 / 16.0, 15 / 16.0, 4 / 16.0),
-                    new Vector3(12 / 16.0, 2 / 16.0, 12 / 16.0),
-                    new Vector4(15 / 16.0, 2 / 16.0, 0 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(4 / 16.0, 15 / 16.0, 4 / 16.0),
-                    new Vector3(12 / 16.0, 15 / 16.0, 4 / 16.0),
-                    new Vector3(4 / 16.0, 2 / 16.0, 4 / 16.0),
-                    new Vector4(8 / 16.0, 0 / 16.0, 16 / 16.0, 3 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(12 / 16.0, 15 / 16.0, 12 / 16.0),
-                    new Vector3(4 / 16.0, 15 / 16.0, 12 / 16.0),
-                    new Vector3(12 / 16.0, 2 / 16.0, 12 / 16.0),
-                    new Vector4(16 / 16.0, 8 / 16.0, 13 / 16.0, 0 / 16.0)
-            )
-    };
 
-    private static final Quad[] topQuadsNorth = Model.rotateX(new Quad[]{
-            new Quad(
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
-                    new Vector4(0 / 16.0, 16 / 16.0, 2 / 16.0, 15 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0.01 / 16.0, 12 / 16.0, 3 / 16.0),
-                    new Vector3(15.99 / 16.0, 12 / 16.0, 3 / 16.0),
-                    new Vector3(0.01 / 16.0, 12 / 16.0, 16 / 16.0),
-                    new Vector4(0 / 16.0, 16 / 16.0, 3 / 16.0, 16 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0.01 / 16.0, 16 / 16.0, 16 / 16.0),
-                    new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(0.01 / 16.0, 12 / 16.0, 16 / 16.0),
-                    new Vector4(13 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
-                    new Vector3(15.99 / 16.0, 12 / 16.0, 3 / 16.0),
-                    new Vector4(13 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
-                    new Vector3(0.01 / 16.0, 12 / 16.0, 3 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 12 / 16.0)
-            ),
-            new Quad(
-                    new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
-                    new Vector3(0.01 / 16.0, 16 / 16.0, 16 / 16.0),
-                    new Vector3(15.99 / 16.0, 12 / 16.0, 16 / 16.0),
-                    new Vector4(16 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
-            )
-    }, Math.toRadians(-22.5));
+  private static final Quad[] quadsNorth = new Quad[]{
+      new Quad(
+          new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+          new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+          new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+          new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+          new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+          new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+          new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+          new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+      ),
+      new Quad(
+          new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+          new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+          new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 10 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(4 / 16.0, 2 / 16.0, 12 / 16.0),
+          new Vector3(4 / 16.0, 15 / 16.0, 12 / 16.0),
+          new Vector3(4 / 16.0, 2 / 16.0, 4 / 16.0),
+          new Vector4(15 / 16.0, 2 / 16.0, 8 / 16.0, 0 / 16.0)
+      ),
+      new Quad(
+          new Vector3(12 / 16.0, 2 / 16.0, 4 / 16.0),
+          new Vector3(12 / 16.0, 15 / 16.0, 4 / 16.0),
+          new Vector3(12 / 16.0, 2 / 16.0, 12 / 16.0),
+          new Vector4(15 / 16.0, 2 / 16.0, 0 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(4 / 16.0, 15 / 16.0, 4 / 16.0),
+          new Vector3(12 / 16.0, 15 / 16.0, 4 / 16.0),
+          new Vector3(4 / 16.0, 2 / 16.0, 4 / 16.0),
+          new Vector4(8 / 16.0, 0 / 16.0, 16 / 16.0, 3 / 16.0)
+      ),
+      new Quad(
+          new Vector3(12 / 16.0, 15 / 16.0, 12 / 16.0),
+          new Vector3(4 / 16.0, 15 / 16.0, 12 / 16.0),
+          new Vector3(12 / 16.0, 2 / 16.0, 12 / 16.0),
+          new Vector4(16 / 16.0, 8 / 16.0, 13 / 16.0, 0 / 16.0)
+      )
+  };
 
-    static final Quad[][] orientedQuads = new Quad[4][];
+  private static final Quad[] topQuadsNorth = Model.rotateX(new Quad[]{
+      new Quad(
+          new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
+          new Vector4(0 / 16.0, 16 / 16.0, 2 / 16.0, 15 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0.01 / 16.0, 12 / 16.0, 3 / 16.0),
+          new Vector3(15.99 / 16.0, 12 / 16.0, 3 / 16.0),
+          new Vector3(0.01 / 16.0, 12 / 16.0, 16 / 16.0),
+          new Vector4(0 / 16.0, 16 / 16.0, 3 / 16.0, 16 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0.01 / 16.0, 16 / 16.0, 16 / 16.0),
+          new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(0.01 / 16.0, 12 / 16.0, 16 / 16.0),
+          new Vector4(13 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
+          new Vector3(15.99 / 16.0, 12 / 16.0, 3 / 16.0),
+          new Vector4(13 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
+      ),
+      new Quad(
+          new Vector3(0.01 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(15.99 / 16.0, 16 / 16.0, 3 / 16.0),
+          new Vector3(0.01 / 16.0, 12 / 16.0, 3 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 12 / 16.0)
+      ),
+      new Quad(
+          new Vector3(15.99 / 16.0, 16 / 16.0, 16 / 16.0),
+          new Vector3(0.01 / 16.0, 16 / 16.0, 16 / 16.0),
+          new Vector3(15.99 / 16.0, 12 / 16.0, 16 / 16.0),
+          new Vector4(16 / 16.0, 0 / 16.0, 12 / 16.0, 8 / 16.0)
+      )
+  }, Math.toRadians(-22.5));
 
-    static final Quad[][] orientedTopQuads = new Quad[4][];
+  static final Quad[][] orientedQuads = new Quad[4][];
 
-    static {
-        orientedQuads[0] = quadsNorth;
-        orientedQuads[1] = Model.rotateY(orientedQuads[0]);
-        orientedQuads[2] = Model.rotateY(orientedQuads[1]);
-        orientedQuads[3] = Model.rotateY(orientedQuads[2]);
+  static final Quad[][] orientedTopQuads = new Quad[4][];
 
-        orientedTopQuads[0] = topQuadsNorth;
-        orientedTopQuads[1] = Model.rotateY(orientedTopQuads[0]);
-        orientedTopQuads[2] = Model.rotateY(orientedTopQuads[1]);
-        orientedTopQuads[3] = Model.rotateY(orientedTopQuads[2]);
+  static {
+    orientedQuads[0] = quadsNorth;
+    orientedQuads[1] = Model.rotateY(orientedQuads[0]);
+    orientedQuads[2] = Model.rotateY(orientedQuads[1]);
+    orientedQuads[3] = Model.rotateY(orientedQuads[2]);
+
+    orientedTopQuads[0] = topQuadsNorth;
+    orientedTopQuads[1] = Model.rotateY(orientedTopQuads[0]);
+    orientedTopQuads[2] = Model.rotateY(orientedTopQuads[1]);
+    orientedTopQuads[3] = Model.rotateY(orientedTopQuads[2]);
+  }
+
+  public static final Texture[] tex = {
+      Texture.lecternBase, Texture.oakPlanks,
+      Texture.lecternBase, Texture.lecternBase, Texture.lecternBase, Texture.lecternBase,
+
+      Texture.lecternSides, Texture.lecternSides, Texture.lecternFront, Texture.lecternFront,
+
+      Texture.lecternTop, Texture.oakPlanks,
+      Texture.lecternSides, Texture.lecternSides, Texture.lecternSides, Texture.lecternSides
+  };
+
+  private final String facing;
+  private final boolean hasBook;
+
+  public Lectern(Vector3 position, String facing, boolean hasBook) {
+    super(position);
+    this.facing = facing;
+    this.hasBook = hasBook;
+  }
+
+  public Lectern(JsonObject json) {
+    super(JsonUtil.vec3FromJsonObject(json.get("position")));
+    this.facing = json.get("facing").stringValue("north");
+    this.hasBook = json.get("hasBook").boolValue(false);
+  }
+
+  @Override
+  public Collection<Primitive> primitives(Vector3 offset) {
+    Collection<Primitive> faces = new LinkedList<>();
+    Transform transform = Transform.NONE
+        .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z);
+    int facing = getOrientationIndex(this.facing);
+    for (int i = 0; i < orientedQuads[facing].length; i++) {
+      orientedQuads[facing][i].addTriangles(faces, new TextureMaterial(tex[i]), transform);
+    }
+    for (int i = 0; i < orientedTopQuads[facing].length; i++) {
+      orientedTopQuads[facing][i]
+          .addTriangles(faces, new TextureMaterial(tex[i + orientedQuads[facing].length]),
+              transform);
     }
 
-    public static final Texture[] tex = {
-            Texture.lecternBase, Texture.oakPlanks,
-            Texture.lecternBase, Texture.lecternBase, Texture.lecternBase, Texture.lecternBase,
+    if (hasBook) {
+      Transform bookTransform = Transform.NONE.translate(-0.5, -0.5, -0.5)
+          .rotateX(Math.toRadians(90 - 22.5))
+          .translate(0, 0, -2 / 16.0)
+          .rotateY(Math.PI)
+          .translate(0.5, 0.5, 0.5)
+          .translate(0, 8.5 / 16.0, 0)
+          .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z);
 
-            Texture.lecternSides, Texture.lecternSides, Texture.lecternFront, Texture.lecternFront,
+      double openAngle = Math.PI / 32;
+      double pageAngleA = Math.PI / 8;
+      double pageAngleB = Math.PI - Math.PI / 8;
 
-            Texture.lecternTop, Texture.oakPlanks,
-            Texture.lecternSides, Texture.lecternSides, Texture.lecternSides, Texture.lecternSides
-    };
-
-    private final String facing;
-
-    public Lectern(Vector3 position, String facing) {
-        super(position);
-        this.facing = facing;
+      Book book = new Book(position, openAngle, pageAngleA, pageAngleB);
+      faces.addAll(book.primitives(bookTransform));
     }
 
-    public Lectern(JsonObject json) {
-        super(JsonUtil.vec3FromJsonObject(json.get("position")));
-        this.facing = json.get("facing").stringValue("north");
-    }
+    return faces;
+  }
 
-    @Override
-    public Collection<Primitive> primitives(Vector3 offset) {
-        Collection<Primitive> faces = new LinkedList<>();
-        Transform transform = Transform.NONE
-                .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z);
-        int facing = getOrientationIndex(this.facing);
-        for (int i = 0; i < orientedQuads[facing].length; i++) {
-            orientedQuads[facing][i].addTriangles(faces, new TextureMaterial(tex[i]), transform);
-        }
-        for (int i = 0; i < orientedTopQuads[facing].length; i++) {
-            orientedTopQuads[facing][i].addTriangles(faces, new TextureMaterial(tex[i + orientedQuads[facing].length]), transform);
-        }
-        return faces;
-    }
+  @Override
+  public JsonValue toJson() {
+    JsonObject json = new JsonObject();
+    json.add("kind", "lectern");
+    json.add("position", position.toJson());
+    json.add("facing", facing);
+    json.add("hasBook", hasBook);
+    return json;
+  }
 
-    @Override
-    public JsonValue toJson() {
-        JsonObject json = new JsonObject();
-        json.add("kind", "lectern");
-        json.add("position", position.toJson());
-        json.add("facing", facing);
-        return json;
-    }
+  public static Entity fromJson(JsonObject json) {
+    return new Lectern(json);
+  }
 
-    public static Entity fromJson(JsonObject json) {
-        return new Lectern(json);
+  private static int getOrientationIndex(String facing) {
+    switch (facing) {
+      case "north":
+        return 0;
+      case "east":
+        return 1;
+      case "south":
+        return 2;
+      case "west":
+        return 3;
+      default:
+        return 0;
     }
-
-    private static int getOrientationIndex(String facing) {
-        switch (facing) {
-            case "north":
-                return 0;
-            case "east":
-                return 1;
-            case "south":
-                return 2;
-            case "west":
-                return 3;
-            default:
-                return 0;
-        }
-    }
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -494,6 +494,7 @@ public class Texture {
   public static final EntityTexture skeleton = new EntityTexture();
   public static final EntityTexture wither = new EntityTexture();
   public static final EntityTexture dragon = new EntityTexture();
+  public static final EntityTexture book = new EntityTexture();
 
   // [1.10] Bone, magma, nether wart block, red nether brick.
   public static final Texture boneSide = new Texture();

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -2474,6 +2474,8 @@ public class TexturePackLoader {
         new EntityTextureLoader("assets/minecraft/textures/entity/wither/wither", Texture.wither));
     allTextures.put("dragon",
         new EntityTextureLoader("assets/minecraft/textures/entity/enderdragon/dragon", Texture.dragon));
+    allTextures.put("book",
+        new EntityTextureLoader("assets/minecraft/textures/entity/enchanting_table_book", Texture.book));
 
     // Minecraft 1.10 blocks.
     allTextures.put("boneSide", new AlternateTextures(

--- a/chunky/src/java/se/llbit/chunky/world/model/CubeModel.java
+++ b/chunky/src/java/se/llbit/chunky/world/model/CubeModel.java
@@ -23,7 +23,9 @@ import se.llbit.chunky.resources.TexturePackLoader;
 import se.llbit.chunky.resources.texturepack.SimpleTexture;
 import se.llbit.chunky.resources.texturepack.TextureLoader;
 import se.llbit.log.Log;
+import se.llbit.math.DoubleSidedQuad;
 import se.llbit.math.Quad;
+import se.llbit.math.Ray;
 import se.llbit.math.Vector2;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
@@ -82,7 +84,8 @@ public class CubeModel {
                 new int[] { 1, 1 },
                 new int[][] { { 0, 0 }, { 0, 1 } },
                 new int[][] { { 2, 1 }, { 2, 0 } },
-                uv);
+                uv,
+                Math.abs(cube.start.y - cube.end.y) > Ray.EPSILON);
             break;
           case "down":
             addFace(theFaces, face,
@@ -90,7 +93,8 @@ public class CubeModel {
                 new int[] { 1, 0 },
                 new int[][] { { 0, 0 }, { 0, 1 } },
                 new int[][] { { 2, 0 }, { 2, 1 } },
-                uv);
+                uv,
+                Math.abs(cube.start.y - cube.end.y) > Ray.EPSILON);
             break;
           case "north":
             addFace(theFaces, face,
@@ -98,7 +102,8 @@ public class CubeModel {
                 new int[] { 2, 0 },
                 new int[][] { { 0, 1 }, { 0, 0 } },
                 new int[][] { { 1, 0 }, { 1, 1 } },
-                uv);
+                uv,
+                Math.abs(cube.start.z - cube.end.z) > Ray.EPSILON);
             break;
           case "south":
             addFace(theFaces, face,
@@ -106,7 +111,8 @@ public class CubeModel {
                 new int[] { 2, 1 },
                 new int[][] { { 0, 0 }, { 0, 1 } },
                 new int[][] { { 1, 0 }, { 1, 1 } },
-                uv);
+                uv,
+                Math.abs(cube.start.z - cube.end.z) > Ray.EPSILON);
             break;
           case "east":
             addFace(theFaces, face,
@@ -114,7 +120,8 @@ public class CubeModel {
                 new int[] { 0, 1 },
                 new int[][] { { 2, 1 }, { 2, 0 } },
                 new int[][] { { 1, 0 }, { 1, 1 } },
-                uv);
+                uv,
+                Math.abs(cube.start.x - cube.end.x) > Ray.EPSILON);
             break;
           case "west":
             addFace(theFaces, face,
@@ -122,7 +129,8 @@ public class CubeModel {
                 new int[] { 0, 0 },
                 new int[][] { { 2, 0 }, { 2, 1 } },
                 new int[][] { { 1, 0 }, { 1, 1 } },
-                uv);
+                uv,
+                Math.abs(cube.start.x - cube.end.x) > Ray.EPSILON);
             break;
         }
       }
@@ -143,7 +151,7 @@ public class CubeModel {
   }
 
   private void addFace(Collection<Quad> theFaces, Face face, double[][] fromto, int[] passive,
-      int[][] x, int[][] y, Vector4 uv) {
+      int[][] x, int[][] y, Vector4 uv, boolean doubleSided) {
     double[] o = new double[3];
     double[] u = new double[3];
     double[] v = new double[3];
@@ -218,8 +226,14 @@ public class CubeModel {
         v[y[0][0]] = fromto[y[0][1]][y[0][0]];
         break;
     }
-    theFaces.add(new Quad(new Vector3(o[0], o[1], o[2]), new Vector3(u[0], u[1], u[2]),
-        new Vector3(v[0], v[1], v[2]), uv));
+
+    if (doubleSided) {
+      theFaces.add(new DoubleSidedQuad(new Vector3(o[0], o[1], o[2]), new Vector3(u[0], u[1], u[2]),
+          new Vector3(v[0], v[1], v[2]), uv));
+    } else {
+      theFaces.add(new Quad(new Vector3(o[0], o[1], o[2]), new Vector3(u[0], u[1], u[2]),
+          new Vector3(v[0], v[1], v[2]), uv));
+    }
   }
 
 }

--- a/chunky/src/java/se/llbit/math/DoubleSidedQuad.java
+++ b/chunky/src/java/se/llbit/math/DoubleSidedQuad.java
@@ -16,6 +16,11 @@
  */
 package se.llbit.math;
 
+import java.util.Collection;
+import se.llbit.chunky.world.Material;
+import se.llbit.math.primitive.Primitive;
+import se.llbit.math.primitive.TexturedTriangle;
+
 /**
  * A double-sided quad
  *
@@ -57,6 +62,30 @@ public class DoubleSidedQuad extends Quad {
       }
     }
     return false;
+  }
+
+  @Override
+  public void addTriangles(Collection<Primitive> primitives, Material material,
+      Transform transform) {
+    Vector3 c0 = new Vector3(o);
+    Vector3 c1 = new Vector3();
+    Vector3 c2 = new Vector3();
+    Vector3 c3 = new Vector3();
+    c1.add(o, xv);
+    c2.add(o, yv);
+    c3.add(c1, yv);
+    transform.apply(c0);
+    transform.apply(c1);
+    transform.apply(c2);
+    transform.apply(c3);
+    double u0 = uv.x;
+    double u1 = uv.x + uv.y;
+    double v0 = uv.z;
+    double v1 = uv.z + uv.w;
+    primitives.add(new TexturedTriangle(c0, c2, c1, new Vector2(u0, v0), new Vector2(u0, v1),
+        new Vector2(u1, v0), material, true));
+    primitives.add(new TexturedTriangle(c1, c2, c3, new Vector2(u1, v0), new Vector2(u0, v1),
+        new Vector2(u1, v1), material, true));
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/Quad.java
+++ b/chunky/src/java/se/llbit/math/Quad.java
@@ -179,9 +179,9 @@ public class Quad {
     double v0 = uv.z;
     double v1 = uv.z + uv.w;
     primitives.add(new TexturedTriangle(c0, c2, c1, new Vector2(u0, v0), new Vector2(u0, v1),
-        new Vector2(u1, v0), material));
+        new Vector2(u1, v0), material, false));
     primitives.add(new TexturedTriangle(c1, c2, c3, new Vector2(u1, v0), new Vector2(u0, v1),
-        new Vector2(u1, v1), material));
+        new Vector2(u1, v1), material, false));
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
+++ b/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
@@ -39,6 +39,7 @@ public class TexturedTriangle implements Primitive {
   private final Vector2 t2;
   private final Vector2 t3;
   private final Material material;
+  private final boolean doubleSided;
 
   /**
    * @param c1 first corner
@@ -47,6 +48,16 @@ public class TexturedTriangle implements Primitive {
    */
   public TexturedTriangle(Vector3 c1, Vector3 c2, Vector3 c3, Vector2 t1, Vector2 t2,
       Vector2 t3, Material material) {
+    this(c1, c2, c3, t1, t2, t3, material, true);
+  }
+
+  /**
+   * @param c1 first corner
+   * @param c2 second corner
+   * @param c3 third corner
+   */
+  public TexturedTriangle(Vector3 c1, Vector3 c2, Vector3 c3, Vector2 t1, Vector2 t2,
+      Vector2 t3, Material material, boolean doubleSided) {
     e1.sub(c2, c1);
     e2.sub(c3, c1);
     o.set(c1);
@@ -56,6 +67,7 @@ public class TexturedTriangle implements Primitive {
     this.t2 = new Vector2(t3);
     this.t3 = new Vector2(t1);
     this.material = material;
+    this.doubleSided = doubleSided;
 
     bounds = AABB.bounds(c1, c2, c3);
   }
@@ -68,7 +80,11 @@ public class TexturedTriangle implements Primitive {
 
     pvec.cross(ray.d, e2);
     double det = e1.dot(pvec);
-    if (det > -EPSILON && det < EPSILON) {
+    if (doubleSided) {
+      if (det > -EPSILON && det < EPSILON) {
+        return false;
+      }
+    } else if (det > -EPSILON) {
       return false;
     }
     double recip = 1 / det;


### PR DESCRIPTION
This PR adds rendering of books placed on top of a lectern. The book is not yet customizable but provides everything that is needed to render the enchantment table book.

![0000_lectern-100 denoised](https://user-images.githubusercontent.com/5544859/90988692-1b5a1e00-e595-11ea-990b-f588786543b8.png)

It also fixes triangles always being double-sided, even if they belong to single-sided quads, which causes rendering issues if two quads overlap but have their textures on different sides (e.g. the book cover, the book pages and the campfire flame).

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/5544859/90988639-ad155b80-e594-11ea-9afe-0f01554e3e09.png)|![image](https://user-images.githubusercontent.com/5544859/90988667-e221ae00-e594-11ea-9846-fda8e8be8800.png)|


