### PR TITLE
Emitter sampling reload chunks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -81,6 +81,7 @@ import se.llbit.chunky.world.Icon;
 import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.listeners.ChunkUpdateListener;
 import se.llbit.fx.ToolPane;
+import se.llbit.fxutil.Dialogs;
 import se.llbit.fxutil.GroupedChangeListener;
 import se.llbit.log.Level;
 import se.llbit.log.Log;
@@ -498,7 +499,7 @@ public class ChunkyFxController
 
     deleteChunks.setTooltip(new Tooltip("Delete selected chunks."));
     deleteChunks.setOnAction(e -> {
-      Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+      Alert alert = Dialogs.createAlert(Alert.AlertType.CONFIRMATION);
       alert.setTitle("Delete Selected Chunks");
       alert.setContentText(
           "Do you really want to delete the selected chunks? This can not be undone.");
@@ -889,7 +890,7 @@ public class ChunkyFxController
     File oldFormat = new File(PersistentSettings.getSceneDirectory(), sceneName + Scene.EXTENSION);
     File newFormat = new File(PersistentSettings.getSceneDirectory(), sceneName);
     if (oldFormat.exists() || newFormat.exists()) {
-      Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+      Alert alert = Dialogs.createAlert(Alert.AlertType.CONFIRMATION);
       alert.setTitle("Overwrite existing scene");
       alert.setContentText("A scene with that name already exists. This will overwrite the existing scene, are you sure you want to continue?");
 

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -33,6 +33,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import se.llbit.chunky.main.SceneHelper;
 import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.log.Log;
@@ -98,7 +99,7 @@ public class SceneChooserController implements Initializable {
           Log.error("Can not delete scene with unknown filename.");
           return;
         }
-        Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+        Alert alert = Dialogs.createAlert(Alert.AlertType.CONFIRMATION);
         alert.setTitle("Delete Scene");
         alert.setContentText(String.format("Are you sure you want to delete the scene %s? "
             + "All files for the scene, except snapshot images, will be deleted.", scene.sceneName));

--- a/chunky/src/java/se/llbit/chunky/ui/UILogReceiver.java
+++ b/chunky/src/java/se/llbit/chunky/ui/UILogReceiver.java
@@ -20,6 +20,7 @@ import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
+import se.llbit.fxutil.Dialogs;
 import se.llbit.log.Level;
 import se.llbit.log.Receiver;
 
@@ -39,11 +40,7 @@ public class UILogReceiver extends Receiver {
       case INFO:
       case WARNING:
         Platform.runLater(() -> {
-          Alert warning = new Alert(Alert.AlertType.WARNING);
-          // We have to do some adjustments to make the warning dialog resize to
-          // the text content on Linux. Source: http://stackoverflow.com/a/33905734
-          warning.getDialogPane().getChildren().stream().filter(node -> node instanceof Label)
-              .forEach(node -> ((Label) node).setMinHeight(Region.USE_PREF_SIZE));
+          Alert warning = Dialogs.createAlert(Alert.AlertType.WARNING);
           warning.setContentText(message);
           warning.show();
         });

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -43,6 +43,7 @@ import se.llbit.chunky.ui.RenderCanvasFx;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Icon;
+import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.log.Log;
@@ -155,7 +156,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
 
     restoreDefaults.setOnAction(
         event -> {
-          Alert alert = new Alert(AlertType.CONFIRMATION);
+          Alert alert = Dialogs.createAlert(AlertType.CONFIRMATION);
           alert.setTitle("Restore default settings");
           alert.setContentText("Do you really want to reset all scene settings?");
           if (alert.showAndWait().get() == ButtonType.OK) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
@@ -125,9 +125,6 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
             ButtonType result = warning.showAndWait().orElse(ButtonType.CANCEL);
             if (result.getButtonData() == ButtonData.FINISH) {
               controller.getRenderController().getSceneManager().reloadChunks();
-            } else {
-              scene.setEmitterSamplingStrategy(EmitterSamplingStrategy.NONE);
-              emitterSamplingStrategy.getSelectionModel().select(EmitterSamplingStrategy.NONE);
             }
           }
         });

--- a/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/LightingTab.java
@@ -38,7 +38,7 @@ import se.llbit.chunky.ui.AngleAdjuster;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.fx.LuxColorPicker;
-import se.llbit.fxutil.AlertFactory;
+import se.llbit.fxutil.Dialogs;
 import se.llbit.math.ColorUtil;
 import se.llbit.math.QuickMath;
 
@@ -116,7 +116,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
         .addListener((observable, oldvalue, newvalue) -> {
           scene.setEmitterSamplingStrategy(newvalue);
           if (newvalue != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() == null) {
-            Alert warning = AlertFactory.createAlert(AlertType.CONFIRMATION);
+            Alert warning = Dialogs.createAlert(AlertType.CONFIRMATION);
             warning.setContentText("The selected chunks need to be reloaded in order for emitter sampling to work.");
             warning.getButtonTypes().setAll(
               ButtonType.CANCEL,

--- a/chunky/src/java/se/llbit/fxutil/AlertFactory.java
+++ b/chunky/src/java/se/llbit/fxutil/AlertFactory.java
@@ -1,0 +1,22 @@
+package se.llbit.fxutil;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+
+public class AlertFactory {
+
+  /**
+   * Create an alert dialog of the given type that will resize to the text content properly on
+   * Linux.
+   */
+  public static Alert createAlert(AlertType type) {
+    Alert alert = new Alert(type);
+    // We have to do some adjustments to make the alert dialog resize to
+    // the text content on Linux. Source: http://stackoverflow.com/a/33905734
+    alert.getDialogPane().getChildren().stream().filter(node -> node instanceof Label)
+        .forEach(node -> ((Label) node).setMinHeight(Region.USE_PREF_SIZE));
+    return alert;
+  }
+}

--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -5,7 +5,7 @@ import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 
-public class AlertFactory {
+public class Dialogs {
 
   /**
    * Create an alert dialog of the given type that will resize to the text content properly on


### PR DESCRIPTION
The UX when enabling emitter sampling was slightly confusing (reload _world_ instead of _chunks_) so here is the proper dialog from the TODO. If the user doesn't reload the chunks, it disables emitter sampling.