### PR TITLE
Fix removing entity gear

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -322,7 +322,9 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         TextField gearField = new TextField();
         gearField.setOnAction(event -> {
           JsonObject gear = new JsonObject();
-          gear.add("id", gearField.getText());
+          if (!gearField.getText().trim().isEmpty()) {
+            gear.add("id", gearField.getText());
+          }
           geared.getGear().set(slot, gear);
           scene.rebuildActorBvh();
         });


### PR DESCRIPTION
This fixes an issue where the gear would be replaced by an invalid (red/black) texture when removing it, i.e. setting it to an empty string.