### PR TITLE
Sliders to zero

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -89,7 +89,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     horizonOffset.onValueChange(value -> scene.sky().setHorizonOffset(value));
 
     cloudSize.setName("Cloud size");
-    cloudSize.setRange(0.1, 128);
+    cloudSize.setRange(0, 128);
     cloudSize.clampMin();
     cloudSize.makeLogarithmic();
     cloudSize.onValueChange(value -> scene.sky().setCloudSize(value));
@@ -102,7 +102,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudZ.onValueChange(value -> scene.sky().setCloudZOffset(value));
 
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");
-    fogDensity.setRange(0, 1, 0.001);
+    fogDensity.setRange(0, 1);
     fogDensity.makeLogarithmic();
     fogDensity.clampMin();
     fogDensity.onValueChange(value -> scene.setFogDensity(value));

--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -89,7 +89,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     horizonOffset.onValueChange(value -> scene.sky().setHorizonOffset(value));
 
     cloudSize.setName("Cloud size");
-    cloudSize.setRange(0, 128);
+    cloudSize.setRange(0.1, 128);
     cloudSize.clampMin();
     cloudSize.makeLogarithmic();
     cloudSize.onValueChange(value -> scene.sky().setCloudSize(value));

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -23,12 +23,15 @@ import javafx.beans.value.ChangeListener;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Tooltip;
 
+//import se.llbit.chunky.launcher.ConsoleLogger;
+
 /**
  * A control for editing numeric values with a slider and text field.
  */
 public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
   private final Slider valueSlider = new Slider();
-  private double sliderMin = 0.01; // Lower limit for logarithmic calculations.
+  private static final double LOG_ARG_MIN = 0.01; // Lower limit for logarithm argument.
+  private double logScaleStart = LOG_ARG_MIN; 
   private double min = 0; // TODO: handle minimum.
   private double max = 100;
   protected boolean clampMax;
@@ -51,11 +54,11 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
   }
 
   public void setRange(double min, double max) {
-    setRange(min, max, min < 0.01 && min >= 0 ? 0.01 : min);
+    setRange(min, max, min < LOG_ARG_MIN && min >= 0 ? LOG_ARG_MIN : min);
   }
 
-  public void setRange(double min, double max, double sliderMin) {
-    this.sliderMin = sliderMin;
+  public void setRange(double min, double max, double logScaleStart) {
+    this.logScaleStart = logScaleStart;
     this.min = min;
     this.max = max;
     if (!logarithmic) {
@@ -77,15 +80,17 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
    */
   public void makeLogarithmic() {
     logarithmic = true;
-    valueSlider.setMin(0);
+    valueSlider.setMin(0); // In logarithmic case, slider value is always from 0 to 100.
     valueSlider.setMax(100);
     DoubleProperty sliderValue = new SimpleDoubleProperty();
     ChangeListener<Number> sliderListener = (observable, oldValue, newValue) -> {
       double result;
       if (maxInfinity && newValue.doubleValue() > 99.9) {
         result = Double.POSITIVE_INFINITY;
+      } else if (newValue.doubleValue() < logScaleStart) {
+        result = min; // Set value to lowest number.
       } else {
-        double logMin = Math.log(sliderMin);
+        double logMin = Math.log(logScaleStart);
         double logMax = Math.log(max);
         double range = logMax - logMin;
         result = Math.pow(Math.E, (newValue.doubleValue() / 100.0) * range + logMin);
@@ -94,13 +99,17 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     };
     ChangeListener<Number> valueListener = (observable, oldValue, newValue) -> {
       double result;
-      double logMin = Math.log(sliderMin);
+      double logMin = Math.log(logScaleStart);
       double logMax = Math.log(max);
-      double logValue = Math.log(newValue.doubleValue());
-      logValue = Math.max(logMin, logValue);
-      logValue = Math.min(logMax, logValue);
-      double pos = (logValue - logMin) / (logMax - logMin);
-      result = pos * 100;
+      if (newValue.doubleValue() < logScaleStart) {
+        result = 0; // Set slider to lowest position.
+      } else {
+        double logValue = Math.log(newValue.doubleValue());
+        logValue = Math.max(logMin, logValue);
+        logValue = Math.min(logMax, logValue);
+        double pos = (logValue - logMin) / (logMax - logMin);
+        result = pos * 100;
+      }
       // Temporarily stop listening to avoid event recursion.
       sliderValue.removeListener(sliderListener);
       sliderValue.set(result);

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -23,8 +23,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Tooltip;
 
-//import se.llbit.chunky.launcher.ConsoleLogger;
-
 /**
  * A control for editing numeric values with a slider and text field.
  */


### PR DESCRIPTION
Fixes #733 

The issue says that there are setting sliders, which dont go down to zero, but the textbox allows it. 
I noticed there are 2 casses where this happens:
1. When DoubleAdjuster.setRange(min, max, slider_min) is called to set the range. I suppose this is for the logarithmic scaling, slider_min preventing values too close to zero. I fixed this problem, but it was only in one case (fog density). Now, setRange(min, max) will automatically set the minimum for logarithmic scaling (logScaleStart) to  0.01. For slider positions < logScaleStart, the value is set to 0. Also, for values < logScaleStart, the slider position is set to zero.
2. When DoubleAdjuster(setRange(min, max) is called to set the range, with min > 0. In this case,the slider will go down to min, but the textbox can still be set to ANY value, including zero. I did not fix this. Its a different Problem. 