### PR TITLE
Enchantment table book

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/EnchantingTable.java
+++ b/chunky/src/java/se/llbit/chunky/block/EnchantingTable.java
@@ -1,18 +1,43 @@
 package se.llbit.chunky.block;
 
+import se.llbit.chunky.entity.Book;
+import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.model.EnchantmentTableModel;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.nbt.CompoundTag;
 
 public class EnchantingTable extends MinecraftBlockTranslucent {
+
   public EnchantingTable() {
     super("enchanting_table", Texture.enchantmentTableSide);
     localIntersect = true;
     solid = false;
   }
 
-  @Override public boolean intersect(Ray ray, Scene scene) {
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
     return EnchantmentTableModel.intersect(ray);
+  }
+
+  @Override
+  public boolean isBlockEntity() {
+    return true;
+  }
+
+  @Override
+  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+    Vector3 newPosition = new Vector3(position);
+    newPosition.add(0, 0.35, 0);
+    Book book = new Book(
+        newPosition,
+        Math.toRadians(11.25),
+        Math.toRadians(30),
+        Math.toRadians(180 - 30));
+    book.setPitch(Math.toRadians(80));
+    book.setYaw(Math.toRadians(45));
+    return book;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/EnchantingTable.java
+++ b/chunky/src/java/se/llbit/chunky/block/EnchantingTable.java
@@ -33,7 +33,7 @@ public class EnchantingTable extends MinecraftBlockTranslucent {
     newPosition.add(0, 0.35, 0);
     Book book = new Book(
         newPosition,
-        Math.toRadians(11.25),
+        Math.PI - Math.PI / 16,
         Math.toRadians(30),
         Math.toRadians(180 - 30));
     book.setPitch(Math.toRadians(80));

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -12,6 +12,7 @@ import se.llbit.math.Transform;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Primitive;
+import se.llbit.util.JsonUtil;
 
 public class Book extends Entity {
 
@@ -175,17 +176,49 @@ public class Book extends Entity {
   private double openAngle;
   private double pageAngleA;
   private double pageAngleB;
+  private double pitch;
+  private double yaw;
 
-  protected Book(Vector3 position, double openAngle, double pageAngleA, double pageAngleB) {
+  public Book(Vector3 position, double openAngle, double pageAngleA, double pageAngleB) {
     super(position);
     this.openAngle = openAngle;
     this.pageAngleA = pageAngleA;
     this.pageAngleB = pageAngleB;
   }
 
+  public Book(JsonObject json) {
+    this(JsonUtil.vec3FromJsonObject(json.get("position")),
+        json.get("openAngle").doubleValue(0),
+        json.get("pageAngleA").doubleValue(0),
+        json.get("pageAngleB").doubleValue(0));
+    setPitch(json.get("pitch").asDouble(0));
+    setYaw(json.get("yaw").asDouble(0));
+  }
+
+  public double getPitch() {
+    return pitch;
+  }
+
+  public void setPitch(double pitch) {
+    this.pitch = pitch;
+  }
+
+  public double getYaw() {
+    return yaw;
+  }
+
+  public void setYaw(double yaw) {
+    this.yaw = yaw;
+  }
+
   @Override
   public Collection<Primitive> primitives(Vector3 offset) {
     return primitives(Transform.NONE
+        .translate(-0.5, -0.5, -0.5)
+        .rotateX(getPitch())
+        .translate(0, 0, 0)
+        .rotateY(getYaw())
+        .translate(0.5, 0.5, 0.5)
         .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z));
   }
 
@@ -242,9 +275,15 @@ public class Book extends Entity {
     JsonObject json = new JsonObject();
     json.add("kind", "book");
     json.add("position", position.toJson());
-    json.add("openedAngle", openAngle);
+    json.add("openAngle", openAngle);
     json.add("pageAngleA", pageAngleA);
     json.add("pageAngleB", pageAngleB);
+    json.add("pitch", getPitch());
+    json.add("yaw", getYaw());
     return json;
+  }
+
+  public static Entity fromJson(JsonObject json) {
+    return new Book(json);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -182,8 +182,8 @@ public class Book extends Entity {
   public Book(Vector3 position, double openAngle, double pageAngleA, double pageAngleB) {
     super(position);
     this.openAngle = openAngle;
-    this.pageAngleA = pageAngleA;
-    this.pageAngleB = pageAngleB;
+    this.pageAngleA = Math.max(openAngle, pageAngleA);
+    this.pageAngleB = Math.min(Math.PI - openAngle, pageAngleB);
   }
 
   public Book(JsonObject json) {
@@ -227,8 +227,7 @@ public class Book extends Entity {
 
     for (Quad quad : Model
         .translate(Model.rotateY(leftCover, -openAngle),
-            -1 / 16.0, 0,
-            0)) {
+            -1 / 16.0, 0, 0)) {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
@@ -239,27 +238,29 @@ public class Book extends Entity {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
+    double pagesDistance = 0.01 + ((1 - openAngle * 2 / Math.PI)) / 16.0; // TODO
+
     for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(leftPages, 0, 0, 1.01 / 16.0), -openAngle),
-            0, 0, -1.01 / 16.0)) {
+        .translate(Model.rotateY(Model.translate(leftPages, 0, 0, pagesDistance), -openAngle),
+            0, 0, -pagesDistance)) {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
     for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(rightPages, 0, 0, 1.01 / 16.0), openAngle),
-            0, 0, -1.01 / 16.0)) {
+        .translate(Model.rotateY(Model.translate(rightPages, 0, 0, pagesDistance), openAngle),
+            0, 0, -pagesDistance)) {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
     for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(pageA, 0, 0, 1.01 / 16.0), pageAngleA),
-            0, 0, -1.01 / 16.0)) {
+        .translate(Model.rotateY(Model.translate(pageA, -0.5, 0, -pagesDistance), pageAngleA),
+            0.5, 0, pagesDistance)) {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
     for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(pageB, 0, 0, 1.01 / 16.0), pageAngleB),
-            0, 0, -1.01 / 16.0)) {
+        .translate(Model.rotateY(Model.translate(pageB, 0.5, 0, -pagesDistance), pageAngleB),
+            -0.5, 0, pagesDistance)) {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -38,37 +38,37 @@ public class Book extends Entity {
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
-          new Vector4(1 / 64.0, 6 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(1 / 64.0, 6 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(3 / 16.0, 4 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
           new Vector3(3 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(6 / 64.0, 11 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(6 / 64.0, 11 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(3 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(3 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(0 / 64.0, 1 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(0 / 64.0, 1 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
-          new Vector4(6 / 64.0, 7 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(6 / 64.0, 7 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(3 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(3 / 16.0, 4 / 16.0, 6.99 / 16.0),
-          new Vector4(7 / 64.0, 12 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(7 / 64.0, 12 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(3 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(1 / 64.0, 6 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(1 / 64.0, 6 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       )
   };
 
@@ -109,37 +109,37 @@ public class Book extends Entity {
           new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
-          new Vector4(13 / 64.0, 18 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(13 / 64.0, 18 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
           new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(18 / 64.0, 23 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(18 / 64.0, 23 / 64.0, 1 - 10 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(12 / 64.0, 13 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(12 / 64.0, 13 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(13 / 16.0, 4 / 16.0, 6.99 / 16.0),
-          new Vector4(18 / 64.0, 19 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(18 / 64.0, 19 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(8 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(13 / 16.0, 12 / 16.0, 6.99 / 16.0),
           new Vector3(8 / 16.0, 4 / 16.0, 6.99 / 16.0),
-          new Vector4(13 / 64.0, 18 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(13 / 64.0, 18 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
       new Quad(
           new Vector3(13 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(8 / 16.0, 12 / 16.0, 7.99 / 16.0),
           new Vector3(13 / 16.0, 4 / 16.0, 7.99 / 16.0),
-          new Vector4(19 / 64.0, 24 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0) //ok
+          new Vector4(19 / 64.0, 24 / 64.0, 1 - 19 / 32.00, 1 - 11 / 32.0)
       ),
   };
 
@@ -238,30 +238,30 @@ public class Book extends Entity {
       quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
     }
 
-    double pagesDistance = 0.01 + ((1 - openAngle * 2 / Math.PI)) / 16.0; // TODO
+    double pagesDistance = (1 - Math.sin(Math.PI / 2 - openAngle)) / 16.0;
 
-    for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(leftPages, 0, 0, pagesDistance), -openAngle),
-            0, 0, -pagesDistance)) {
-      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    for (Quad quad : leftPages) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book),
+          Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(-openAngle)
+              .translate(0.5, 0.5, 0.5 - 1.01 / 16.0 + pagesDistance).chain(transform));
     }
 
-    for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(rightPages, 0, 0, pagesDistance), openAngle),
-            0, 0, -pagesDistance)) {
-      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    for (Quad quad : rightPages) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book),
+          Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(openAngle)
+              .translate(0.5, 0.5, 0.5 - 1.01 / 16.0 + pagesDistance).chain(transform));
     }
 
-    for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(pageA, -0.5, 0, -pagesDistance), pageAngleA),
-            0.5, 0, pagesDistance)) {
-      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    for (Quad quad : pageA) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book),
+          Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(pageAngleA)
+              .translate(0.5, 0.5, 0.5 - 1.01 / 16.0 + pagesDistance).chain(transform));
     }
 
-    for (Quad quad : Model
-        .translate(Model.rotateY(Model.translate(pageB, 0.5, 0, -pagesDistance), pageAngleB),
-            -0.5, 0, pagesDistance)) {
-      quad.addTriangles(faces, new TextureMaterial(Texture.book), transform);
+    for (Quad quad : pageB) {
+      quad.addTriangles(faces, new TextureMaterial(Texture.book),
+          Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(pageAngleB)
+              .translate(0.5, 0.5, 0.5 - 1.01 / 16.0 + pagesDistance).chain(transform));
     }
 
     for (Quad quad : middleCover) {

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -237,7 +237,7 @@ public class Book extends Entity implements Poseable {
       }
       if (i == 4 && (pageAngleA >= (Math.PI + openAngle) / 2
           || pageAngleB >= (Math.PI + openAngle) / 2)) {
-        continue; // the a single angle is clamped to the right pages, which would overlay this face
+        continue; // a single page is clamped to the left pages box, which would overlay this face
       }
       leftPages[i].addTriangles(faces, new TextureMaterial(Texture.book),
           Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(-pageAngle)
@@ -250,7 +250,7 @@ public class Book extends Entity implements Poseable {
       }
       if (i == 4 && (pageAngleA <= (Math.PI - openAngle) / 2
           || pageAngleB <= (Math.PI - openAngle) / 2)) {
-        continue; // the a single angle is clamped to the right pages, which would overlay this face
+            continue; // a single page is clamped to the right pages box, which would overlay this face
       }
       rightPages[i].addTriangles(faces, new TextureMaterial(Texture.book),
           Transform.NONE.translate(-0.5, -0.5, -0.5 + 1.01 / 16.0).rotateY(pageAngle)

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -83,6 +83,8 @@ abstract public class Entity {
         return Lectern.fromJson(json);
       case "campfire":
         return Campfire.fromJson(json);
+      case "book":
+        return Book.fromJson(json);
     }
     return null;
   }

--- a/chunky/src/java/se/llbit/chunky/entity/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Lectern.java
@@ -193,11 +193,11 @@ public class Lectern extends Entity {
           break;
       }
 
-      double openAngle = Math.PI / 32;
-      double pageAngleA = Math.PI / 8;
-      double pageAngleB = Math.PI - Math.PI / 8;
-
-      Book book = new Book(bookPosition, openAngle, pageAngleA, pageAngleB);
+      Book book = new Book(
+          bookPosition,
+          Math.PI - Math.PI / 16,
+          Math.PI / 8,
+          Math.PI - Math.PI / 8);
       book.setPitch(Math.toRadians(90 - 22.5));
       book.setYaw(getBookYaw(this.facing));
       faces.addAll(book.primitives(offset));

--- a/chunky/src/java/se/llbit/chunky/entity/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Lectern.java
@@ -175,20 +175,32 @@ public class Lectern extends Entity {
     }
 
     if (hasBook) {
-      Transform bookTransform = Transform.NONE.translate(-0.5, -0.5, -0.5)
-          .rotateX(Math.toRadians(90 - 22.5))
-          .translate(0, 0, -2 / 16.0)
-          .rotateY(Math.PI)
-          .translate(0.5, 0.5, 0.5)
-          .translate(0, 8.5 / 16.0, 0)
-          .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z);
+      Vector3 bookPosition = new Vector3(position);
+      bookPosition.add(0, 8.5 / 16.0, 0);
+
+      switch (this.facing) {
+        case "north":
+          bookPosition.add(0, 0, -2 / 16.0);
+          break;
+        case "east":
+          bookPosition.add(2 / 16.0, 0, 0);
+          break;
+        case "south":
+          bookPosition.add(0, 0, 2 / 16.0);
+          break;
+        case "west":
+          bookPosition.add(-2 / 16.0, 0, 0);
+          break;
+      }
 
       double openAngle = Math.PI / 32;
       double pageAngleA = Math.PI / 8;
       double pageAngleB = Math.PI - Math.PI / 8;
 
-      Book book = new Book(position, openAngle, pageAngleA, pageAngleB);
-      faces.addAll(book.primitives(bookTransform));
+      Book book = new Book(bookPosition, openAngle, pageAngleA, pageAngleB);
+      book.setPitch(Math.toRadians(90 - 22.5));
+      book.setYaw(getBookYaw(this.facing));
+      faces.addAll(book.primitives(offset));
     }
 
     return faces;
@@ -218,6 +230,21 @@ public class Lectern extends Entity {
         return 2;
       case "west":
         return 3;
+      default:
+        return 0;
+    }
+  }
+
+  private static double getBookYaw(String facing) {
+    switch (facing) {
+      case "north":
+        return 0;
+      case "east":
+        return -Math.PI / 2;
+      case "south":
+        return Math.PI;
+      case "west":
+        return Math.PI / 2;
       default:
         return 0;
     }

--- a/chunky/src/java/se/llbit/chunky/entity/Poseable.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Poseable.java
@@ -37,8 +37,9 @@ public interface Poseable {
   double getScale();
   void setScale(double value);
 
-  double getHeadScale();
-  void setHeadScale(double value);
+  default boolean hasHead() { return true; }
+  default double getHeadScale() { return 1; }
+  default void setHeadScale(double value) {};
 
   Vector3 getPosition();
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1036,8 +1036,18 @@ public class Scene implements JsonSerializable, Refreshable {
             Vector3 position = new Vector3(x + wx0, y, z + wz0);
             if (block.isBlockEntity()) {
               Entity blockEntity = block.toBlockEntity(position, entityTag);
-              if (blockEntity instanceof Poseable ){
-                actors.add(blockEntity);
+              if (blockEntity instanceof Poseable) {
+                // don't add the actor again if it was already loaded from json
+                if (actors.stream().noneMatch(actor -> {
+                  if (actor.getClass().equals(blockEntity.getClass())) {
+                    Vector3 distance = new Vector3(actor.position);
+                    distance.sub(blockEntity.position);
+                    return distance.lengthSquared() < Ray.EPSILON;
+                  }
+                  return false;
+                })) {
+                  actors.add(blockEntity);
+                }
               } else {
                 entities.add(blockEntity);
               }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -28,6 +28,7 @@ import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.entity.PaintingEntity;
 import se.llbit.chunky.entity.PlayerEntity;
+import se.llbit.chunky.entity.Poseable;
 import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.resources.BitmapImage;
@@ -1034,7 +1035,12 @@ public class Scene implements JsonSerializable, Refreshable {
             // Metadata is the old block data (to be replaced in future Minecraft versions?).
             Vector3 position = new Vector3(x + wx0, y, z + wz0);
             if (block.isBlockEntity()) {
-              entities.add(block.toBlockEntity(position, entityTag));
+              Entity blockEntity = block.toBlockEntity(position, entityTag);
+              if (blockEntity instanceof Poseable ){
+                actors.add(blockEntity);
+              } else {
+                entities.add(blockEntity);
+              }
             }
             /*
             switch (block) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -34,6 +34,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import se.llbit.chunky.entity.ArmorStand;
+import se.llbit.chunky.entity.Book;
 import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.entity.Geared;
 import se.llbit.chunky.entity.PlayerEntity;
@@ -75,6 +76,8 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       } else {
         if (entity instanceof ArmorStand) {
           kind = "Armor stand";
+        } else if (entity instanceof Book) {
+          kind = "Book";
         } else {
           kind = "Other";
         }

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -191,8 +191,44 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         controls.getChildren().addAll(modelBox, skinBox);
       }
 
-      DoubleAdjuster scale = new DoubleAdjuster();
+      if (entity instanceof Book) {
+        Book book = (Book) entity;
 
+        DoubleAdjuster openingAngle = new DoubleAdjuster();
+        openingAngle.setName("Opening angle");
+        openingAngle.setTooltip("Modifies the book's opening angle.");
+        openingAngle.set(Math.toDegrees(book.getOpenAngle()));
+        openingAngle.setRange(0, 180);
+        openingAngle.onValueChange(value -> {
+          book.setOpenAngle(Math.toRadians(value));
+          scene.rebuildActorBvh();
+        });
+        controls.getChildren().add(openingAngle);
+
+        DoubleAdjuster page1Angle = new DoubleAdjuster();
+        page1Angle.setName("Page 1 angle");
+        page1Angle.setTooltip("Modifies the book's first visible page's angle.");
+        page1Angle.set(Math.toDegrees(book.getPageAngleA()));
+        page1Angle.setRange(0, 180);
+        page1Angle.onValueChange(value -> {
+          book.setPageAngleA(Math.toRadians(value));
+          scene.rebuildActorBvh();
+        });
+        controls.getChildren().add(page1Angle);
+
+        DoubleAdjuster page2Angle = new DoubleAdjuster();
+        page2Angle.setName("Page 2 angle");
+        page2Angle.setTooltip("Modifies the book's second visible page's angle.");
+        page2Angle.set(Math.toDegrees(book.getPageAngleB()));
+        page2Angle.setRange(0, 180);
+        page2Angle.onValueChange(value -> {
+          book.setPageAngleB(Math.toRadians(value));
+          scene.rebuildActorBvh();
+        });
+        controls.getChildren().add(page2Angle);
+      }
+
+      DoubleAdjuster scale = new DoubleAdjuster();
       scale.setName("Scale");
       scale.setTooltip("Modifies entity scale.");
       scale.set(poseable.getScale());

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -203,17 +203,22 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         poseable.setScale(value);
         scene.rebuildActorBvh();
       });
+      controls.getChildren().add(scale);
 
-      DoubleAdjuster headScale = new DoubleAdjuster();
-      headScale.setName("Head scale");
-      headScale.setTooltip("Modifies entity head scale.");
-      headScale.set(poseable.getHeadScale());
-      headScale.setRange(0.1, 10);
-      headScale.onValueChange(value -> {
-        poseable.setHeadScale(value);
-        scene.rebuildActorBvh();
-      });
+      if (poseable.hasHead()) {
+        DoubleAdjuster headScale = new DoubleAdjuster();
+        headScale.setName("Head scale");
+        headScale.setTooltip("Modifies entity head scale.");
+        headScale.set(poseable.getHeadScale());
+        headScale.setRange(0.1, 10);
+        headScale.onValueChange(value -> {
+          poseable.setHeadScale(value);
+          scene.rebuildActorBvh();
+        });
+        controls.getChildren().add(headScale);
+      }
 
+      String[] partNames = poseable.partNames();
       ChoiceBox<String> partList = new ChoiceBox<>();
       partList.setTooltip(new Tooltip("Select the part of the entity to adjust."));
       partList.getItems().setAll(poseable.partNames());
@@ -222,6 +227,9 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       poseBox.setSpacing(10.0);
       poseBox.setAlignment(Pos.CENTER_LEFT);
       poseBox.getChildren().addAll(new Label("Pose part"), partList);
+      if (partNames.length > 1) {
+        controls.getChildren().add(poseBox);
+      }
 
       AngleAdjuster yaw = new AngleAdjuster();
       yaw.setTooltip("Modifies yaw of currently selected entity part.");
@@ -265,7 +273,9 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         scene.rebuildActorBvh();
       });
 
-      controls.getChildren().addAll(scale, headScale, poseBox, pitch, yaw, roll);
+      if (partNames.length > 0) {
+        controls.getChildren().addAll(pitch, yaw, roll);
+      }
     }
 
     if (entity instanceof Geared) {
@@ -321,7 +331,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       entityTable.getItems().add(data);
       entityTable.getSelectionModel().select(data);
     });
-    delete.setTooltip(new Tooltip("Delete the selected player."));
+    delete.setTooltip(new Tooltip("Delete the selected entity."));
     delete.setOnAction(e -> withEntity(entity -> {
       scene.removeEntity(entity);
       update(scene);

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -76,10 +76,8 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       } else {
         if (entity instanceof ArmorStand) {
           kind = "Armor stand";
-        } else if (entity instanceof Book) {
-          kind = "Book";
         } else {
-          kind = "Other";
+          kind = entity.getClass().getSimpleName();
         }
         name = "entity";
       }

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -246,9 +246,9 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       partList.getSelectionModel().selectedItemProperty().addListener(
           (observable, oldValue, part) ->
               withPose(entity, part, partPose -> {
-                pitch.set(partPose.get(0).asDouble(0));
-                yaw.set(partPose.get(1).asDouble(0));
-                roll.set(partPose.get(2).asDouble(0));
+                pitch.set(Math.toDegrees(partPose.get(0).asDouble(0)));
+                yaw.set(Math.toDegrees(partPose.get(1).asDouble(0)));
+                roll.set(Math.toDegrees(partPose.get(2).asDouble(0)));
             }
           ));
 


### PR DESCRIPTION
This PR adds the books on enchantment tables as poseable entities. The opening angle, rotation and the angle of the two single pages can be configured.

It also fixes the rotation of books on lecterns (oversight in a previous PR) and the pose controls in the entities tab being initialized to radians instead of degrees.

![0000_lectern-68 denoised](https://user-images.githubusercontent.com/5544859/91648077-768f8300-ea63-11ea-93e7-47fea9b71f6a.png)

Related to #41, closes #72 