### PR TITLE
Fix workers live-locking on transparent textures for opaque blocks without localIntersect

### DIFF
--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -504,6 +504,9 @@ public class Octree {
         }
       } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
         TexturedBlockModel.getIntersectionColor(ray);
+        if (currentBlock.opaque) {
+          ray.color.w = 1;
+        }
         return true;
       }
 
@@ -611,6 +614,9 @@ public class Octree {
           return true;
         } else if (currentBlock != Air.INSTANCE) {
           TexturedBlockModel.getIntersectionColor(ray);
+          if (currentBlock.opaque) {
+            ray.color.w = 1;
+          }
           return true;
         } else {
           return true;


### PR DESCRIPTION
Force the alpha value of opaque blocks to be 1 when using the fast path (no block-specific intersecion).

When going the "fast path" (`localIntersect` false, so only get the ray color because we already know where we hit the block, which is just a cube in this case), textures with transparent parts can cause live-locks under certain (random but reproducible) circumstances.

This PR fixes it but also keeps glass working (by checking the `opaque` property).