### PR TITLE
Add an option to disable default texture loading and fix some texture bugs

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1202,6 +1202,15 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * Rebuild the actors and the other blocks bounding volume hierarchy.
+   */
+  public void rebuildBvh() {
+    buildBvh();
+    buildActorBvh();
+    refresh();
+  }
+
+  /**
    * Rebuild the actors bounding volume hierarchy.
    */
   public void rebuildActorBvh() {

--- a/chunky/src/java/se/llbit/chunky/resources/TextureCache.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TextureCache.java
@@ -16,14 +16,16 @@
  */
 package se.llbit.chunky.resources;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 /**
  * Cache for texture lookups for infrequently used textures.
  */
 public class TextureCache {
-  private static Map<Object, Texture> map = new HashMap<>();
+
+  private static Map<Object, Texture> map = Collections.synchronizedMap(new WeakHashMap<>());
 
   public static Texture get(Object key) {
     return map.get(key);
@@ -34,7 +36,6 @@ public class TextureCache {
   }
 
   public static void reset() {
-    // TODO: make thread safe.
     map.clear();
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3666,6 +3666,7 @@ public class TexturePackLoader {
    * last used texture pack.
    */
   public static void loadTexturePacks(@NotNull String[] texturePacks, boolean remember) {
+    TextureCache.reset();
     TexturePackLoader.texturePacks = texturePacks;
     Set<Map.Entry<String, TextureLoader>> toLoad = allTextures.entrySet();
     for (String path : texturePacks) {

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3681,7 +3681,7 @@ public class TexturePackLoader {
         }
       }
     }
-    if (!toLoad.isEmpty()) {
+    if (!toLoad.isEmpty() && !PersistentSettings.getDisableDefaultTextures()) {
       // If there are textures left to load we try to load the default textures.
       File defaultResources = MinecraftFinder.getMinecraftJar();
       if (defaultResources != null) {
@@ -3798,7 +3798,7 @@ public class TexturePackLoader {
         }
       }
     }
-    if (!toLoad.isEmpty()) {
+    if (!toLoad.isEmpty() && !PersistentSettings.getDisableDefaultTextures()) {
       // If there are textures left to load we try to load the default textures.
       File defaultResources = MinecraftFinder.getMinecraftJar();
       if (defaultResources != null) {

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3666,6 +3666,7 @@ public class TexturePackLoader {
    * last used texture pack.
    */
   public static void loadTexturePacks(@NotNull String[] texturePacks, boolean remember) {
+    TexturePackLoader.texturePacks = texturePacks;
     Set<Map.Entry<String, TextureLoader>> toLoad = allTextures.entrySet();
     for (String path : texturePacks) {
       if (!path.isEmpty()) {

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -577,6 +577,7 @@ public class ChunkyFxController
     editResourcePacks.setOnAction(e -> {
       ResourceLoadOrderEditor editor = new ResourceLoadOrderEditor(() -> {
         scene.refresh();
+        scene.rebuildBvh();
       });
       editor.show();
     });

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -134,6 +134,7 @@ public class ChunkyFxController
   @FXML private Tab aboutTab;
   @FXML private Button editResourcePacks;
   @FXML private CheckBox singleColorBtn;
+  @FXML private CheckBox disableDefaultTexturesBtn;
   @FXML private CheckBox showLauncherBtn;
   @FXML private Button openSceneDirBtn;
   @FXML private Button changeSceneDirBtn;
@@ -595,6 +596,11 @@ public class ChunkyFxController
     singleColorBtn.setSelected(PersistentSettings.getSingleColorTextures());
     singleColorBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
       PersistentSettings.setSingleColorTextures(newValue);
+    });
+
+    disableDefaultTexturesBtn.setSelected(PersistentSettings.getDisableDefaultTextures());
+    disableDefaultTexturesBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      PersistentSettings.setDisableDefaultTextures(newValue);
     });
 
     trackPlayerBtn.selectedProperty().bindBidirectional(trackPlayer);

--- a/chunky/src/java/se/llbit/chunky/ui/ResourceLoadOrderEditor.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ResourceLoadOrderEditor.java
@@ -57,7 +57,6 @@ public class ResourceLoadOrderEditor extends Stage {
       String[] paths = new String[pathList.getItems().size()];
       pathList.getItems().toArray(paths);
       TexturePackLoader.loadTexturePacks(paths, true);
-      TextureCache.reset();
       onResourcesChanged.run();
       hide();
     });

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -149,7 +149,7 @@
           <Hyperlink fx:id="issueTrackerLink" text="Issue Tracker"/>
           <Hyperlink fx:id="forumLink" text="Discussion Forum"/>
           <Hyperlink fx:id="discordLink" text="Discord Server" />
-          <Hyperlink fx:id="guideLink" text="jackt8's Guide to Chunky" />
+          <Hyperlink fx:id="guideLink" text="jackjt8's Guide to Chunky" />
           <Separator />
           <Label text="Chunky was created by Jesper Öqvist (jesper@llbit.se)"/>
           <Button fx:id="creditsBtn" mnemonicParsing="false" text="View Credits"/>

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -130,6 +130,7 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
           </padding>
           <Button fx:id="editResourcePacks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Edit resource packs"/>
+          <CheckBox fx:id="disableDefaultTexturesBtn" mnemonicParsing="false" text="Disable default textures (needs restart)"/>
           <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures (needs restart)"/>
           <CheckBox fx:id="showLauncherBtn" mnemonicParsing="false" text="Show launcher when starting Chunky"/>
           <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open Scenes Directory"/>

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -438,5 +438,18 @@ public final class PersistentSettings {
   public static boolean getPreventNormalEmitterWithSampling() {
     return settings.getBool("preventNormalEmitterWithSampling", false);
   }
+
+  /**
+   * Checks if Chunky should try to load the default textures from the latest Minecraft version it can find if they
+   * are not found in the selected resource packs.
+   * For deterministic renders (independent of installed Minecraft versions), this option should be enabled.
+   */
+  public static boolean getDisableDefaultTextures() {
+    return settings.getBool("disableDefaultTextures", false);
+  }
+
+  public static void setDisableDefaultTextures(boolean value) {
+    settings.setBool("disableDefaultTextures", value);
+  }
 }
 


### PR DESCRIPTION
Currently Chunky always loads the latest local Minecraft version by default. This can cause inconsistencies when rendering the very same scene with the very same (user-selected) resource packs on two different machines (e.g. for leather armor textures, which used to be loaded on start and were never reloaded).

This PR adds an option to disable loading from the local Minecraft version. It also makes it so that textures of primitives in the bvh trees (e.g. armor of armorstands or players) get reloaded too by rebuilding the bvh trees after changing the resourcepacks.

Textures are still cached in Chunky though, so even after removing all resourcepacks, most of the previous textures (anything but bvh primitive textures) will still be loaded. In practice one of the resource pack is usually set to either a Minecraft jar or a complete resourcepack so this shouldn't be an issue since all textures will be overwritten with the new ones.