### PR TITLE
Improvements regarding emitter sampling

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -156,7 +156,7 @@ public class PathTracer implements RayTracer {
 
             Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
-            if (scene.emittersEnabled && currentMat.emittance > Ray.EPSILON) {
+            if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE) && currentMat.emittance > Ray.EPSILON) {
 
               emittance = addEmitted;
               ray.emittance.x = ray.color.x * ray.color.x *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -166,7 +166,7 @@ public class PathTracer implements RayTracer {
               ray.emittance.z = ray.color.z * ray.color.z *
                   currentMat.emittance * scene.emitterIntensity;
               hit = true;
-            } else if(scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.NONE) {
+            } else if(scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() != null) {
               // Sample emitter
               boolean sampleOne = scene.emitterSamplingStrategy == EmitterSamplingStrategy.ONE;
               if(sampleOne) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -298,6 +298,10 @@ public class Scene implements JsonSerializable, Refreshable {
 
   private Grid emitterGrid;
 
+  private int gridSize = PersistentSettings.getGridSizeDefault();
+
+  private boolean preventNormalEmitterWithSampling = PersistentSettings.getPreventNormalEmitterWithSampling();
+
   /**
    * The octree implementation to use
    */
@@ -759,7 +763,7 @@ public class Scene implements JsonSerializable, Refreshable {
       worldOctree = new Octree(octreeImplementation, requiredDepth);
       waterOctree = new Octree(octreeImplementation, requiredDepth);
       if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
-        emitterGrid = new Grid(requiredDepth, 10); // TODO Make configurable
+        emitterGrid = new Grid(requiredDepth, gridSize);
 
       // Parse the regions first - force chunk lists to be populated!
       Set<ChunkPosition> regions = new HashSet<>();
@@ -3042,5 +3046,22 @@ public class Scene implements JsonSerializable, Refreshable {
       this.emitterSamplingStrategy = emitterSamplingStrategy;
       refresh();
     }
+  }
+
+  public int getGridSize() {
+    return gridSize;
+  }
+
+  public void setGridSize(int gridSize) {
+    this.gridSize = gridSize;
+  }
+
+  public boolean isPreventNormalEmitterWithSampling() {
+    return preventNormalEmitterWithSampling;
+  }
+
+  public void setPreventNormalEmitterWithSampling(boolean preventNormalEmitterWithSampling) {
+    this.preventNormalEmitterWithSampling = preventNormalEmitterWithSampling;
+    refresh();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -512,12 +512,11 @@ public class Scene implements JsonSerializable, Refreshable {
       mode = RenderMode.PAUSED;
     }
 
-    // Try loading the grid unconditionally for now
-    boolean emitterGridLoaded = true;
+    boolean emitterGridNeedChunkReload = false;
     if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
-      emitterGridLoaded = loadEmitterGrid(context, taskTracker);
+      emitterGridNeedChunkReload = !loadEmitterGrid(context, taskTracker);
     boolean octreeLoaded = loadOctree(context, taskTracker);
-    if (!emitterGridLoaded || !octreeLoaded) {
+    if (emitterGridNeedChunkReload || !octreeLoaded) {
       // Could not load stored octree or emitter grid.
       // Load the chunks from the world.
       if (loadedWorld == EmptyWorld.INSTANCE) {
@@ -1025,7 +1024,7 @@ public class Scene implements JsonSerializable, Refreshable {
                 }
                 worldOctree.set(octNode, x, cy - origin.y, z);
 
-                if (emitterGrid != null & block.emittance > 1e-4) {
+                if (emitterGrid != null && block.emittance > 1e-4) {
                   emitterGrid.addEmitter(x, cy - origin.y, z);
                 }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
@@ -34,6 +34,7 @@ import se.llbit.chunky.ui.AngleAdjuster;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.fx.LuxColorPicker;
+import se.llbit.log.Log;
 import se.llbit.math.ColorUtil;
 import se.llbit.math.QuickMath;
 
@@ -109,6 +110,8 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
             .addListener((observable, oldvalue, newvalue) -> {
               scene.setEmitterSamplingStrategy(newvalue);
+              if(newvalue != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() == null)
+                Log.warn("The world need to be reloaded for emitter sampling to work");
             });
     emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce"));
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
@@ -111,7 +111,8 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
             .addListener((observable, oldvalue, newvalue) -> {
               scene.setEmitterSamplingStrategy(newvalue);
               if(newvalue != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() == null)
-                Log.warn("The world need to be reloaded for emitter sampling to work");
+                // TODO add nice UI dialog for this
+                Log.warn("The world needs to be reloaded for emitter sampling to work");
             });
     emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce"));
   }

--- a/chunky/src/res/se/llbit/chunky/ui/render/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/AdvancedTab.fxml
@@ -36,6 +36,8 @@
             <ChoiceBox fx:id="octreeImplementation" prefWidth="150.0" />
           </children>
         </HBox>
+        <IntegerAdjuster fx:id="gridSize" />
+        <CheckBox fx:id="preventNormalEmitterWithSampling" mnemonicParsing="false" text="Prevent normal emitter when using emitter sampling" />
       </children>
       <padding>
         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -422,5 +422,21 @@ public final class PersistentSettings {
   public static String getOctreeImplementation() {
     return settings.getString("octreeImplementation", "PACKED");
   }
+
+  public static void setGridSizeDefault(int value) {
+    settings.setInt("gridSize", value);
+  }
+
+  public static int getGridSizeDefault() {
+    return settings.getInt("gridSize", 10);
+  }
+
+  public static void setPreventNormalEmitterWithSampling(boolean value) {
+    settings.setBool("preventNormalEmitterWithSampling", value);
+  }
+
+  public static boolean getPreventNormalEmitterWithSampling() {
+    return settings.getBool("preventNormalEmitterWithSampling", false);
+  }
 }
 


### PR DESCRIPTION
Various improvements regarding emitter sampling that needed to be done:
 - Only create the emitter grid when using sampling strategy One or All (when switching to one of those 2, a warning appears to inform that the chunks need to be reloaded. A problem with this is that when changing sampling strategy before loading any chunks, the warning still appears, it would be better if it didn't)
 - Add some advanced options to control the size of the grid cell and, as suggested by Ryhida, add an option to prevent usual emitter contribution when using emitter sampling. 
 - Change the internal structure used to store the emitter grid to be (hopefully) more memory efficient. This only changes internals, the interface or the format on disk are unchanged so full backward compatibility.