### PR TITLE
Don't store the linear texture and gamma correct on the fly

### DIFF
--- a/chunky/src/java/se/llbit/math/ColorUtil.java
+++ b/chunky/src/java/se/llbit/math/ColorUtil.java
@@ -28,6 +28,15 @@ import se.llbit.chunky.renderer.scene.Scene;
  */
 public final class ColorUtil {
 
+  // Look up table used to speed up gamma correction
+  public static final float[] toLinearLut = new float[256];
+
+  static {
+    for(int i = 0; i < 256; i++) {
+      toLinearLut[i] = (float)Math.pow(i / 255.0, Scene.DEFAULT_GAMMA);
+    }
+  }
+
   private ColorUtil() {
   }
 
@@ -168,6 +177,16 @@ public final class ColorUtil {
     frgb[0] = (0xFF & (irgb >> 16)) / 255.0;
     frgb[1] = (0xFF & (irgb >> 8)) / 255.0;
     frgb[2] = (0xFF & irgb) / 255.0;
+  }
+
+  /**
+   * Get the RGBA color component gamma corrected from an ARGB int
+   */
+  public static void getRGBAComponentsGammaCorrected(int argb, float[] components) {
+    components[3] = (argb >>> 24) / 255.0f;
+    components[0] = toLinearLut[(0xFF & (argb >> 16))];
+    components[1] = toLinearLut[(0xFF & (argb >> 8))];
+    components[2] = toLinearLut[(0xFF & argb)];
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/ColorUtil.java
+++ b/chunky/src/java/se/llbit/math/ColorUtil.java
@@ -29,10 +29,10 @@ import se.llbit.chunky.renderer.scene.Scene;
 public final class ColorUtil {
 
   // Look up table used to speed up gamma correction
-  public static final float[] toLinearLut = new float[256];
+  private static final float[] toLinearLut = new float[256];
 
   static {
-    for(int i = 0; i < 256; i++) {
+    for (int i = 0; i < 256; i++) {
       toLinearLut[i] = (float)Math.pow(i / 255.0, Scene.DEFAULT_GAMMA);
     }
   }


### PR DESCRIPTION
New memory optimization we talked about in discord.
Remove the linear texture stored as a float array and only keep the BitmapImage (where every pixel, 4 components, is stored as an int).
Gamma correction is then done on the fly by using a look up table.
I made some tests to measure the performance impact this has, The difference in time I measured is in the order of 4% in favor of the gamma correction on the fly! But my RAM was pretty much saturated when I did those measurement so they may not be representative of usages where more memory is available.
In term of memory reduction, the size of textures has been divided by 5 (from one int and 4 float per pixel to only one int), for 16*16 textures this means a reduction of about 4MB