### PR TITLE
Change emitter grid to not store useless cells

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -763,7 +763,7 @@ public class Scene implements JsonSerializable, Refreshable {
       worldOctree = new Octree(octreeImplementation, requiredDepth);
       waterOctree = new Octree(octreeImplementation, requiredDepth);
       if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
-        emitterGrid = new Grid(requiredDepth, gridSize);
+        emitterGrid = new Grid(gridSize);
 
       // Parse the regions first - force chunk lists to be populated!
       Set<ChunkPosition> regions = new HashSet<>();
@@ -1926,7 +1926,7 @@ public class Scene implements JsonSerializable, Refreshable {
       try(DataInputStream in = new DataInputStream(new GZIPInputStream(context.getSceneFileInputStream(filename)))) {
         emitterGrid = Grid.load(in);
         return true;
-      } catch(IOException e) {
+      } catch(Exception e) {
         Log.info("Couldn't load the grid", e);
         return false;
       }

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -53,14 +53,14 @@ public class Grid {
     this.cellSize = cellSize;
     long totalSize = (1L << octreeDepth);
     this.gridSize = (int) ((totalSize + (cellSize-1)) / cellSize);
-    minX = maxX = minY = maxY = minZ = maxZ = 1;
+    minX = maxX = minY = maxY = minZ = maxZ = -1;
   }
 
   // Constructor used by the load method
   private Grid(int gridSize, int cellSize, int overloadSelectFlag /*unused*/) {
     this.gridSize = gridSize;
     this.cellSize = cellSize;
-    minX = maxX = minY = maxY = minZ = maxZ = 1;
+    minX = maxX = minY = maxY = minZ = maxZ = -1;
   }
 
   public void addEmitter(int x, int y, int z) {

--- a/chunky/src/java/se/llbit/math/Grid.java
+++ b/chunky/src/java/se/llbit/math/Grid.java
@@ -230,18 +230,33 @@ public class Grid {
    */
   public static Grid load(DataInputStream in) throws IOException {
     int version = in.readInt();
-    if(version != GRID_FORMAT_VERSION) {
+    if(version > GRID_FORMAT_VERSION) {
       throw new RuntimeException("Unknown grid format version, can't load the grid");
     }
 
-    int cellSize = in.readInt();
-    Grid grid = new Grid(cellSize);
-    grid.offsetX = in.readInt();
-    grid.sizeX = in.readInt();
-    grid.offsetY = in.readInt();
-    grid.sizeY = in.readInt();
-    grid.offsetZ = in.readInt();
-    grid.sizeZ = in.readInt();
+    Grid grid;
+
+    if(version == 0) {
+      int gridSize = in.readInt();
+      int cellSize = in.readInt();
+      grid = new Grid(cellSize);
+      grid.offsetX = 0;
+      grid.sizeX = gridSize;
+      grid.offsetY = 0;
+      grid.sizeY = gridSize;
+      grid.offsetZ = 0;
+      grid.sizeZ = gridSize;
+    } else {
+      int cellSize = in.readInt();
+      grid = new Grid(cellSize);
+      grid.offsetX = in.readInt();
+      grid.sizeX = in.readInt();
+      grid.offsetY = in.readInt();
+      grid.sizeY = in.readInt();
+      grid.offsetZ = in.readInt();
+      grid.sizeZ = in.readInt();
+    }
+
 
     // Read emitter positions
     int emitterNo = in.readInt();


### PR DESCRIPTION
Instead of having an emitter grid that spans the whole octree, the emitter grid is changed to only span as much as is necessary for the emitter in the scene. This should further decrease memory usage of the grid.