### PR TITLE
Fix infinite loops when using transparent textures for grass, stairs and hoppers

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -14,16 +14,14 @@ import se.llbit.nbt.CompoundTag;
 public abstract class Block extends Material {
 
   /**
-   * Set to true if there is a local intersection model
-   * for this block.
+   * Set to true if there is a local intersection model for this block.
    */
   public boolean localIntersect = false;
 
   /**
-   * Invisible blocks are not rendered as regular voxels
-   * (they are not added to the voxel octree).
-   * This is used for blocks that are rendered as entities,
-   * and blocks that are not implemented yet.
+   * Invisible blocks are not rendered as regular voxels (they are not added to the voxel octree).
+   * This is used for blocks that are rendered as entities, and blocks that are not implemented
+   * yet.
    */
   public boolean invisible = false;
 
@@ -31,6 +29,15 @@ public abstract class Block extends Material {
     super(name, texture);
   }
 
+  /**
+   * Intersect the given ray in the given scene with this block and update the Ray's color, distance
+   * and origin accordingly. Note that the alpha component of the ray color must be positive if and
+   * only if it hits (i.e. this method returns true) and zero otherwise.
+   *
+   * @param ray   Ray
+   * @param scene Scene
+   * @return True if the ray hit this block, false if not
+   */
   public boolean intersect(Ray ray, Scene scene) {
     return TexturedBlockModel.intersect(ray, texture);
   }

--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -14,7 +14,9 @@ import se.llbit.nbt.CompoundTag;
 public abstract class Block extends Material {
 
   /**
-   * Set to true if there is a local intersection model for this block.
+   * Set to true if there is a local intersection model for this block. If this is set to
+   * <code>false</code> (default), this block is assumed to be an opaque cube block and {@link
+   * #intersect(Ray, Scene)} will never be called.
    */
   public boolean localIntersect = false;
 

--- a/chunky/src/java/se/llbit/chunky/model/GrassModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/GrassModel.java
@@ -30,10 +30,12 @@ public class GrassModel {
       if (ray.n.y == -1) {
         // Bottom face.
         Texture.dirt.getColor(ray);
+        ray.color.w = 1;
         ray.t = ray.tNext;
       } else if (ray.n.y == 0 && (ray.getCurrentData() & (1 << 8)) != 0) {
         // Snowy side face.
         Texture.snowSide.getColor(ray);
+        ray.color.w = 1;
         ray.t = ray.tNext;
       } else {
         float[] color;

--- a/chunky/src/java/se/llbit/chunky/model/HopperModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/HopperModel.java
@@ -110,6 +110,7 @@ public class HopperModel {
       } else {
         Texture.hopperOutside.getColor(ray);
       }
+      ray.color.w = 1;
       ray.t = ray.tNext;
       hit = true;
     }

--- a/chunky/src/java/se/llbit/chunky/model/StairModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/StairModel.java
@@ -154,6 +154,7 @@ public class StairModel {
     }
 
     if (hit) {
+      ray.color.w = 1;
       ray.distance += ray.t;
       ray.o.scaleAdd(ray.t, ray.d);
     }
@@ -168,6 +169,7 @@ public class StairModel {
       } else if (ray.n.y < 0) {
         bottom.getColor(ray);
       }
+      ray.color.w = 1;
     }
     return hit;
   }
@@ -181,6 +183,7 @@ public class StairModel {
       } else if (ray.n.y < 0) {
         bottom.getColor(ray);
       }
+      ray.color.w = 1;
     }
     return hit;
   }


### PR DESCRIPTION
Fix alpha component of the ray color not always being set to 1 after grass, stairs and hopper intersections.

`Block.intersect` should make sure that the ray color's alpha value is 0 only if it didn't hit. I checked all models and found that allmost all of them enforce this. Only grass, stairs and hoppers didn't in all cases. This would result in infinite loops when using resourcepacks with unexpected transparency (which do exist).