### PR TITLE
Fix crash when saving the octree of worlds with corrupted block NBT data

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
@@ -7,9 +7,11 @@ import java.util.LinkedList;
 import java.util.List;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
+import se.llbit.util.NbtUtil;
 import se.llbit.util.NotNull;
 
 public class BlockSpec {
+
   public static final List<BlockProvider> blockProviders = new LinkedList<>();
 
   private final Tag tag;
@@ -27,7 +29,7 @@ public class BlockSpec {
   }
 
   public void serialize(DataOutputStream out) throws IOException {
-    tag.write(out);
+    NbtUtil.safeSerialize(out, tag);
   }
 
   @Override
@@ -40,7 +42,9 @@ public class BlockSpec {
     return (obj instanceof BlockSpec) && ((BlockSpec) obj).tag.equals(tag);
   }
 
-  /** Converts NBT block data to Chunky block object. */
+  /**
+   * Converts NBT block data to Chunky block object.
+   */
   public Block toBlock() {
     String name = tag.get("Name").stringValue("unknown:unknown");
     for (BlockProvider provider : blockProviders) {

--- a/chunky/src/java/se/llbit/util/NbtUtil.java
+++ b/chunky/src/java/se/llbit/util/NbtUtil.java
@@ -1,0 +1,56 @@
+package se.llbit.util;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.ErrorTag;
+import se.llbit.nbt.ListTag;
+import se.llbit.nbt.NamedTag;
+import se.llbit.nbt.SpecificTag;
+import se.llbit.nbt.Tag;
+
+public class NbtUtil {
+
+  /**
+   * Write the given NBT tag into the given outputstream but skip any invalid tags instead of
+   * throwing errors. This can be removed once https://github.com/llbit/jo-nbt/pull/2 is merged.
+   *
+   * @param out output stream
+   * @param tag NBT tag
+   * @throws IOException if writing to the stream fails
+   */
+  public static void safeSerialize(DataOutputStream out, Tag tag) throws IOException {
+    if (tag instanceof ErrorTag) {
+      // ignore invalid tag
+    } else if (tag instanceof CompoundTag) {
+      for (NamedTag item : (CompoundTag) tag) {
+        safeSerialize(out, item);
+      }
+      out.writeByte(Tag.TAG_END);
+    } else if (tag instanceof ListTag) {
+      out.writeByte(((ListTag) tag).getType());
+      List<SpecificTag> validItems = new ArrayList<>();
+      for (SpecificTag item : (ListTag) tag) {
+        if (!(item instanceof ErrorTag)) {
+          validItems.add(item);
+        }
+      }
+      out.writeInt(validItems.size());
+      for (SpecificTag item : validItems) {
+        safeSerialize(out, item);
+      }
+    } else if (tag instanceof NamedTag) {
+      if (((NamedTag) tag).getTag() instanceof ErrorTag) {
+        // ignore invalid named tag
+        return;
+      }
+      ((NamedTag) tag).getTag().writeType(out);
+      out.writeUTF(((NamedTag) tag).name());
+      safeSerialize(out, ((NamedTag) tag).getTag());
+    } else {
+      tag.write(out);
+    }
+  }
+}


### PR DESCRIPTION
Chunky can render chunks with broken nbt block data just fine, as long as it's not using it. When saving the octree, _all_ nbt data gets serialized which throws errors for invalid nbt data (literal `Error` instances, so it crashes).
This means that without this fix there are worlds that you can load and render but not save the octree of.

Related to llbit/jo-nbt#2