### PR TITLE
Fix downloading custom head skins if the json is invalid

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/TextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/TextureLoader.java
@@ -66,10 +66,9 @@ public abstract class TextureLoader {
    * @throws IOException
    */
   public boolean load(File file) throws IOException, TextureFormatError {
-    FileInputStream in = new FileInputStream(file);
-    boolean result = load(in);
-    in.close();
-    return result;
+    try (FileInputStream in = new FileInputStream(file)) {
+      return load(in);
+    }
   }
 
   /**


### PR DESCRIPTION
Looks like the base64-encoded value isn't always valid json. This changes the code to get the skin url with a regex instead.

Fixes #680