### PR TITLE
Concurrent chunk position cache

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -16,8 +16,8 @@
  */
 package se.llbit.chunky.world;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A chunk position consists of two integer coordinates x and z.
@@ -27,6 +27,7 @@ import java.util.Map;
  * @author Jesper Öqvist (jesper@llbit.se)
  */
 public class ChunkPosition {
+
   public int x, z;
 
   private ChunkPosition(int x, int z) {
@@ -34,7 +35,8 @@ public class ChunkPosition {
     this.z = z;
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     return "[" + x + ", " + z + "]";
   }
 
@@ -42,13 +44,16 @@ public class ChunkPosition {
     return get(x >> 5, z >> 5);
   }
 
-  private final static Map<Integer, Map<Integer, ChunkPosition>> map = new HashMap<>();
+  private static final Map<Integer, Map<Integer, ChunkPosition>> map = new ConcurrentHashMap<>();
 
-  public synchronized static ChunkPosition get(int x, int z) {
+  public static ChunkPosition get(int x, int z) {
     Map<Integer, ChunkPosition> submap = map.get(x);
     if (submap == null) {
-      submap = new HashMap<>();
+      submap = new ConcurrentHashMap<>();
       map.put(x, submap);
+      ChunkPosition chunkPosition = new ChunkPosition(x, z);
+      submap.put(z, chunkPosition);
+      return chunkPosition;
     }
 
     ChunkPosition chunkPosition = submap.get(z);

--- a/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 public class WorldTexture {
 
-  private final Map<ChunkPosition, ChunkTexture> map = new HashMap<>();
+  private final Map<Long, ChunkTexture> map = new HashMap<>();
 
   /**
    * Timestamp of last serialization.
@@ -42,7 +42,7 @@ public class WorldTexture {
    * @param frgb RGB color components
    */
   public void set(int x, int z, float[] frgb) {
-    ChunkPosition cp = ChunkPosition.get(x >> 4, z >> 4);
+    long cp = ((long) x >> 4) << 32 | ((z >> 4) & 0xffffffffL);
     ChunkTexture ct = map.get(cp);
     if (ct == null) {
       ct = new ChunkTexture();
@@ -55,7 +55,7 @@ public class WorldTexture {
    * @return True if this texture contains a RGB color components at (x, z)
    */
   public boolean contains(int x, int z) {
-    ChunkPosition cp = ChunkPosition.get(x >> 4, z >> 4);
+    long cp = ((long) x >> 4) << 32 | ((z >> 4) & 0xffffffffL);
     return map.containsKey(cp);
   }
 
@@ -63,7 +63,7 @@ public class WorldTexture {
    * @return RGB color components at (x, z)
    */
   public float[] get(int x, int z) {
-    ChunkPosition cp = ChunkPosition.get(x >> 4, z >> 4);
+    long cp = ((long) x >> 4) << 32 | ((z >> 4) & 0xffffffffL);
     ChunkTexture ct = map.get(cp);
     if (ct == null) {
       ct = new ChunkTexture();
@@ -79,11 +79,11 @@ public class WorldTexture {
    */
   public void store(DataOutputStream out) throws IOException {
     out.writeInt(map.size());
-    for (Map.Entry<ChunkPosition, ChunkTexture> entry : map.entrySet()) {
-      ChunkPosition pos = entry.getKey();
+    for (Map.Entry<Long, ChunkTexture> entry : map.entrySet()) {
+      long pos = entry.getKey();
       ChunkTexture texture = entry.getValue();
-      out.writeInt(pos.x);
-      out.writeInt(pos.z);
+      out.writeInt((int) (pos >> 32));
+      out.writeInt((int) pos);
       texture.store(out);
     }
   }
@@ -101,7 +101,7 @@ public class WorldTexture {
       int x = in.readInt();
       int z = in.readInt();
       ChunkTexture tile = ChunkTexture.load(in);
-      texture.map.put(ChunkPosition.get(x, z), tile);
+      texture.map.put(((long) x) << 32 | (z & 0xffffffffL), tile);
     }
     return texture;
   }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -320,7 +320,7 @@ public class Octree {
   /**
    * @return The voxel type at the given coordinates
    */
-  public synchronized Node get(int x, int y, int z) {
+  public Node get(int x, int y, int z) {
     return implementation.get(x, y, z);
   }
 


### PR DESCRIPTION
`ChunkPosition` is used very frequently (via `WorldTexture`) and thus the object instances are created with a factory method and cached. The factory method, however, was `synchronized`, which made it block all threads but one very often during rendering.

This PR changes it to use a [ConcurrentHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html), which supports "full concurrency for retrievals and high expected concurrency for updates". That's exactly what we want for an object cache used by all render threads.

On my machine (16 threads) this improves render times by up to 20%. Especially with larger thread counts, the render threads used to spend a lot of time waiting to call the synchronized method (cc @stormboomer).

---

Edit: By also changing the `WorldTexture` to not use `ChunkPosition` at all, rendering got a bit faster (because `ChunkPosition.get` isn't called during rendering anymore).