### PR TITLE
Player head helmet and armor stand updates

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
@@ -372,6 +372,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
   private final JsonObject gear;
   private final JsonObject pose;
   private final boolean showArms;
+  private final boolean invisible;
+  private final boolean noBasePlate;
 
   public ArmorStand(JsonObject json) {
     super(JsonUtil.vec3FromJsonObject(json.get("position")));
@@ -380,6 +382,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
     this.showArms = json.get("showArms").asBoolean(false);
     this.gear = json.get("gear").object();
     this.pose = json.get("pose").object();
+    this.invisible = json.get("invisible").asBoolean(false);
+    this.noBasePlate = json.get("noBasePlate").asBoolean(false);
   }
 
   public ArmorStand(Vector3 position, Tag tag) {
@@ -420,6 +424,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
     pose.add("rightArm", JsonUtil.listTagToJson(poseTag.get("RightArm")));
     pose.add("leftLeg", JsonUtil.listTagToJson(poseTag.get("LeftLeg")));
     pose.add("rightLeg", JsonUtil.listTagToJson(poseTag.get("RightLeg")));
+    invisible = tag.get("Invisible").boolValue(false);
+    noBasePlate = tag.get("NoBasePlate").boolValue(false);
   }
 
   @Override public Collection<Primitive> primitives(Vector3 offset) {
@@ -430,13 +436,6 @@ public class ArmorStand extends Entity implements Poseable, Geared {
         position.x + offset.x,
         position.y + offset.y,
         position.z + offset.z);
-
-    // Add the base - not rotated or scaled.
-    Transform transform = Transform.NONE.translate(-0.5, 0, -0.5).translate(worldOffset);
-    for (Quad quad : base) {
-      quad.addTriangles(primitives, material, transform);
-    }
-
 
     double armWidth = 2;
     JsonObject pose = new JsonObject();
@@ -476,74 +475,86 @@ public class ArmorStand extends Entity implements Poseable, Geared {
     PlayerEntity.addArmor(primitives, gear, pose, armWidth, worldTransform,
         headScale);
 
-    if (showArms) {
+    Transform transform = Transform.NONE.translate(-0.5, 0, -0.5).translate(worldOffset);
+
+    if (!invisible) {
+      if (!noBasePlate) {
+        // Add the base - not rotated or scaled.
+        for (Quad quad : base) {
+          quad.addTriangles(primitives, material, transform);
+        }
+      }
+
+      if (showArms) {
+        transform = Transform.NONE
+            .translate(0, -5 / 16., 0)
+            .rotateX(leftArmPose.x)
+            .rotateY(leftArmPose.y)
+            .rotateZ(leftArmPose.z)
+            .translate(-(4 + armWidth) / 16., 23 / 16., 0)
+            .chain(worldTransform);
+        for (Quad quad : leftArm) {
+          quad.addTriangles(primitives, material, transform);
+        }
+
+        transform = Transform.NONE
+            .translate(0, -5 / 16., 0)
+            .rotateX(rightArmPose.x)
+            .rotateY(rightArmPose.y)
+            .rotateZ(rightArmPose.z)
+            .translate((4 + armWidth) / 16., 23 / 16., 0)
+            .chain(worldTransform);
+        for (Quad quad : rightArm) {
+          quad.addTriangles(primitives, material, transform);
+        }
+      }
+
       transform = Transform.NONE
           .translate(0, -5 / 16., 0)
-          .rotateX(leftArmPose.x)
-          .rotateY(leftArmPose.y)
-          .rotateZ(leftArmPose.z)
-          .translate(-(4 + armWidth) / 16., 23 / 16., 0)
+          .rotateX(leftLegPose.x)
+          .rotateY(leftLegPose.y)
+          .rotateZ(leftLegPose.z)
+          .translate(-2 / 16., 11.5 / 16., 0)
           .chain(worldTransform);
-      for (Quad quad : leftArm) {
+      for (Quad quad : leftLeg) {
         quad.addTriangles(primitives, material, transform);
       }
 
       transform = Transform.NONE
           .translate(0, -5 / 16., 0)
-          .rotateX(rightArmPose.x)
-          .rotateY(rightArmPose.y)
-          .rotateZ(rightArmPose.z)
-          .translate((4 + armWidth) / 16., 23 / 16., 0)
+          .rotateX(rightLegPose.x)
+          .rotateY(rightLegPose.y)
+          .rotateZ(rightLegPose.z)
+          .translate(2 / 16., 11.5 / 16., 0)
           .chain(worldTransform);
-      for (Quad quad : rightArm) {
+      for (Quad quad : rightLeg) {
+        quad.addTriangles(primitives, material, transform);
+      }
+
+      transform = Transform.NONE
+          .translate(0, -5 / 16., 0)
+          .rotateX(chestPose.x)
+          .rotateY(chestPose.y)
+          .rotateZ(chestPose.z)
+          .translate(0, (5 + 18) / 16., 0)
+          .chain(worldTransform);
+      for (Quad quad : torso) {
+        quad.addTriangles(primitives, material, transform);
+      }
+
+      transform = Transform.NONE
+          .translate(0, 2 / 16.0, 0)
+          .rotateX(headPose.x)
+          .rotateY(headPose.y)
+          .rotateZ(headPose.z)
+          .scale(headScale)
+          .translate(0, 24 / 16.0, 0)
+          .chain(worldTransform);
+      for (Quad quad : neck) {
         quad.addTriangles(primitives, material, transform);
       }
     }
 
-    transform = Transform.NONE
-        .translate(0, -5 / 16., 0)
-        .rotateX(leftLegPose.x)
-        .rotateY(leftLegPose.y)
-        .rotateZ(leftLegPose.z)
-        .translate(-2 / 16., 11.5 / 16., 0)
-        .chain(worldTransform);
-    for (Quad quad : leftLeg) {
-      quad.addTriangles(primitives, material, transform);
-    }
-
-    transform = Transform.NONE
-        .translate(0, -5 / 16., 0)
-        .rotateX(rightLegPose.x)
-        .rotateY(rightLegPose.y)
-        .rotateZ(rightLegPose.z)
-        .translate(2 / 16., 11.5 / 16., 0)
-        .chain(worldTransform);
-    for (Quad quad : rightLeg) {
-      quad.addTriangles(primitives, material, transform);
-    }
-
-    transform = Transform.NONE
-        .translate(0, -5 / 16., 0)
-        .rotateX(chestPose.x)
-        .rotateY(chestPose.y)
-        .rotateZ(chestPose.z)
-        .translate(0, (5 + 18) / 16., 0)
-        .chain(worldTransform);
-    for (Quad quad : torso) {
-      quad.addTriangles(primitives, material, transform);
-    }
-
-    transform = Transform.NONE
-        .translate(0, 2 / 16.0, 0)
-        .rotateX(headPose.x)
-        .rotateY(headPose.y)
-        .rotateZ(headPose.z)
-        .scale(headScale)
-        .translate(0, 24 / 16.0, 0)
-        .chain(worldTransform);
-    for (Quad quad : neck) {
-      quad.addTriangles(primitives, material, transform);
-    }
     return primitives;
   }
 
@@ -556,6 +567,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
     json.add("showArms", showArms);
     json.add("gear", gear);
     json.add("pose", pose);
+    json.add("invisible", invisible);
+    json.add("noBasePlate", noBasePlate);
     return json;
   }
 

--- a/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
@@ -146,9 +146,10 @@ public class HeadEntity extends Entity {
   /**
    * Download the skin or take it from the cache.
    *
+   * @param skin The URL of the skin
    * @return The downloaded/cached skin or the steve skin if the download failed
    */
-  private EntityTexture downloadSkin() {
+  public static EntityTexture downloadTexture(String skin) {
     return textureCache.computeIfAbsent(skin, (skinUrl) -> {
       EntityTexture texture = new EntityTexture();
       EntityTextureLoader loader = new EntityTextureLoader(skinUrl, texture);
@@ -182,6 +183,15 @@ public class HeadEntity extends Entity {
 
       return EntityTexture.steve;
     });
+  }
+
+  /**
+   * Download the skin or take it from the cache.
+   *
+   * @return The downloaded/cached skin or the steve skin if the download failed
+   */
+  private EntityTexture downloadSkin() {
+    return downloadTexture(skin);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -427,9 +427,9 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       "{\"elements\":[{\"from\":[3,3,3],\"to\":[13,13,13],\"faces\":{\"up\":{\"uv\":[2,0,4,4],\"texture\":\"#texture\"},\"east\":{\"uv\":[0,4,2,8],\"texture\":\"#texture\"},\"west\":{\"uv\":[4,4,6,8],\"texture\":\"#texture\"},\"north\":{\"uv\":[2,4,4,8],\"texture\":\"#texture\"},\"south\":{\"uv\":[6,4,8,8],\"texture\":\"#texture\"}}}]}";
 
   private static final String headJson =
-      "{\"elements\":[{\"from\":[4,4,4],\"to\":[12,12,12],\"faces\":{\"up\":{\"uv\":[2,0,4,2],\"texture\":\"#texture\"},\"down\":{\"uv\":[4,0,6,2],\"texture\":\"#texture\"},\"east\":{\"uv\":[6,2,4,4],\"texture\":\"#texture\"},\"west\":{\"uv\":[2,2,0,4],\"texture\":\"#texture\"},\"north\":{\"uv\":[2,2,4,4],\"texture\":\"#texture\"},\"south\":{\"uv\":[6,2,8,4],\"texture\":\"#texture\"}}}]}";
+      "{\"elements\":[{\"from\":[4,4,4],\"to\":[12,12,12],\"faces\":{\"up\":{\"uv\":[4,2,2,0],\"texture\":\"#texture\"},\"down\":{\"uv\":[4,0,6,2],\"texture\":\"#texture\"},\"east\":{\"uv\":[6,2,4,4],\"texture\":\"#texture\"},\"west\":{\"uv\":[2,2,0,4],\"texture\":\"#texture\"},\"north\":{\"uv\":[2,2,4,4],\"texture\":\"#texture\"},\"south\":{\"uv\":[6,2,8,4],\"texture\":\"#texture\"}}},{\"from\":[3.75,3.75,3.75],\"to\":[12.25,12.25,12.25],\"faces\":{\"up\":{\"uv\":[12,2,10,0],\"texture\":\"#texture\"},\"down\":{\"uv\":[12,0,14,2],\"texture\":\"#texture\"},\"east\":{\"uv\":[14,2,12,4],\"texture\":\"#texture\"},\"west\":{\"uv\":[10,2,8,4],\"texture\":\"#texture\"},\"north\":{\"uv\":[10,2,12,4],\"texture\":\"#texture\"},\"south\":{\"uv\":[14,2,14,4],\"texture\":\"#texture\"}}}]}";
 
-  // The difference between skullJson/headJson is that skullJson is textured with a half as tall texture.
+  // The difference between skullJson/headJson is that skullJson is textured with a half as tall texture and has no hat.
   private static final String skullJson =
       "{\"elements\":[{\"from\":[4,4,4],\"to\":[12,12,12],\"faces\":{\"up\":{\"uv\":[2,0,4,4],\"texture\":\"#texture\"},\"down\":{\"uv\":[4,0,6,4],\"texture\":\"#texture\"},\"east\":{\"uv\":[6,4,4,8],\"texture\":\"#texture\"},\"west\":{\"uv\":[2,4,0,8],\"texture\":\"#texture\"},\"north\":{\"uv\":[2,4,4,8],\"texture\":\"#texture\"},\"south\":{\"uv\":[6,4,8,8],\"texture\":\"#texture\"}}}]}";
 

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -192,22 +192,26 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
         .rotateZ(allPose.z)
         .translate(worldOffset);
     Collection<Primitive> primitives = new LinkedList<>();
-    Box head = new Box(-4 / 16., 4 / 16., -4 / 16., 4 / 16., -4 / 16., 4 / 16.);
-    head.transform(Transform.NONE
-        .translate(0, 4 / 16., 0)
-        .scale(headScale)
-        .rotateX(headPose.x)
-        .rotateY(headPose.y)
-        .rotateZ(headPose.z)
-        .translate(0, -4 / 16., 0)
-        .translate(0, 28 / 16., 0)
-        .chain(worldTransform));
-    head.addFrontFaces(primitives, texture, texture.headFront);
-    head.addBackFaces(primitives, texture, texture.headBack);
-    head.addLeftFaces(primitives, texture, texture.headLeft);
-    head.addRightFaces(primitives, texture, texture.headRight);
-    head.addTopFaces(primitives, texture, texture.headTop);
-    head.addBottomFaces(primitives, texture, texture.headBottom);
+    if (!gear.get("head").object().get("id").stringValue("").equals("minecraft:player_head") &&
+        !gear.get("head").object().get("id").stringValue("").equals("minecraft:skull")
+    ) {
+      Box head = new Box(-4 / 16., 4 / 16., -4 / 16., 4 / 16., -4 / 16., 4 / 16.);
+      head.transform(Transform.NONE
+          .translate(0, 4 / 16., 0)
+          .scale(headScale)
+          .rotateX(headPose.x)
+          .rotateY(headPose.y)
+          .rotateZ(headPose.z)
+          .translate(0, -4 / 16., 0)
+          .translate(0, 28 / 16., 0)
+          .chain(worldTransform));
+      head.addFrontFaces(primitives, texture, texture.headFront);
+      head.addBackFaces(primitives, texture, texture.headBack);
+      head.addLeftFaces(primitives, texture, texture.headLeft);
+      head.addRightFaces(primitives, texture, texture.headRight);
+      head.addTopFaces(primitives, texture, texture.headTop);
+      head.addBottomFaces(primitives, texture, texture.headBottom);
+    }
     Box hat = new Box(-4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16.);
     hat.transform(Transform.NONE
         .translate(0, 4 / 16., 0)

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -217,23 +217,24 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       head.addRightFaces(primitives, texture, texture.headRight);
       head.addTopFaces(primitives, texture, texture.headTop);
       head.addBottomFaces(primitives, texture, texture.headBottom);
+
+      Box hat = new Box(-4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16.);
+      hat.transform(Transform.NONE
+          .translate(0, 4 / 16., 0)
+          .scale(headScale)
+          .rotateX(headPose.x)
+          .rotateY(headPose.y)
+          .rotateZ(headPose.z)
+          .translate(0, -4 / 16., 0)
+          .translate(0, 28.2 / 16., 0)
+          .chain(worldTransform));
+      hat.addFrontFaces(primitives, texture, texture.hatFront);
+      hat.addBackFaces(primitives, texture, texture.hatBack);
+      hat.addLeftFaces(primitives, texture, texture.hatLeft);
+      hat.addRightFaces(primitives, texture, texture.hatRight);
+      hat.addTopFaces(primitives, texture, texture.hatTop);
+      hat.addBottomFaces(primitives, texture, texture.hatBottom);
     }
-    Box hat = new Box(-4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16.);
-    hat.transform(Transform.NONE
-        .translate(0, 4 / 16., 0)
-        .scale(headScale)
-        .rotateX(headPose.x)
-        .rotateY(headPose.y)
-        .rotateZ(headPose.z)
-        .translate(0, -4 / 16., 0)
-        .translate(0, 28.2 / 16., 0)
-        .chain(worldTransform));
-    hat.addFrontFaces(primitives, texture, texture.hatFront);
-    hat.addBackFaces(primitives, texture, texture.hatBack);
-    hat.addLeftFaces(primitives, texture, texture.hatLeft);
-    hat.addRightFaces(primitives, texture, texture.hatRight);
-    hat.addTopFaces(primitives, texture, texture.hatTop);
-    hat.addBottomFaces(primitives, texture, texture.hatBottom);
     Box chest = new Box(-4 / 16., 4 / 16., -6 / 16., 6 / 16., -2 / 16., 2 / 16.);
     chest.transform(Transform.NONE
         .translate(0, -5 / 16., 0)

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -17,6 +17,7 @@
  */
 package se.llbit.chunky.entity;
 
+import se.llbit.chunky.block.Head;
 import se.llbit.chunky.renderer.scene.PlayerModel;
 import se.llbit.chunky.resources.EntityTexture;
 import se.llbit.chunky.resources.Texture;
@@ -118,6 +119,11 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       // Skull type is stored in the damage field.
       int damage = tag.get("Damage").shortValue();
       item.add("type", damage);
+    } else if (id.equals("minecraft:player_head")) {
+      Tag skinTag = tag.get("tag").get("SkullOwner").get("Properties").get("textures").get(0).get("Value");
+      if (!skinTag.isError()) {
+        item.add("skin", Head.getTextureUrl(tag.get("tag").asCompound()));
+      }
     }
     return item;
   }
@@ -534,6 +540,8 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           json = parseJson(skullJson);
           break;
       }
+    } else if (id.equals("minecraft:player_head")) {
+      json = parseJson(headJson);
     }
     Map<String, Texture> textureMap = Collections.singletonMap("#texture", getTexture(item));
     return new CubeModel(JsonModel.fromJson(json), 16, textureMap);
@@ -666,6 +674,9 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           break;
         case "turtle_helmet":
           loader = simpleTexture("models/armor/turtle_layer_1", texture);
+          break;
+        case "player_head":
+          texture = HeadEntity.downloadTexture(item.get("skin").asString(""));
           break;
         default:
           Log.warnf("Unknown item ID: %s%n", id);


### PR DESCRIPTION
This PR adds support for players and armor stands to wear player heads. It also adds support for invisible armor stands and armor stands without a base plate.

Closes #727 
Implements some of the features from #452 

![image](https://user-images.githubusercontent.com/5544859/100556478-fca9a880-32a2-11eb-9a6c-da51b9c964a5.png)
