### PR TITLE
Fix spruce and birch leaves

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Leaves.java
+++ b/chunky/src/java/se/llbit/chunky/block/Leaves.java
@@ -3,9 +3,12 @@ package se.llbit.chunky.block;
 import se.llbit.chunky.model.LeafModel;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
+import se.llbit.math.ColorUtil;
 import se.llbit.math.Ray;
 
 public class Leaves extends MinecraftBlock {
+  private float[] tint;
+
   public Leaves(String name, Texture texture) {
     super(name, texture);
     localIntersect = true;
@@ -13,7 +16,17 @@ public class Leaves extends MinecraftBlock {
     opaque = false;
   }
 
+  public Leaves(String name, Texture texture, int tint) {
+    this(name, texture);
+    this.tint = new float[3];
+    ColorUtil.getRGBComponents(tint, this.tint);
+    ColorUtil.toLinear(this.tint);
+  }
+
   @Override public boolean intersect(Ray ray, Scene scene) {
+    if (tint != null) {
+      return LeafModel.intersect(ray, texture, tint);
+    }
     return LeafModel.intersect(ray, scene, texture);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -919,9 +919,9 @@ public class MinecraftBlockProvider implements BlockProvider {
       case "oak_leaves":
         return new Leaves(name, Texture.oakLeaves);
       case "spruce_leaves":
-        return new Leaves(name, Texture.spruceLeaves);
+        return new Leaves(name, Texture.spruceLeaves, 0x619961);
       case "birch_leaves":
-        return new Leaves(name, Texture.birchLeaves);
+        return new Leaves(name, Texture.birchLeaves, 0x80a755);
       case "jungle_leaves":
         return new Leaves(name, Texture.jungleTreeLeaves);
       case "acacia_leaves":

--- a/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 public class LilyPadEntity extends Entity {
-
+  private static final Material lilyMaterial = new LilyPadMaterial();
   private final int rotation;
 
   public LilyPadEntity(Vector3 position) {
@@ -56,7 +56,6 @@ public class LilyPadEntity extends Entity {
     Vector2 t2 = new Vector2(0, 1);
     Vector2 t3 = new Vector2(1, 1);
     Vector2 t4 = new Vector2(1, 0);
-    Material lilyMaterial = new LilyPadMaterial();
     Collection<Primitive> primitives = new LinkedList<>();
     switch (rotation) {
       case 0:

--- a/chunky/src/java/se/llbit/chunky/model/LeafModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/LeafModel.java
@@ -34,8 +34,7 @@ public class LeafModel {
       float[] color = texture.getColor(ray.u, ray.v);
       if (color[3] > Ray.EPSILON) {
         ray.color.set(color);
-        float[] biomeColor;
-        biomeColor = ray.getBiomeFoliageColor(scene);
+        float[] biomeColor = ray.getBiomeFoliageColor(scene);
         ray.color.x *= biomeColor[0];
         ray.color.y *= biomeColor[1];
         ray.color.z *= biomeColor[2];

--- a/chunky/src/java/se/llbit/chunky/world/material/LilyPadMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/LilyPadMaterial.java
@@ -21,7 +21,6 @@ import se.llbit.chunky.world.Material;
 import se.llbit.math.ColorUtil;
 import se.llbit.math.Ray;
 
-// TODO: fetch color from biome?
 public class LilyPadMaterial extends Material {
 
   private static final int COLOR = 0x208030;
@@ -29,6 +28,7 @@ public class LilyPadMaterial extends Material {
 
   static {
     ColorUtil.getRGBAComponents(COLOR, lilyPadColor);
+    ColorUtil.toLinear(lilyPadColor);
   }
 
   public LilyPadMaterial() {


### PR DESCRIPTION
In Minecraft, birch and spruce leaves don't take the biome color into account but always have fixed tint colors instead.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5544859/97119882-91a10b00-1713-11eb-9ef9-02c18d9ee586.png)|![image](https://user-images.githubusercontent.com/5544859/97119888-99f94600-1713-11eb-87f1-f6c92abc24fb.png)|
|![image](https://user-images.githubusercontent.com/5544859/97119893-a382ae00-1713-11eb-9e73-2e155d516a5a.png)|![image](https://user-images.githubusercontent.com/5544859/97119899-aa112580-1713-11eb-91e8-27c73afa8b99.png)|

