### PR TITLE
Fix skull texture loading errors

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -18,7 +18,7 @@ import se.llbit.nbt.Tag;
 public class Head extends MinecraftBlockTranslucent {
 
   private static final Pattern SKIN_URL_FROM_OBJECT = Pattern
-      .compile("\"?SKIN\"?\\s*:\\s*\\{\\s*\"?url\"?\\s*:\\s*\"(.+?)\"");
+      .compile("\"?SKIN\"?\\s*:\\s*\\{.+?\"?url\"?\\s*:\\s*\"(.+?)\"");
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -122,7 +122,10 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
     } else if (id.equals("minecraft:player_head")) {
       Tag skinTag = tag.get("tag").get("SkullOwner").get("Properties").get("textures").get(0).get("Value");
       if (!skinTag.isError()) {
-        item.add("skin", Head.getTextureUrl(tag.get("tag").asCompound()));
+        String skinUrl = Head.getTextureUrl(tag.get("tag").asCompound());
+        if (skinUrl != null && !skinUrl.isEmpty()) {
+          item.add("skin", skinUrl);
+        }
       }
     }
     return item;
@@ -677,7 +680,10 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           loader = simpleTexture("models/armor/turtle_layer_1", texture);
           break;
         case "player_head":
-          texture = HeadEntity.downloadTexture(item.get("skin").asString(""));
+          String skin = item.get("skin").asString("");
+          if (!skin.isEmpty()) {
+            texture = HeadEntity.downloadTexture(skin);
+          }
           break;
         default:
           Log.warnf("Unknown item ID: %s%n", id);


### PR DESCRIPTION
The regex didn't match for Alex skins because the object doesn't start with the url but with the model metadata in that case. We can't use JSON parsing though, as older worlds don't use json for the base64-encoded skull data (no quotes around properties, which would fail parsing).