### PR TITLE
Allow selecting the output format in the save current frame dialog.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -297,20 +297,9 @@ public class Chunky {
         scene.loadDump(context, taskTracker); // Load the render dump.
         OutputMode outputMode = scene.getOutputMode();
         if (options.imageOutputFile.isEmpty()) {
-          String extension = ".png";
-          if (outputMode == OutputMode.TIFF_32) {
-            extension = ".tiff";
-          }
-          options.imageOutputFile = String.format("%s-%d%s", scene.name(), scene.spp, extension);
+          options.imageOutputFile = String.format("%s-%d%s", scene.name(), scene.spp, outputMode.getExtension());
         }
-        switch (outputMode) {
-          case PNG:
-            System.out.println("Image output mode: PNG");
-            break;
-          case TIFF_32:
-            System.out.println("Image output mode: TIFF32");
-            break;
-        }
+        System.out.println("Image output mode: " + outputMode);
         scene.saveFrame(new File(options.imageOutputFile), taskTracker, context.numRenderThreads());
         System.out.println("Saved snapshot to " + options.imageOutputFile);
         return 0;

--- a/chunky/src/java/se/llbit/chunky/renderer/OutputMode.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/OutputMode.java
@@ -39,7 +39,7 @@ public enum OutputMode {
     }
 
     @Override public String getExtension() {
-      return ".tif";
+      return ".tiff";
     }
   };
 
@@ -50,6 +50,17 @@ public enum OutputMode {
       return OutputMode.valueOf(name);
     } catch (IllegalArgumentException e) {
       return DEFAULT;
+    }
+  }
+
+  public static OutputMode fromExtension(String extension) {
+    switch (extension) {
+      case ".png":
+        return PNG;
+      case ".tiff":
+        return TIFF_32;
+      default:
+        return DEFAULT;
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1642,14 +1642,21 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * Save the current frame as a PNG or TIFF image.
+   * Save the current frame as a PNG or TIFF image, depending on this scene's outputMode.
    */
   public synchronized void saveFrame(File targetFile, TaskTracker progress, int threadCount) {
+    this.saveFrame(targetFile, outputMode, progress, threadCount);
+  }
+
+  /**
+   * Save the current frame as a PNG or TIFF image.
+   */
+  public synchronized void saveFrame(File targetFile, OutputMode mode, TaskTracker progress, int threadCount) {
     computeAlpha(progress, threadCount);
     if (!finalized) {
       postProcessFrame(progress);
     }
-    writeImage(targetFile, outputMode, progress);
+    writeImage(targetFile, mode, progress);
   }
 
   /**


### PR DESCRIPTION
The _Save current frame_ dialog only allowed saving in the format specified by the scene's _output mode_. This PR allows selecting the format in the save dialog and makes the code more generic.