### PR TITLE
Reset settings to default values if reloading the settings fails

### DIFF
--- a/lib/src/se/llbit/chunky/JsonSettings.java
+++ b/lib/src/se/llbit/chunky/JsonSettings.java
@@ -55,12 +55,9 @@ public final class JsonSettings {
       JsonParser parser = new JsonParser(in);
       json = parser.parse().object();
       Log.infof("Settings loaded from %s", path);
-    } catch (IOException e) {
-      Log.warnf("Warning: Could not load settings from %s - defaults will be used", path);
-    } catch (SyntaxError e) {
-      Log.warnf(
-          "Warning: Could not load settings from %s - defaults will be used (%s)",
-          path, e.getMessage());
+    } catch (SyntaxError | IOException e) {
+      Log.warn(String.format("Warning: Could not load settings from %s - defaults will be used", path), e);
+      json = new JsonObject();
     }
   }
 


### PR DESCRIPTION
…after changing the settings directory.

Most likely only an issue when using Chunky as a library because it could yield to unexpected behavior if the .chunky directory exists but you don't want to use it.