### PR TITLE
Remove data nodes from the octree

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Lava.java
+++ b/chunky/src/java/se/llbit/chunky/block/Lava.java
@@ -17,22 +17,29 @@ public class Lava extends MinecraftBlockTranslucent {
   private static final AABB fullBlock = new AABB(0, 1, 0, 1, 0, 1);
 
   public final int level;
+  public final int data;
 
-  public Lava(int level) {
+  public Lava(int level, int data) {
     super("lava", Texture.lava);
     this.level = level;
+    this.data = data;
     solid = false;
     localIntersect = true;
     emittance = 1.0f;
   }
 
+  public Lava(int level) {
+    this(level, 1 << FULL_BLOCK);
+  }
+
+  public boolean isFullBlock() {
+    return (this.data & (1 << FULL_BLOCK)) != 0;
+  }
+
   @Override public boolean intersect(Ray ray, Scene scene) {
     ray.t = Double.POSITIVE_INFINITY;
 
-    int data = ray.getCurrentData();
-    int isFull = (data >> FULL_BLOCK) & 1;
-
-    if (isFull != 0) {
+    if (isFullBlock()) {
       if (fullBlock.intersect(ray)) {
         texture.getColor(ray);
         ray.distance += ray.tNext;

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -846,10 +846,14 @@ public class MinecraftBlockProvider implements BlockProvider {
         return new SpriteBlock(name, Texture.darkOakSapling);
       case "water":
         return new Water(BlockProvider.stringToInt(tag.get("Properties").get("level"), 0));
+      case "water$chunky":
+        return new Water(tag.get("level").intValue(), tag.get("data").intValue());
       case "bubble_column":
         return new Water(0); // TODO: render bubbles!
       case "lava":
         return new Lava(BlockProvider.stringToInt(tag.get("Properties").get("level"), 0));
+      case "lava$chunky":
+        return new Lava(tag.get("level").intValue(), tag.get("data").intValue());
       case "bedrock":
         return new MinecraftBlock(name, Texture.bedrock);
       case "sand":

--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -21,7 +21,7 @@ public class Water extends MinecraftBlockTranslucent {
   public static final Water INSTANCE = new Water(0);
   
   // Used only as starting material when camera is submerged.
-  public static final Water OCEAN_WATER = new Water(0);
+  public static final Water OCEAN_WATER = new Water(0, 1 << Water.FULL_BLOCK);
 
   public final int level;
   public final int data;

--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -18,20 +18,31 @@ import java.util.List;
 
 public class Water extends MinecraftBlockTranslucent {
 
-  // Used only as starting material when camera is submerged.
   public static final Water INSTANCE = new Water(0);
+  
+  // Used only as starting material when camera is submerged.
   public static final Water OCEAN_WATER = new Water(0);
 
   public final int level;
+  public final int data;
 
-  public Water(int level) {
+  public Water(int level, int data) {
     super("water", Texture.water);
     this.level = level;
+    this.data = data;
     solid = false;
     localIntersect = true;
     specular = 0.12f;
     ior = 1.333f;
     refractive = true;
+  }
+
+  public Water(int level) {
+    this(level, 0);
+  }
+
+  public boolean isFullBlock() {
+    return (this.data & (1 << FULL_BLOCK)) != 0;
   }
 
   @Override public boolean isWater() {

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -3,6 +3,7 @@ package se.llbit.chunky.chunk;
 import se.llbit.chunky.block.*;
 import se.llbit.math.Octree;
 import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.IntTag;
 import se.llbit.nbt.StringTag;
 import se.llbit.nbt.Tag;
 
@@ -84,6 +85,48 @@ public class BlockPalette {
     if(id == ANY_ID)
       return stone;
     return palette.get(id);
+  }
+
+  /**
+   * Get the index for a water block with the given level and data. If it doesn't exist, it is
+   * created.
+   *
+   * @param level Water level
+   * @param data  Water data (for corner levels)
+   * @return Index of the water block in this palette
+   * @throws IllegalArgumentException If the level is out of range
+   */
+  public int getWaterId(int level, int data) {
+    if (level < 0 || level > 8) {
+      throw new IllegalArgumentException("Invalid water level " + level);
+    }
+    CompoundTag tag = new CompoundTag();
+    tag.add("Name", new StringTag("minecraft:water$chunky"));
+    tag.add("level", new IntTag(level));
+    tag.add("data", new IntTag(data));
+    BlockSpec spec = new BlockSpec(tag);
+    return put(spec);
+  }
+
+  /**
+   * Get the index for a lava block with the given level and data. If it doesn't exist, it is
+   * created.
+   *
+   * @param level Lava level
+   * @param data  Lava data (for corner levels)
+   * @return Index of the lava block in this palette
+   * @throws IllegalArgumentException If the level is out of range
+   */
+  public int getLavaId(int level, int data) {
+    if (level < 0 || level > 8) {
+      throw new IllegalArgumentException("Invalid lava level " + level);
+    }
+    CompoundTag tag = new CompoundTag();
+    tag.add("Name", new StringTag("minecraft:lava$chunky"));
+    tag.add("level", new IntTag(level));
+    tag.add("data", new IntTag(data));
+    BlockSpec spec = new BlockSpec(tag);
+    return put(spec);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
@@ -381,7 +381,7 @@ public class CauldronModel {
         ray.n.set(water.n);
       }
       ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());
-      ray.setCurrentMaterial(Water.INSTANCE, Water.FULL_BLOCK);
+      ray.setCurrentMaterial(Water.INSTANCE, 0);
       ray.t = ray.tNext;
     }
     if (hit) {

--- a/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
@@ -381,7 +381,7 @@ public class CauldronModel {
         ray.n.set(water.n);
       }
       ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());
-      ray.setCurrentMaterial(Water.INSTANCE, 0);
+      ray.setCurrentMaterial(Water.INSTANCE);
       ray.t = ray.tNext;
     }
     if (hit) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -26,19 +26,20 @@ import se.llbit.math.Octree;
 import se.llbit.math.Vector3i;
 
 /**
- * Processes the Octree after it has been loaded and updates block states for
- * blocks that depend on neighbor blocks. Octree finalization is be done after
- * all chunks have been loaded because before then we can't reliably test for
- * neighbor blocks.
+ * Processes the Octree after it has been loaded and updates block states for blocks that depend on
+ * neighbor blocks. Octree finalization is be done after all chunks have been loaded because before
+ * then we can't reliably test for neighbor blocks.
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
 public class OctreeFinalizer {
+
   /**
    * Finalize a chunk in the octree.
+   *
    * @param worldTree Octree to finalize
-   * @param origin Origin of the octree
-   * @param cp     Position of the chunk to finalize
+   * @param origin    Origin of the octree
+   * @param cp        Position of the chunk to finalize
    */
   public static void finalizeChunk(Octree worldTree, Octree waterTree, BlockPalette palette,
       Vector3i origin, ChunkPosition cp, int yMin, int yMax) {
@@ -48,7 +49,7 @@ public class OctreeFinalizer {
         for (int cx = 0; cx < 16; ++cx) {
           int x = cx + cp.x * 16 - origin.x;
           // process blocks that are at the edge of the chunk, the other should have be taken care of during th loading
-          if(cy == yMin || cy == yMax-1 || cz == 0 || cz == 15 || cx == 0 || cx == 15) {
+          if (cy == yMin || cy == yMax - 1 || cz == 0 || cz == 15 || cx == 0 || cx == 15) {
             hideBlocks(worldTree, palette, x, cy, z, yMin, yMax, origin);
             processBlock(worldTree, waterTree, palette, x, cy, z);
           }
@@ -58,12 +59,12 @@ public class OctreeFinalizer {
   }
 
   private static void hideBlocks(Octree worldTree, BlockPalette palette, int x,
-                                 int cy, int z, int yMin, int yMax, Vector3i origin) {
+      int cy, int z, int yMin, int yMax, Vector3i origin) {
     // Set non-visible blocks to be any block, in order to merge large patches.
     int y = cy - origin.y;
     if (cy > yMin && cy < yMax - 1) {
       boolean isHidden =
-              worldTree.getMaterial(x - 1, y, z, palette).opaque
+          worldTree.getMaterial(x - 1, y, z, palette).opaque
               && worldTree.getMaterial(x + 1, y, z, palette).opaque
               && worldTree.getMaterial(x, y, z - 1, palette).opaque
               && worldTree.getMaterial(x, y, z + 1, palette).opaque
@@ -122,14 +123,11 @@ public class OctreeFinalizer {
         corner1 = Math.min(7, 8 - (corner1 / 4));
         corner2 = Math.min(7, 8 - (corner2 / 4));
         corner3 = Math.min(7, 8 - (corner3 / 4));
-        Octree.Node node = waterTree.get(x, cy, z);
-        node = new Octree.DataNode(
-            node.type,
-            (corner0 << Water.CORNER_0)
-                | (corner1 << Water.CORNER_1)
-                | (corner2 << Water.CORNER_2)
-                | (corner3 << Water.CORNER_3));
-        waterTree.set(node, x, cy, z);
+
+        waterTree.set(palette.getWaterId(((Water) wmat).level, (corner0 << Water.CORNER_0)
+            | (corner1 << Water.CORNER_1)
+            | (corner2 << Water.CORNER_2)
+            | (corner3 << Water.CORNER_3)), x, cy, z);
       }
     } else if (mat instanceof Lava) {
       Material above = worldTree.getMaterial(x, cy + 1, z, palette);
@@ -174,14 +172,13 @@ public class OctreeFinalizer {
         corner1 = Math.min(7, 8 - (corner1 / 4));
         corner2 = Math.min(7, 8 - (corner2 / 4));
         corner3 = Math.min(7, 8 - (corner3 / 4));
-        Octree.Node node = worldTree.get(x, cy, z);
-        Octree.Node replaced = new Octree.DataNode(
-            node.type,
+        worldTree.set(palette.getLavaId(
+            lava.level,
             (corner0 << Water.CORNER_0)
                 | (corner1 << Water.CORNER_1)
                 | (corner2 << Water.CORNER_2)
-                | (corner3 << Water.CORNER_3));
-        worldTree.set(replaced, x, cy, z);
+                | (corner3 << Water.CORNER_3)
+        ), x, cy, z);
       }
     }
   }
@@ -191,8 +188,9 @@ public class OctreeFinalizer {
     Octree.Node node = waterTree.get(x, cy, z);
     Material corner = palette.get(node.type);
     if (corner instanceof Water) {
-      int fullBlock = (node.getData() >> Water.FULL_BLOCK) & 1;
-      return 8 - (1 - fullBlock) * ((Water) corner).level;
+      Material above = palette.get(waterTree.get(x, cy + 1, z).type);
+      boolean isFullBlock = above.isWaterFilled();
+      return isFullBlock ? 8 : 8 - ((Water) corner).level;
     } else if (corner.waterlogged) {
       return 8;
     } else if (!worldTree.getMaterial(x, cy, z, palette).solid) {
@@ -206,8 +204,9 @@ public class OctreeFinalizer {
     Octree.Node node = octree.get(x, cy, z);
     Material corner = palette.get(node.type);
     if (corner instanceof Lava) {
-      int fullBlock = (node.getData() >> Water.FULL_BLOCK) & 1;
-      return 8 - (1 - fullBlock) * ((Lava) corner).level;
+      Material above = palette.get(octree.get(x, cy + 1, z).type);
+      boolean isFullBlock = above instanceof Lava;
+      return isFullBlock ? 8 : 8 - ((Lava) corner).level;
     } else if (!corner.solid) {
       return 0;
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -43,9 +43,9 @@ public class PathTracer implements RayTracer {
   @Override public void trace(Scene scene, WorkerState state) {
     Ray ray = state.ray;
     if (scene.isInWater(ray)) {
-      ray.setCurrentMaterial(Water.INSTANCE, 0);
+      ray.setCurrentMaterial(Water.INSTANCE);
     } else {
-      ray.setCurrentMaterial(Air.INSTANCE, 0);
+      ray.setCurrentMaterial(Air.INSTANCE);
     }
     pathTrace(scene, ray, state, 1, true);
   }
@@ -376,7 +376,7 @@ public class PathTracer implements RayTracer {
           Ray.EPSILON, airDistance - Ray.EPSILON);
       atmos.o.scaleAdd(offset, od, ox);
       sun.getRandomSunDirection(atmos, random);
-      atmos.setCurrentMaterial(Air.INSTANCE, 0);
+      atmos.setCurrentMaterial(Air.INSTANCE);
 
       double fogDensity = scene.getFogDensity() * EXTINCTION_FACTOR;
       double extinction = Math.exp(-airDistance * fogDensity);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -36,9 +36,9 @@ public class PreviewRayTracer implements RayTracer {
   @Override public void trace(Scene scene, WorkerState state) {
     Ray ray = state.ray;
     if (scene.isInWater(ray)) {
-      ray.setCurrentMaterial(Water.INSTANCE, 0);
+      ray.setCurrentMaterial(Water.INSTANCE);
     } else {
-      ray.setCurrentMaterial(Air.INSTANCE, 0);
+      ray.setCurrentMaterial(Air.INSTANCE);
     }
     while (true) {
       if (!nextIntersection(scene, ray)) {
@@ -105,7 +105,7 @@ public class PreviewRayTracer implements RayTracer {
       scene.updateOpacity(ray);
       return true;
     } else {
-      ray.setCurrentMaterial(Air.INSTANCE, 0);
+      ray.setCurrentMaterial(Air.INSTANCE);
       return false;
     }
   }
@@ -117,7 +117,7 @@ public class PreviewRayTracer implements RayTracer {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
         ray.n.set(0, 1, 0);
-        ray.setCurrentMaterial(Water.OCEAN_WATER, 1 << Water.FULL_BLOCK);
+        ray.setCurrentMaterial(Water.OCEAN_WATER);
         return true;
       }
     }
@@ -127,7 +127,7 @@ public class PreviewRayTracer implements RayTracer {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
         ray.n.set(0, -1, 0);
-        ray.setCurrentMaterial(Air.INSTANCE, 0);
+        ray.setCurrentMaterial(Air.INSTANCE);
         return true;
       }
     }
@@ -150,7 +150,7 @@ public class PreviewRayTracer implements RayTracer {
           } else {
             ray.color.set(0.25, 0.25, 0.25, 1);
           }
-          ray.setCurrentMaterial(MinecraftBlock.STONE, 0);
+          ray.setCurrentMaterial(MinecraftBlock.STONE);
           ray.n.set(0, 1, 0);
           return true;
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1412,9 +1412,9 @@ public class Scene implements JsonSerializable, Refreshable {
     WorkerState state = new WorkerState();
     state.ray = ray;
     if (isInWater(ray)) {
-      ray.setCurrentMaterial(Water.INSTANCE, 0);
+      ray.setCurrentMaterial(Water.INSTANCE);
     } else {
-      ray.setCurrentMaterial(Air.INSTANCE, 0);
+      ray.setCurrentMaterial(Air.INSTANCE);
     }
     camera.getTargetDirection(ray);
     ray.o.x -= origin.x;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -969,13 +969,13 @@ public class Sky implements JsonSerializable {
   private static void enterCloud(Ray ray, double t) {
     ray.t = t;
     ray.color.set(CloudMaterial.color);
-    ray.setCurrentMaterial(CloudMaterial.INSTANCE, 0);
+    ray.setCurrentMaterial(CloudMaterial.INSTANCE);
   }
 
   private static void exitCloud(Ray ray, double t) {
     ray.t = t;
     ray.color.set(CloudMaterial.color);
-    ray.setCurrentMaterial(Air.INSTANCE, 0);
+    ray.setCurrentMaterial(Air.INSTANCE);
   }
 
   private static boolean inCloud(double x, double z) {

--- a/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
+++ b/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
@@ -16,23 +16,30 @@
  */
 package se.llbit.chunky.resources;
 
-import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.renderer.RenderContext;
-import se.llbit.chunky.world.WorldTexture;
-import se.llbit.math.Octree;
+import static se.llbit.math.Octree.DATA_FLAG;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.world.WorldTexture;
+import se.llbit.log.Log;
+import se.llbit.math.Octree;
 
 public class OctreeFileFormat {
+
   private static final int MIN_OCTREE_VERSION = 3;
-  private static final int OCTREE_VERSION = 4;
+  private static final int OCTREE_VERSION = 5;
 
   /**
    * Load octrees and grass/foliage textures from a file.
    *
-   * @param in input stream for the file to load the scene from.
+   * @param in   input stream for the file to load the scene from.
    * @param impl The octree implementation to use
    */
   public static OctreeData load(DataInputStream in, String impl) throws IOException {
@@ -44,14 +51,66 @@ public class OctreeFileFormat {
     }
     OctreeData data = new OctreeData();
     data.palette = BlockPalette.read(in);
-    data.worldTree = Octree.load(impl, in);
-    data.waterTree = Octree.load(impl, in);
+    data.worldTree = Octree.load(impl, version < 5 ? convertDataNodes(data.palette, in) : in);
+    data.waterTree = Octree.load(impl, version < 5 ? convertDataNodes(data.palette, in) : in);
     data.grassColors = WorldTexture.load(in);
     data.foliageColors = WorldTexture.load(in);
     if (version >= 4) {
       data.waterColors = WorldTexture.load(in);
     }
     return data;
+  }
+
+  /**
+   * This converts a v3-v4 octree to v5 while loading it. In v5, data nodes (only used for water and
+   * lava) were replaced by new per-variant types.
+   *
+   * @param palette Block palette for the octree, new block variants for water and lava will be
+   *                added to it
+   * @param in      Input stream of a v3 or v4 octree
+   * @return Input stream of a v5 octree
+   * @throws IOException If reading or writing a streams fails
+   * @see <a href="https://github.com/chunky-dev/chunky/pull/704">PR #704</a>
+   */
+  private static DataInputStream convertDataNodes(BlockPalette palette, final DataInputStream in)
+      throws IOException {
+    final PipedOutputStream pipedOut = new PipedOutputStream();
+    PipedInputStream resultingStream = new PipedInputStream(pipedOut);
+    Thread convertThread = new Thread(() -> {
+      try (DataOutputStream out = new DataOutputStream(pipedOut)) {
+        out.writeInt(in.readInt()); // depth
+        
+        long remainingNodes = 1;
+        while (remainingNodes > 0) {
+          int type = in.readInt();
+          remainingNodes--;
+          if (type == Octree.BRANCH_NODE) {
+            out.writeInt(type);
+            remainingNodes += 8;
+          } else {
+            if ((type & DATA_FLAG) == 0) {
+              out.writeInt(type);
+            } else {
+              int typeOnly = type ^ DATA_FLAG;
+              int data = in.readInt();
+              Block block = palette.get(typeOnly);
+              if (block instanceof Water) {
+                out.writeInt(palette.getWaterId(((Water) block).level, data));
+              } else if (block instanceof Lava) {
+                out.writeInt(palette.getWaterId(((Lava) block).level, data));
+              } else {
+                out.writeInt(typeOnly);
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        Log.error("Octree conversion failed", e);
+      }
+    });
+    convertThread.setDaemon(true);
+    convertThread.start();
+    return new DataInputStream(resultingStream);
   }
 
   /**
@@ -71,6 +130,7 @@ public class OctreeFileFormat {
   }
 
   public static class OctreeData {
+
     public Octree worldTree, waterTree;
     public WorldTexture grassColors, foliageColors, waterColors;
     public BlockPalette palette;

--- a/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
+++ b/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
@@ -79,7 +79,7 @@ public class OctreeFileFormat {
     Thread convertThread = new Thread(() -> {
       try (DataOutputStream out = new DataOutputStream(pipedOut)) {
         out.writeInt(in.readInt()); // depth
-        
+
         long remainingNodes = 1;
         while (remainingNodes > 0) {
           int type = in.readInt();

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -409,14 +409,12 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
   private void storeNode(DataOutputStream out, long nodeIndex) throws IOException {
     long value = getAt(nodeIndex);
     int type = value > 0 ? BRANCH_NODE : typeFromValue(value);
+    out.writeInt(type);
     if(type == BRANCH_NODE) {
-      out.writeInt(type);
       for(int i = 0; i < 8; ++i) {
         long childIndex = getAt(nodeIndex) + i;
         storeNode(out, childIndex);
       }
-    } else {
-      out.writeInt(type);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -91,7 +91,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public int getData(Octree.NodeId node) {
-    return dataFromValue(getAt(((NodeId)node).nodeIndex));
+    return 0;
   }
 
   /**
@@ -141,15 +141,11 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
   }
 
   private static int typeFromValue(long value) {
-    return -(int) ((value & 0xFFFFFFFF00000000L) >> 32);
+    return -(int) (value);
   }
 
-  private static int dataFromValue(long value) {
-    return (int) (value & 0xFFFFFFFFL);
-  }
-
-  private static long valueFromTypeData(int type, int data) {
-    return (long)(-type) << 32 | data;
+  private static long valueFromType(int type) {
+    return (long)(-type);
   }
 
   /**
@@ -277,8 +273,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
     if(firstIsBranch && secondIsBranch)
       return false;
     else if(!firstIsBranch && !secondIsBranch)
-      return typeFromValue(value1) == secondNode.type // compare types
-              && dataFromValue(value1) == secondNode.getData(); // compare data
+      return typeFromValue(value1) == secondNode.type; // compare types
     return false;
   }
 
@@ -311,7 +306,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
     }
     long finalNodeIndex = getAt(parents[0]) + position;
-    setAt(finalNodeIndex, valueFromTypeData(data.type, data.getData()));
+    setAt(finalNodeIndex, valueFromType(data.type));
 
     // Merge nodes where all children have been set to the same type.
     for (int i = 0; i <= parentLevel; ++i) {
@@ -351,7 +346,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
   public Octree.Node get(int x, int y, int z) {
     long nodeIndex = getNodeIndex(x, y, z);
     long value = getAt(nodeIndex);
-    Octree.Node node = new Octree.DataNode(value > 0 ? BRANCH_NODE : typeFromValue(value), dataFromValue(value));
+    Octree.Node node = new Octree.Node(value > 0 ? BRANCH_NODE : typeFromValue(value));
 
     // Return dummy Node, will work if only type and data are used, breaks if children are needed
     return node;
@@ -403,10 +398,10 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
       }
     } else {
       if ((type & DATA_FLAG) == 0) {
-        setAt(nodeIndex, valueFromTypeData(type, 0));
+        setAt(nodeIndex, valueFromType(type));
       } else {
         int data = in.readInt();
-        setAt(nodeIndex, valueFromTypeData(type ^ DATA_FLAG, 0));
+        setAt(nodeIndex, valueFromType(type ^ DATA_FLAG));
       }
     }
   }
@@ -421,13 +416,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
         storeNode(out, childIndex);
       }
     } else {
-      boolean isDataNode = (dataFromValue(value) != 0);
-      if(isDataNode) {
-        out.writeInt(type | DATA_FLAG);
-        out.writeInt(dataFromValue(value));
-      } else {
-        out.writeInt(type);
-      }
+      out.writeInt(type);
     }
   }
 
@@ -456,7 +445,6 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
   private void finalizationNode(long nodeIndex) {
     boolean canMerge = true;
     int mergedType = ANY_TYPE;
-    int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       long childIndex = getAt(nodeIndex) + i;
       if(getAt(childIndex) > 0) {
@@ -470,14 +458,13 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
         if(mergedType == ANY_TYPE) {
           long value = getAt(childIndex);
           mergedType = typeFromValue(value);
-          mergedData = dataFromValue(value);
-        } else if(!(typeFromValue(getAt(childIndex)) == ANY_TYPE || getAt(childIndex) == valueFromTypeData(mergedType, mergedData))) {
+        } else if(!(typeFromValue(getAt(childIndex)) == ANY_TYPE || getAt(childIndex) == valueFromType(mergedType))) {
           canMerge = false;
         }
       }
     }
     if(canMerge) {
-      mergeNode(nodeIndex, valueFromTypeData(mergedType, mergedData));
+      mergeNode(nodeIndex, valueFromType(mergedType));
     }
   }
 

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -42,6 +42,7 @@ public class Octree {
 
   public interface OctreeImplementation {
     void set(int type, int x, int y, int z);
+    @Deprecated
     void set(Node data, int x, int y, int z);
     Node get(int x, int y, int z);
     Material getMaterial(int x, int y, int z, BlockPalette palette);
@@ -52,6 +53,7 @@ public class Octree {
     boolean isBranch(NodeId node);
     NodeId getChild(NodeId parent, int childNo);
     int getType(NodeId node);
+    @Deprecated
     int getData(NodeId node);
     default void startFinalization() {}
     default void endFinalization() {}
@@ -202,6 +204,7 @@ public class Octree {
       }
     }
 
+    @Deprecated
     public int getData() {
       return 0;
     }
@@ -217,7 +220,9 @@ public class Octree {
 
   /**
    * An octree node with extra data.
+   * @deprecated Not used anymore, only kept for compatibility with plugins
    */
+  @Deprecated
   static public final class DataNode extends Node {
     final int data;
 
@@ -482,7 +487,7 @@ public class Octree {
       Material prevBlock = ray.getCurrentMaterial();
 
       ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, implementation.getData(node));
+      ray.setCurrentMaterial(currentBlock, 0);
 
       if (currentBlock.localIntersect) {
         if (currentBlock.intersect(ray, scene)) {
@@ -596,7 +601,7 @@ public class Octree {
       Material prevBlock = ray.getCurrentMaterial();
 
       ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, implementation.getData(node));
+      ray.setCurrentMaterial(currentBlock, 0);
 
       if (!currentBlock.isWater()) {
         if (currentBlock.localIntersect) {
@@ -612,7 +617,7 @@ public class Octree {
         }
       }
 
-      if ((implementation.getData(node) & (1 << Water.FULL_BLOCK)) == 0) {
+      if (!(currentBlock instanceof Water && ((Water) currentBlock).isFullBlock())) {
         if (WaterModel.intersectTop(ray)) {
           ray.setCurrentMaterial(Air.INSTANCE, 0);
           return true;

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -487,7 +487,7 @@ public class Octree {
       Material prevBlock = ray.getCurrentMaterial();
 
       ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, 0);
+      ray.setCurrentMaterial(currentBlock);
 
       if (currentBlock.localIntersect) {
         if (currentBlock.intersect(ray, scene)) {
@@ -498,7 +498,7 @@ public class Octree {
           continue;
         } else {
           // Exit ray from this local block.
-          ray.setCurrentMaterial(Air.INSTANCE, 0); // Current material is air.
+          ray.setCurrentMaterial(Air.INSTANCE); // Current material is air.
           ray.exitBlock(x, y, z);
           continue;
         }
@@ -601,12 +601,12 @@ public class Octree {
       Material prevBlock = ray.getCurrentMaterial();
 
       ray.setPrevMaterial(prevBlock, ray.getCurrentData());
-      ray.setCurrentMaterial(currentBlock, 0);
+      ray.setCurrentMaterial(currentBlock);
 
       if (!currentBlock.isWater()) {
         if (currentBlock.localIntersect) {
           if (!currentBlock.intersect(ray, scene)) {
-            ray.setCurrentMaterial(Air.INSTANCE, 0);
+            ray.setCurrentMaterial(Air.INSTANCE);
           }
           return true;
         } else if (currentBlock != Air.INSTANCE) {
@@ -619,7 +619,7 @@ public class Octree {
 
       if (!(currentBlock instanceof Water && ((Water) currentBlock).isFullBlock())) {
         if (WaterModel.intersectTop(ray)) {
-          ray.setCurrentMaterial(Air.INSTANCE, 0);
+          ray.setCurrentMaterial(Air.INSTANCE);
           return true;
         } else {
           ray.exitBlock(x, y, z);

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -214,7 +214,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * @param nodeIndex    The index of the node to merge
    * @param typeNegation The negation of the type (the value directly stored in the array)
    */
-  private void mergeNode(int nodeIndex, int typeNegation, int data) {
+  private void mergeNode(int nodeIndex, int typeNegation) {
     int childrenIndex = treeData[nodeIndex];
     freeSpace(childrenIndex); // Delete children
     treeData[nodeIndex] = typeNegation; // Make the node a leaf one
@@ -231,9 +231,6 @@ public class PackedOctree implements Octree.OctreeImplementation {
     boolean firstIsBranch = treeData[firstNodeIndex] > 0;
     boolean secondIsBranch = treeData[secondNodeIndex] > 0;
     return ((firstIsBranch && secondIsBranch) || treeData[firstNodeIndex] == treeData[secondNodeIndex]); // compare types
-    // FIXME possible bug here as we always compare the data even when dealing with nodes that don't really have data
-    // The data int could potentially contain some junk leftover of a previous node
-    // In theory it should be reset to 0 but we need to be careful
   }
 
   /**
@@ -294,7 +291,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       }
 
       if(allSame) {
-        mergeNode(parentIndex, treeData[nodeIndex], 0);
+        mergeNode(parentIndex, treeData[nodeIndex]);
       } else {
         break;
       }
@@ -433,7 +430,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       }
     }
     if(canMerge) {
-      mergeNode(nodeIndex, mergedType, 0);
+      mergeNode(nodeIndex, mergedType);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -88,7 +88,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public Octree.NodeId getChild(Octree.NodeId parent, int childNo) {
-    return new NodeId(treeData[((NodeId) parent).nodeIndex] + 2 * childNo);
+    return new NodeId(treeData[((NodeId) parent).nodeIndex] + childNo);
   }
 
   @Override
@@ -98,7 +98,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public int getData(Octree.NodeId node) {
-    return treeData[((NodeId) node).nodeIndex + 1];
+    return 0;
   }
 
   /**
@@ -115,13 +115,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
    */
   public PackedOctree(int depth, long nodeCount) {
     this.depth = depth;
-    long arraySize = Math.max(nodeCount * 2, 64);
+    long arraySize = Math.max(nodeCount, 64);
     if(arraySize > (long) MAX_ARRAY_SIZE)
       throw new OctreeTooBigException();
     treeData = new int[(int) arraySize];
     treeData[0] = 0;
-    treeData[1] = 0;
-    size = 2;
+    size = 1;
     freeHead = -1; // No holes
   }
 
@@ -135,8 +134,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     treeData = new int[64];
     // Add a root node
     treeData[0] = 0;
-    treeData[1] = 0;
-    size = 2;
+    size = 1;
     freeHead = -1;
   }
 
@@ -205,11 +203,9 @@ public class PackedOctree implements Octree.OctreeImplementation {
   private void subdivideNode(int nodeIndex) {
     int childrenIndex = findSpace();
     for(int i = 0; i < 8; ++i) {
-      treeData[childrenIndex + 2 * i] = treeData[nodeIndex]; // copy type
-      treeData[childrenIndex + 2 * i + 1] = treeData[nodeIndex + 1]; // copy data
+      treeData[childrenIndex + i] = treeData[nodeIndex]; // copy type
     }
     treeData[nodeIndex] = childrenIndex; // Make the node a parent node pointing to its children
-    treeData[nodeIndex + 1] = 0; // reset its data
   }
 
   /**
@@ -222,7 +218,6 @@ public class PackedOctree implements Octree.OctreeImplementation {
     int childrenIndex = treeData[nodeIndex];
     freeSpace(childrenIndex); // Delete children
     treeData[nodeIndex] = typeNegation; // Make the node a leaf one
-    treeData[nodeIndex + 1] = data;
   }
 
   /**
@@ -235,8 +230,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
   private boolean nodeEquals(int firstNodeIndex, int secondNodeIndex) {
     boolean firstIsBranch = treeData[firstNodeIndex] > 0;
     boolean secondIsBranch = treeData[secondNodeIndex] > 0;
-    return ((firstIsBranch && secondIsBranch) || treeData[firstNodeIndex] == treeData[secondNodeIndex]) // compare types
-            && treeData[firstNodeIndex + 1] == treeData[secondNodeIndex + 1]; // compare data
+    return ((firstIsBranch && secondIsBranch) || treeData[firstNodeIndex] == treeData[secondNodeIndex]); // compare types
     // FIXME possible bug here as we always compare the data even when dealing with nodes that don't really have data
     // The data int could potentially contain some junk leftover of a previous node
     // In theory it should be reset to 0 but we need to be careful
@@ -252,8 +246,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
   private boolean nodeEquals(int firstNodeIndex, Octree.Node secondNode) {
     boolean firstIsBranch = treeData[firstNodeIndex] > 0;
     boolean secondIsBranch = (secondNode.type == BRANCH_NODE);
-    return ((firstIsBranch && secondIsBranch) || -treeData[firstNodeIndex] == secondNode.type) // compare types (don't forget that in the tree the negation of the type is stored)
-            && treeData[firstNodeIndex + 1] == secondNode.getData(); // compare data
+    return ((firstIsBranch && secondIsBranch) || -treeData[firstNodeIndex] == secondNode.type); // compare types (don't forget that in the tree the negation of the type is stored)
   }
 
   @Override
@@ -281,12 +274,11 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int ybit = 1 & (y >> i);
       int zbit = 1 & (z >> i);
       position = (xbit << 2) | (ybit << 1) | zbit;
-      nodeIndex = treeData[nodeIndex] + position * 2;
+      nodeIndex = treeData[nodeIndex] + position;
 
     }
-    int finalNodeIndex = treeData[parents[0]] + position * 2;
+    int finalNodeIndex = treeData[parents[0]] + position;
     treeData[finalNodeIndex] = -data.type; // Store negation of the type
-    treeData[finalNodeIndex + 1] = data.getData();
 
     // Merge nodes where all children have been set to the same type.
     for(int i = 0; i <= parentLevel; ++i) {
@@ -294,7 +286,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
       boolean allSame = true;
       for(int j = 0; j < 8; ++j) {
-        int childIndex = treeData[parentIndex] + 2 * j;
+        int childIndex = treeData[parentIndex] + j;
         if(!nodeEquals(childIndex, nodeIndex)) {
           allSame = false;
           break;
@@ -302,7 +294,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       }
 
       if(allSame) {
-        mergeNode(parentIndex, treeData[nodeIndex], treeData[nodeIndex + 1]);
+        mergeNode(parentIndex, treeData[nodeIndex], 0);
       } else {
         break;
       }
@@ -317,7 +309,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int lx = x >>> level;
       int ly = y >>> level;
       int lz = z >>> level;
-      nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)) * 2;
+      nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1));
     }
     return nodeIndex;
   }
@@ -326,7 +318,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
   public Octree.Node get(int x, int y, int z) {
     int nodeIndex = getNodeIndex(x, y, z);
 
-    Octree.Node node = new Octree.DataNode(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex], treeData[nodeIndex + 1]);
+    Octree.Node node = new Octree.Node(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex]);
 
     // Return dummy Node, will work if only type and data are used, breaks if children are needed
     return node;
@@ -372,18 +364,15 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(type == BRANCH_NODE) {
       int childrenIndex = findSpace();
       treeData[nodeIndex] = childrenIndex;
-      treeData[nodeIndex + 1] = 0; // store 0 as data
       for(int i = 0; i < 8; ++i) {
-        loadNode(in, childrenIndex + 2 * i);
+        loadNode(in, childrenIndex + i);
       }
     } else {
       if((type & DATA_FLAG) == 0) {
         treeData[nodeIndex] = -type; // negation of type
-        treeData[nodeIndex + 1] = 0; // store 0 to be sure we don't have uninitialized garbage
       } else {
         int data = in.readInt();
         treeData[nodeIndex] = -(type ^ DATA_FLAG);
-        treeData[nodeIndex + 1] = data;
       }
     }
   }
@@ -393,17 +382,11 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(type == BRANCH_NODE) {
       out.writeInt(type);
       for(int i = 0; i < 8; ++i) {
-        int childIndex = treeData[nodeIndex] + 2 * i;
+        int childIndex = treeData[nodeIndex] + i;
         storeNode(out, childIndex);
       }
     } else {
-      boolean isDataNode = (treeData[nodeIndex + 1] != 0);
-      if(isDataNode) {
-        out.writeInt(type | DATA_FLAG);
-        out.writeInt(treeData[nodeIndex + 1]);
-      } else {
-        out.writeInt(type);
-      }
+      out.writeInt(type);
     }
   }
 
@@ -416,7 +399,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     if(treeData[nodeIndex] > 0) {
       long total = 1;
       for(int i = 0; i < 8; ++i)
-        total += countNodes(treeData[nodeIndex] + 2 * i);
+        total += countNodes(treeData[nodeIndex] + i);
       return total;
     } else {
       return 1;
@@ -432,9 +415,8 @@ public class PackedOctree implements Octree.OctreeImplementation {
   private void finalizationNode(int nodeIndex) {
     boolean canMerge = true;
     int mergedType = -ANY_TYPE;
-    int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
-      int childIndex = treeData[nodeIndex] + 2 * i;
+      int childIndex = treeData[nodeIndex] + i;
       if(treeData[childIndex] > 0) {
         finalizationNode(childIndex);
         // The node may have been merged, retest if it still a branch node
@@ -445,14 +427,13 @@ public class PackedOctree implements Octree.OctreeImplementation {
       if(canMerge) {
         if(mergedType == -ANY_TYPE) {
           mergedType = treeData[childIndex];
-          mergedData = treeData[childIndex + 1];
-        } else if(!(treeData[childIndex] == -ANY_TYPE || (treeData[childIndex] == mergedType && treeData[childIndex + 1] == mergedData))) {
+        } else if(!(treeData[childIndex] == -ANY_TYPE || (treeData[childIndex] == mergedType))) {
           canMerge = false;
         }
       }
     }
     if(canMerge) {
-      mergeNode(nodeIndex, mergedType, mergedData);
+      mergeNode(nodeIndex, mergedType, 0);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -376,14 +376,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
   private void storeNode(DataOutputStream out, int nodeIndex) throws IOException {
     int type = treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex];
+    out.writeInt(type);
     if(type == BRANCH_NODE) {
-      out.writeInt(type);
       for(int i = 0; i < 8; ++i) {
         int childIndex = treeData[nodeIndex] + i;
         storeNode(out, childIndex);
       }
-    } else {
-      out.writeInt(type);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -385,19 +385,20 @@ public class Ray {
     this.prevData = data;
   }
 
+  public void setCurrentMaterial(Material mat) {
+    this.currentMaterial = mat;
+    if (mat instanceof Water) {
+      this.currentData = ((Water) mat).data;
+    } else if (mat instanceof Lava) {
+      this.currentData = ((Lava) mat).data;
+    } else {
+      this.currentData = 0;
+    }
+  }
+
   public void setCurrentMaterial(Material mat, int data) {
     this.currentMaterial = mat;
-    if (data == 0) {
-      if (mat instanceof Water) {
-        this.currentData = ((Water) mat).data;
-      } else if (mat instanceof Lava) {
-        this.currentData = ((Lava) mat).data;
-      } else {
-        this.currentData = 0;
-      }
-    } else {
-      this.currentData = data;
-    }
+    this.currentData = data;
   }
 
   public Material getPrevMaterial() {

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -18,6 +18,8 @@ package se.llbit.math;
 
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.BlockData;
 import se.llbit.chunky.world.Material;
@@ -51,8 +53,8 @@ public class Ray {
   public Vector3 n = new Vector3();
 
   /**
-   * Distance traveled in current medium. This is updated after all intersection
-   * tests have run and the final t value has been found.
+   * Distance traveled in current medium. This is updated after all intersection tests have run and
+   * the final t value has been found.
    */
   public double distance;
 
@@ -97,9 +99,9 @@ public class Ray {
   public double t;
 
   /**
-   * Distance to next potential intersection. The tNext value is stored by
-   * subroutines when calculating a potential next hit point. This can then be
-   * stored in the t variable based on further decision making.
+   * Distance to next potential intersection. The tNext value is stored by subroutines when
+   * calculating a potential next hit point. This can then be stored in the t variable based on
+   * further decision making.
    */
   public double tNext;
 
@@ -163,8 +165,7 @@ public class Ray {
   }
 
   /**
-   * The block data value is a 4-bit integer value describing properties of the
-   * current block.
+   * The block data value is a 4-bit integer value describing properties of the current block.
    *
    * @return current block data (sometimes called metadata).
    */
@@ -185,8 +186,8 @@ public class Ray {
   }
 
   /**
-   * Find the exit point from the given block for this ray. This marches the ray
-   * forward - i.e. updates ray origin directly.
+   * Find the exit point from the given block for this ray. This marches the ray forward - i.e.
+   * updates ray origin directly.
    *
    * @param bx block x coordinate
    * @param by block y coordinate
@@ -386,7 +387,17 @@ public class Ray {
 
   public void setCurrentMaterial(Material mat, int data) {
     this.currentMaterial = mat;
-    this.currentData = data;
+    if (data == 0) {
+      if (mat instanceof Water) {
+        this.currentData = ((Water) mat).data;
+      } else if (mat instanceof Lava) {
+        this.currentData = ((Lava) mat).data;
+      } else {
+        this.currentData = 0;
+      }
+    } else {
+      this.currentData = data;
+    }
   }
 
   public Material getPrevMaterial() {
@@ -397,10 +408,24 @@ public class Ray {
     return currentMaterial;
   }
 
+  /**
+   * Get the data of the previous block. This used to contain the block data but as of Chunky 2,
+   * every block variant gets its own Block instance and this field is only used for water and lava
+   * levels.
+   *
+   * @return Data of the previous block (if water or lava), 0 otherwise
+   */
   public int getPrevData() {
     return prevData;
   }
 
+  /**
+   * Get the data of the current block. This used to contain the block data but as of Chunky 2,
+   * every block variant gets its own Block instance and this field is only used for water and lava
+   * levels.
+   *
+   * @return Data of the current block (if water or lava), 0 otherwise
+   */
   public int getCurrentData() {
     return currentData;
   }

--- a/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
+++ b/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
@@ -114,7 +114,7 @@ public class TexturedTriangle implements Primitive {
       float[] color = material.getColor(ray.u, ray.v);
       if (color[3] > 0) {
         ray.color.set(color);
-        ray.setCurrentMaterial(material, 0);
+        ray.setCurrentMaterial(material);
         ray.t = t;
         ray.n.set(n);
         return true;


### PR DESCRIPTION
In Chunky 1.x, data nodes were used to store block data. As of _the flattening_ in Chunky 2, new block palette entries are created for every block variant (= data configuration) so that data nodes are only used for water and lava to store the corner configuration (different water levels at the four corners; only the base level of the water block is stored in the chunk data, not the corner levels).

This RP remove data nodes from the octree and creates new block palette entries for every data/level configuration of water and lava. This reduces the size of the packed octree by 50% and should not have any negative performance impacts.

Also, this fixes the lava level if there isn't a solid block above lava (used to be full block height, but it's only 14/16th ingame).