### PR TITLE
Check position is in bound of the grid

### DIFF
--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -129,6 +129,10 @@ public class Grid {
     int gridX = x / cellSize;
     int gridY = y / cellSize;
     int gridZ = z / cellSize;
+
+    if(isOOB(gridX) || isOOB(gridY) || isOOB(gridZ))
+      return null;
+
     int index = cellIndex(gridX, gridY, gridZ);
 
     int start = constructedGrid[2*index];
@@ -141,6 +145,11 @@ public class Grid {
     return emitterPositions.get(emitterIndex);
   }
 
+  private boolean isOOB(int coord)
+  {
+    return coord < 0 || coord >= gridSize;
+  }
+
   /**
    * Get the list of emitters position close from a given point
    */
@@ -148,10 +157,14 @@ public class Grid {
     int gridX = x / cellSize;
     int gridY = y / cellSize;
     int gridZ = z / cellSize;
+
+    List<EmitterPosition> pos = new ArrayList<>();
+    if(isOOB(gridX) || isOOB(gridY) || isOOB(gridZ))
+      return pos;
+
     int index = cellIndex(gridX, gridY, gridZ);
     int start = constructedGrid[2*index];
     int size = constructedGrid[2*index+1];
-    List<EmitterPosition> pos = new ArrayList<>();
     for(int i = 0; i < size; ++i) {
       pos.add(emitterPositions.get(positionIndexes[start+i]));
     }

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -130,7 +130,7 @@ public class Grid {
     int gridY = y / cellSize;
     int gridZ = z / cellSize;
 
-    if(isOOB(gridX) || isOOB(gridY) || isOOB(gridZ))
+    if(isOutOfBounds(gridX, gridY, gridZ))
       return null;
 
     int index = cellIndex(gridX, gridY, gridZ);
@@ -145,9 +145,11 @@ public class Grid {
     return emitterPositions.get(emitterIndex);
   }
 
-  private boolean isOOB(int coord)
+  private boolean isOutOfBounds(int x, int y, int z)
   {
-    return coord < 0 || coord >= gridSize;
+    return x < 0 || x >= gridSize
+        || y < 0 || y >= gridSize
+        || z < 0 || z >= gridSize;
   }
 
   /**
@@ -159,7 +161,7 @@ public class Grid {
     int gridZ = z / cellSize;
 
     List<EmitterPosition> pos = new ArrayList<>();
-    if(isOOB(gridX) || isOOB(gridY) || isOOB(gridZ))
+    if(isOutOfBounds(gridX, gridY, gridZ))
       return pos;
 
     int index = cellIndex(gridX, gridY, gridZ);


### PR DESCRIPTION
When using emitter sampling, check that the position at which we want to retrieve emitter is in the grid. Hopefully should fix the bug @jackjt8 encountered