### PR TITLE
Fix wrong water and lava level checks.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Lava.java
+++ b/chunky/src/java/se/llbit/chunky/block/Lava.java
@@ -21,7 +21,7 @@ public class Lava extends MinecraftBlockTranslucent {
 
   public Lava(int level, int data) {
     super("lava", Texture.lava);
-    this.level = level;
+    this.level = level % 8;
     this.data = data;
     solid = false;
     localIntersect = true;

--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -28,7 +28,7 @@ public class Water extends MinecraftBlockTranslucent {
 
   public Water(int level, int data) {
     super("water", Texture.water);
-    this.level = level;
+    this.level = level % 8;
     this.data = data;
     solid = false;
     localIntersect = true;

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -97,7 +97,7 @@ public class BlockPalette {
    * @throws IllegalArgumentException If the level is out of range
    */
   public int getWaterId(int level, int data) {
-    if (level < 0 || level > 8) {
+    if (level < 0 || level > 15) {
       throw new IllegalArgumentException("Invalid water level " + level);
     }
     CompoundTag tag = new CompoundTag();
@@ -118,7 +118,7 @@ public class BlockPalette {
    * @throws IllegalArgumentException If the level is out of range
    */
   public int getLavaId(int level, int data) {
-    if (level < 0 || level > 8) {
+    if (level < 0 || level > 15) {
       throw new IllegalArgumentException("Invalid lava level " + level);
     }
     CompoundTag tag = new CompoundTag();


### PR DESCRIPTION
Regression introduced by #704: Water and lava actually have levels from 0 to 15, where 8-15 are used for falling water and equal (8 + level of non-falling water).
Thanks to @jackjt8 for finding it