### PR TITLE
Fix the light leaking through stairs when using emitter sampling

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -433,6 +433,16 @@ public class PathTracer implements RayTracer {
     emitterRay.d.normalize();
     double indirectEmitterCoef = emitterRay.d.dot(emitterRay.n);
     if(indirectEmitterCoef > 0) {
+      // Here We need to invert the material.
+      // The fact that the dot product is > 0 guarantees that the ray is going away from the surface
+      // it just met. This means the ray is going from the block just hit to the previous material (usually air or water)
+      // TODO If/when normal mapping is implemented, indirectEmitterCoef will be computed with the mapped normal
+      //      but the dot product with the original geometry normal will still need to be computed
+      //      to ensure the emitterRay isn't going through the geometry
+      Material prev = emitterRay.getPrevMaterial();
+      int prevData = emitterRay.getPrevData();
+      emitterRay.setPrevMaterial(emitterRay.getCurrentMaterial(), emitterRay.getCurrentData());
+      emitterRay.setCurrentMaterial(prev, prevData);
       emitterRay.emittance.set(0, 0, 0);
       emitterRay.o.scaleAdd(Ray.EPSILON, emitterRay.d);
       PreviewRayTracer.nextIntersection(scene, emitterRay);


### PR DESCRIPTION
Fix the bug encountered by TurtleRunsSlow on discord where light was going through stairs. It was not due to having a small space between cuboid of the stairs model but to the fact that collision with the stairs where ignored because the current material was already the stairs
before
![blackout-100-light-leak](https://user-images.githubusercontent.com/23342398/103811263-f1455c00-505c-11eb-8fdf-6ddcf16b35c7.png)

after (best render)
![blackout-100](https://user-images.githubusercontent.com/23342398/103811273-f5717980-505c-11eb-806c-0376c1845cf6.png)


