### PR TITLE
Try to locate javafx

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -89,7 +89,8 @@ public class ChunkyLauncher {
 
       if(args.length > 0) {
         mode = LaunchMode.HEADLESS;
-        for(String arg : args) {
+        for(int i = 0; i < args.length; i++) {
+          String arg = args[i];
           switch(arg) {
             case "--nolauncher":
               mode = LaunchMode.GUI;
@@ -148,9 +149,20 @@ public class ChunkyLauncher {
               return;
             case "--noRetryJavafx":
               retryIfMissingJavafx = false;
-              // if this is the only option, we want the launcher
-              if(args.length == 1)
+              // if this is the only option, with "--javaOptions" "<param>" we want the launcher
+              if(args.length == 3)
                 forceLauncher = true;
+              break;
+            case "--javaOptions":
+              if(i == args.length-1) {
+                System.err.println("--javaOptions must be followed by the options to can chunky with");
+                System.exit(1);
+              }
+              if(settings.javaOptions.isEmpty())
+                settings.javaOptions = args[i+1];
+              else if(!settings.javaOptions.contains(args[i+1]))
+                settings.javaOptions = args[i + 1] + " " + settings.javaOptions;
+              ++i;
               break;
             default:
               if(!headlessOptions.isEmpty()) {

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -23,6 +23,8 @@ import se.llbit.chunky.launcher.ui.DebugConsole;
 import se.llbit.chunky.launcher.ui.FirstTimeSetupDialog;
 import se.llbit.chunky.resources.SettingsDirectory;
 
+import javax.swing.*;
+import java.awt.*;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -73,8 +75,6 @@ public class ChunkyLauncher {
        * we strip that and start regularly, but without launcher. The --launcher
        * option overrides everything else and forces the launcher to appear.
        */
-
-      // TODO(llbit): the control flow for launching Chunky needs to be simplified.
 
       boolean forceLauncher = false;
       LaunchMode mode = LaunchMode.GUI;
@@ -224,11 +224,18 @@ public class ChunkyLauncher {
         // Javafx error
         if(retryIfMissingJavafx)
           JavaFxLocator.retryWithJavafx(args);
-        System.err.println("Error: Java cannot find javafx.");
-        System.err.println("If you are using a JVM for java 11 or later, " +
-                "javafx is no longer shipped alongside and must be installed separately");
-        System.err.println("If you already have javafx installed, you need to run chunky with the command:");
-        System.err.println("java --module-path <path/to/javafx/lib> --add-modules javafx.controls,javafx.fxml -jar <path/to/ChunkyLauncher.jar>");
+        String[] errorMessages = new String[]{
+          "Error: Java cannot find javafx.",
+          "If you are using a JVM for java 11 or later, " +
+                  "javafx is no longer shipped alongside and must be installed separately",
+          "If you already have javafx installed, you need to run chunky with the command:",
+          "java --module-path <path/to/javafx/lib> --add-modules javafx.controls,javafx.fxml -jar <path/to/ChunkyLauncher.jar>"
+        };
+        if(!GraphicsEnvironment.isHeadless())
+          JOptionPane.showMessageDialog(null, errorMessages, "Cannot find javafx", JOptionPane.ERROR_MESSAGE);
+        for(String message : errorMessages) {
+          System.err.println(message);
+        }
       }
       e.printStackTrace(System.err);
     }

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -1,0 +1,82 @@
+package se.llbit.chunky.launcher;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class JavaFxLocator {
+
+
+  private static final String[] javafxPathCandidates;
+
+  static {
+    String[] javafxPathCandidates1;
+    try {
+      javafxPathCandidates1 = new String[]{
+              "C:/Program Files/openjfx/lib",
+              System.getProperty("java.home", "") + File.separator + "lib", // java home
+              new File(ChunkyLauncher.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+                      .toPath().getParent().toAbsolutePath().toString() + File.separator + "lib", // directory of the .jar
+              System.getProperty("user.dir", "") + File.separator + "lib", // working directory
+              "/usr/share/openjfx/lib",
+              "/usr/lib/jvm/java-11-openjdk/lib",
+              "/usr/lib/jvm/java-12-openjdk/lib",
+              "/usr/lib/jvm/java-13-openjdk/lib",
+              "/usr/lib/jvm/java-14-openjdk/lib",
+              "/usr/lib/jvm/java-15-openjdk/lib",
+      };
+    } catch(URISyntaxException e) {
+      e.printStackTrace();
+      javafxPathCandidates1 = new String[0];
+    }
+    javafxPathCandidates = javafxPathCandidates1;
+  }
+
+  private static boolean validJavafxDirectory(Path dir) {
+    return dir.toFile().exists()
+            && dir.resolve("javafx.base.jar").toFile().exists()
+            && dir.resolve("javafx.controls.jar").toFile().exists()
+            && dir.resolve("javafx.graphics.jar").toFile().exists()
+            && dir.resolve("javafx.fxml.jar").toFile().exists();
+  }
+
+  private static void runWithJavafx(Path javafxDir, String[] args) {
+    // https://stackoverflow.com/questions/4159802/how-can-i-restart-a-java-application
+    ArrayList<String> cmd = new ArrayList<>();
+    cmd.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    cmd.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
+    cmd.add("--module-path");
+    cmd.add(javafxDir.toAbsolutePath().toString());
+    cmd.add("--add-modules");
+    cmd.add("javafx.controls,javafx.fxml");
+
+    cmd.add("-cp");
+    cmd.add(ManagementFactory.getRuntimeMXBean().getClassPath());
+    cmd.add(ChunkyLauncher.class.getName());
+    cmd.addAll(Arrays.asList(args));
+    cmd.add("--noRetryJavafx"); // Make sure this doesn't end up as a fork bomb
+
+    ProcessBuilder builder = new ProcessBuilder(cmd);
+    builder.inheritIO();
+    try {
+      Process process = builder.start();
+      System.exit(process.waitFor());
+    } catch(IOException | InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public static void retryWithJavafx(String[] args) {
+    for(String candiate : javafxPathCandidates) {
+      Path directory = new File(candiate).toPath();
+      if(validJavafxDirectory(directory)) {
+        runWithJavafx(directory, args);
+      }
+    }
+  }
+
+}

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -56,7 +56,15 @@ public class JavaFxLocator {
     cmd.add(ManagementFactory.getRuntimeMXBean().getClassPath());
     cmd.add(ChunkyLauncher.class.getName());
     cmd.addAll(Arrays.asList(args));
-    cmd.add("--noRetryJavafx"); // Make sure this doesn't end up as a fork bomb
+    cmd.add("--noRetryJavafx"); // Make sure this doesn't end up as a fork bomb*
+    // add the options again so the launcher can use them for chunky
+    cmd.add("--javaOptions");
+    StringBuilder javaOptions = new StringBuilder();
+    javaOptions.append("--module-path ");
+    javaOptions.append(javafxDir.toAbsolutePath().toString());
+    javaOptions.append(" --add-modules ");
+    javaOptions.append("javafx.controls,javafx.fxml");
+    cmd.add(javaOptions.toString());
 
     ProcessBuilder builder = new ProcessBuilder(cmd);
     builder.inheritIO();

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -7,33 +7,31 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class JavaFxLocator {
 
 
-  private static final String[] javafxPathCandidates;
+  private static final List<String> javafxPathCandidates;
 
   static {
-    String[] javafxPathCandidates1;
+    javafxPathCandidates = new ArrayList<>();
+    javafxPathCandidates.add("C:/Program Files/openjfx/lib");
+    javafxPathCandidates.add("/usr/share/openjfx/lib");
+    javafxPathCandidates.add("/usr/lib/jvm/java-11-openjdk/lib");
+    javafxPathCandidates.add("/usr/lib/jvm/java-12-openjdk/lib");
+    javafxPathCandidates.add("/usr/lib/jvm/java-13-openjdk/lib");
+    javafxPathCandidates.add("/usr/lib/jvm/java-14-openjdk/lib");
+    javafxPathCandidates.add("/usr/lib/jvm/java-15-openjdk/lib");
+
+    javafxPathCandidates.add(System.getProperty("java.home", "") + File.separator + "lib"); // java home
+    javafxPathCandidates.add(System.getProperty("user.dir", "") + File.separator + "lib"); // working directory
     try {
-      javafxPathCandidates1 = new String[]{
-              "C:/Program Files/openjfx/lib",
-              System.getProperty("java.home", "") + File.separator + "lib", // java home
-              new File(ChunkyLauncher.class.getProtectionDomain().getCodeSource().getLocation().toURI())
-                      .toPath().getParent().toAbsolutePath().toString() + File.separator + "lib", // directory of the .jar
-              System.getProperty("user.dir", "") + File.separator + "lib", // working directory
-              "/usr/share/openjfx/lib",
-              "/usr/lib/jvm/java-11-openjdk/lib",
-              "/usr/lib/jvm/java-12-openjdk/lib",
-              "/usr/lib/jvm/java-13-openjdk/lib",
-              "/usr/lib/jvm/java-14-openjdk/lib",
-              "/usr/lib/jvm/java-15-openjdk/lib",
-      };
+      javafxPathCandidates.add(new File(ChunkyLauncher.class.getProtectionDomain().getCodeSource().getLocation().toURI())
+              .toPath().getParent().toAbsolutePath().toString() + File.separator + "lib"); // directory of the .jar
     } catch(URISyntaxException e) {
       e.printStackTrace();
-      javafxPathCandidates1 = new String[0];
     }
-    javafxPathCandidates = javafxPathCandidates1;
   }
 
   private static boolean validJavafxDirectory(Path dir) {
@@ -47,7 +45,7 @@ public class JavaFxLocator {
   private static void runWithJavafx(Path javafxDir, String[] args) {
     // https://stackoverflow.com/questions/4159802/how-can-i-restart-a-java-application
     ArrayList<String> cmd = new ArrayList<>();
-    cmd.add(System.getProperty("java.home") + File.separator + "bin" + File.separator + "java");
+    cmd.add(JreUtil.javaCommand(""));
     cmd.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
     cmd.add("--module-path");
     cmd.add(javafxDir.toAbsolutePath().toString());


### PR DESCRIPTION
Change the launcher so it tries to locate javafx in some predefined location (if you think of other locations, tell me).
If javafx is found, restart the launcher with javafx, else stop the launcher as usual but with an additional more descriptive error message.
This doesn't like a robust approach to the problem but I don't have a better idea for now. That's wy I would like some feedback/ideas during developpement.
Passing the argument to the invocation of chunky itself still need to be implemented.

Closes #523 
Closes #484 
