### PR TITLE
Fix player head skin download for some heads

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -79,7 +79,7 @@ public class Head extends MinecraftBlockTranslucent {
         if (matcher.find()) {
           return matcher.group(1);
         } else {
-          Log.warn("Could not get skull texture");
+          Log.warn("Could not get skull texture from json: " + decoded);
         }
       } catch (IllegalArgumentException e) {
         // base64 decoding error

--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -17,8 +17,10 @@ import se.llbit.nbt.Tag;
 
 public class Head extends MinecraftBlockTranslucent {
 
+  // the decoded string might not be valid json (sometimes keys are not quoted)
+  // so we use a regex to extract the skin url
   private static final Pattern SKIN_URL_FROM_OBJECT = Pattern
-      .compile("\"?SKIN\"?\\s*:\\s*\\{.+?\"?url\"?\\s*:\\s*\"(.+?)\"");
+      .compile("\"?SKIN\"?\\s*:\\s*\\{.+?\"?url\"?\\s*:\\s*\"(.+?)\"", Pattern.DOTALL);
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;
@@ -74,7 +76,6 @@ public class Head extends MinecraftBlockTranslucent {
     if (!textureBase64.isEmpty()) {
       try {
         String decoded = new String(Base64.getDecoder().decode(textureBase64));
-        // the decoded string might not be valid json (sometimes keys are not quoted)
         Matcher matcher = SKIN_URL_FROM_OBJECT.matcher(decoded);
         if (matcher.find()) {
           return matcher.group(1);


### PR DESCRIPTION
Sometimes the base64-encoded json contains line breaks that were not ignored by the old regex (`.` does not consume linebreaks by default).

> In dotall mode, the expression . matches any character, including a line terminator. By default this expression does not match line terminators.

https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#DOTALL