### PR TITLE
Fix the option prevent normal emitters

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -156,7 +156,7 @@ public class PathTracer implements RayTracer {
 
             Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
-            if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE) && currentMat.emittance > Ray.EPSILON) {
+            if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
               emittance = addEmitted;
               ray.emittance.x = ray.color.x * ray.color.x *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -415,6 +415,7 @@ public class Scene implements JsonSerializable, Refreshable {
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
+    preventNormalEmitterWithSampling = other.preventNormalEmitterWithSampling;
     transparentSky = other.transparentSky;
     fogDensity = other.fogDensity;
     skyFogDensity = other.skyFogDensity;


### PR DESCRIPTION
When adding the option to prevent normal emitter behavior I somehow forgot to copy it when copying a scene, so basically the option had no effect, silly me. Must have hardcoded stuff during development and not bother to check it was working with the real option... Also change condition to use normal emitter behavior for a direct ray from camera to emitter, else the emitter appears dark