### PR TITLE
Clamp the snow layers to the correct range.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -1202,7 +1202,7 @@ public class MinecraftBlockProvider implements BlockProvider {
       case "stone_button":
         return button(tag, Texture.stone);
       case "snow":
-        return new Snow(BlockProvider.stringToInt(tag.get("Properties").get("layers"), 1));
+        return new Snow(Math.max(1, Math.min(8, BlockProvider.stringToInt(tag.get("Properties").get("layers"), 1))));
       case "ice":
         return new MinecraftBlock(name, Texture.ice);
       case "snow_block":


### PR DESCRIPTION
Fixes #687 

The layers are supposed to be 1...8 but for whatever reason (maybe conversion from Bedrock worlds?) the value was 0 here. This workaround clamps it to the correct tange.