### PR TITLE
Add rough specular reflections

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -132,7 +132,7 @@ public class PathTracer implements RayTracer {
 
         if (!scene.kill(ray.depth + 1, random)) {
           Ray reflected = new Ray();
-          reflected.specularReflection(ray);
+          reflected.specularReflection(ray, random);
 
           if (pathTrace(scene, reflected, state, 1, false)) {
             ray.color.x = reflected.color.x;
@@ -262,7 +262,7 @@ public class PathTracer implements RayTracer {
             // Total internal reflection.
             if (!scene.kill(ray.depth + 1, random)) {
               Ray reflected = new Ray();
-              reflected.specularReflection(ray);
+              reflected.specularReflection(ray, random);
               if (pathTrace(scene, reflected, state, 1, false)) {
 
                 ray.color.x = reflected.color.x;
@@ -287,7 +287,7 @@ public class PathTracer implements RayTracer {
 
               if (random.nextFloat() < Rtheta) {
                 Ray reflected = new Ray();
-                reflected.specularReflection(ray);
+                reflected.specularReflection(ray, random);
                 if (pathTrace(scene, reflected, state, 1, false)) {
                   ray.color.x = reflected.color.x;
                   ray.color.y = reflected.color.y;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3002,17 +3002,14 @@ public class Scene implements JsonSerializable, Refreshable {
       JsonValue properties = materials.get(name);
       if (properties != null) {
         palette.updateProperties(name, block -> {
-          block.emittance = properties.asObject().get("emittance").floatValue(block.emittance);
-          block.specular = properties.asObject().get("specular").floatValue(block.specular);
-          block.ior = properties.asObject().get("ior").floatValue(block.ior);
+          block.loadMaterialProperties(properties.asObject());
         });
       }
     });
-    ExtraMaterials.idMap.forEach((name, material) -> {JsonValue properties = materials.get(name);
+    ExtraMaterials.idMap.forEach((name, material) -> {
+      JsonValue properties = materials.get(name);
       if (properties != null) {
-        material.emittance = properties.asObject().get("emittance").floatValue(material.emittance);
-        material.specular = properties.asObject().get("specular").floatValue(material.specular);
-        material.ior = properties.asObject().get("ior").floatValue(material.ior);
+        material.loadMaterialProperties(properties.asObject());
       }});
   }
 
@@ -3022,9 +3019,7 @@ public class Scene implements JsonSerializable, Refreshable {
     if (value != null) {
       JsonObject properties = value.object();
       for (Material material : materials) {
-        material.emittance = properties.get("emittance").floatValue(material.emittance);
-        material.specular = properties.get("specular").floatValue(material.specular);
-        material.ior = properties.get("ior").floatValue(material.ior);
+        material.loadMaterialProperties(properties);
       }
     }
   }
@@ -3055,6 +3050,16 @@ public class Scene implements JsonSerializable, Refreshable {
   public void setIor(String materialName, float value) {
     JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
     material.set("ior", Json.of(value));
+    materials.put(materialName, material);
+    refresh(ResetReason.MATERIALS_CHANGED);
+  }
+
+  /**
+   * Modifies the roughness property for the given material.
+   */
+  public void setPerceptualSmoothness(String materialName, float value) {
+    JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
+    material.set("roughness", Json.of(Math.pow(1 - value, 2)));
     materials.put(materialName, material);
     refresh(ResetReason.MATERIALS_CHANGED);
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/MaterialsTab.java
@@ -51,6 +51,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private final DoubleAdjuster emittance = new DoubleAdjuster();
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
+  private final DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
   private final ListView<String> listView;
 
   public MaterialsTab() {
@@ -60,6 +61,8 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     specular.setRange(0, 1);
     ior.setName("IoR");
     ior.setRange(0, 5);
+    perceptualSmoothness.setName("Smoothness");
+    perceptualSmoothness.setRange(0, 1);
     ObservableList<String> blockIds = FXCollections.observableArrayList();
     blockIds.addAll(MaterialStore.collections.keySet());
     blockIds.addAll(ExtraMaterials.idMap.keySet());
@@ -75,7 +78,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, specular, ior,
+        emittance, specular, perceptualSmoothness, ior,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);
@@ -103,15 +106,18 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       double emAcc = 0;
       double specAcc = 0;
       double iorAcc = 0;
+      double perceptualSmoothnessAcc = 0;
       Collection<Block> blocks = MaterialStore.collections.get(materialName);
       for (Block block : blocks) {
         emAcc += block.emittance;
         specAcc += block.specular;
         iorAcc += block.ior;
+        perceptualSmoothnessAcc += block.getPerceptualSmoothness();
       }
       emittance.set(emAcc / blocks.size());
       specular.set(specAcc / blocks.size());
       ior.set(iorAcc / blocks.size());
+      perceptualSmoothness.set(perceptualSmoothnessAcc / blocks.size());
       materialExists = true;
     } else if (ExtraMaterials.idMap.containsKey(materialName)) {
       Material material = ExtraMaterials.idMap.get(materialName);
@@ -119,6 +125,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
         emittance.set(material.emittance);
         specular.set(material.specular);
         ior.set(material.ior);
+        perceptualSmoothness.set(material.getPerceptualSmoothness());
         materialExists = true;
       }
     } else if (MaterialStore.blockIds.contains(materialName)) {
@@ -127,16 +134,19 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       emittance.set(block.emittance);
       specular.set(block.specular);
       ior.set(block.ior);
+      perceptualSmoothness.set(block.getPerceptualSmoothness());
       materialExists = true;
     }
     if (materialExists) {
       emittance.onValueChange(value -> scene.setEmittance(materialName, value.floatValue()));
       specular.onValueChange(value -> scene.setSpecular(materialName, value.floatValue()));
       ior.onValueChange(value -> scene.setIor(materialName, value.floatValue()));
+      perceptualSmoothness.onValueChange(value -> scene.setPerceptualSmoothness(materialName, value.floatValue()));
     } else {
       emittance.onValueChange(value -> {});
       specular.onValueChange(value -> {});
       ior.onValueChange(value -> {});
+      perceptualSmoothness.onValueChange(value -> {});
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.world;
 
 import se.llbit.chunky.resources.Texture;
+import se.llbit.json.JsonObject;
 import se.llbit.json.JsonString;
 import se.llbit.json.JsonValue;
 import se.llbit.math.Ray;
@@ -24,25 +25,28 @@ import se.llbit.math.Ray;
 public abstract class Material {
 
   /**
+   * Index of refraction of air.
+   */
+  private static final float DEFAULT_IOR = 1.000293f;
+
+  /**
    * The name of this material.
    */
   public final String name;
 
   /**
-   * Index of refraction.
-   * Default value is equal to the IoR for air.
+   * Index of refraction. Default value is equal to the IoR for air.
    */
-  public float ior = 1.000293f;
+  public float ior = DEFAULT_IOR;
 
   /**
-   * A block is opaque if it occupies an entire voxel
-   * and no light can pass through it.
+   * A block is opaque if it occupies an entire voxel and no light can pass through it.
    */
   public boolean opaque = false;
 
   /**
-   * The solid property controls various block behaviours like
-   * if the block connects to fences, gates, walls, etc.
+   * The solid property controls various block behaviours like if the block connects to fences,
+   * gates, walls, etc.
    */
   public boolean solid = true;
 
@@ -57,11 +61,19 @@ public abstract class Material {
   public float emittance = 0;
 
   /**
+   * The (linear) roughness controlling how rough a shiny block appears. A value of 0 makes the
+   * surface perfectly specular, a value of 1 makes it diffuse.
+   */
+  public float roughness = 0f;
+
+  /**
    * Subsurface scattering property.
    */
   public boolean subSurfaceScattering = false;
 
-  /** Base texture. */
+  /**
+   * Base texture.
+   */
   public final Texture texture;
 
   public boolean refractive = false;
@@ -77,11 +89,12 @@ public abstract class Material {
    * Restore the default material properties.
    */
   public void restoreDefaults() {
-    ior = 1.000293f;
+    ior = DEFAULT_IOR;
     opaque = false;
     solid = true;
     specular = 0;
     emittance = 0;
+    roughness = 0;
     subSurfaceScattering = false;
   }
 
@@ -107,9 +120,11 @@ public abstract class Material {
     return new JsonString("mat:" + name);
   }
 
-  public static Material fromJson(JsonValue json) {
-    // TODO: implement this?
-    throw new UnsupportedOperationException("Can not export material as JSON.");
+  public void loadMaterialProperties(JsonObject json) {
+    ior = json.get("ior").floatValue(ior);
+    specular = json.get("specular").floatValue(specular);
+    emittance = json.get("emittance").floatValue(emittance);
+    roughness = json.get("roughness").floatValue(roughness);
   }
 
   public boolean isWater() {
@@ -122,5 +137,13 @@ public abstract class Material {
 
   public boolean isSameMaterial(Material other) {
     return other == this;
+  }
+
+  public double getPerceptualSmoothness() {
+    return 1 - Math.sqrt(roughness);
+  }
+
+  public void setPerceptualSmoothness(double perceptualSmoothness) {
+    roughness = (float) Math.pow(1 - perceptualSmoothness, 2);
   }
 }


### PR DESCRIPTION
This adds a new _roughness_ property to `Material`. In the _Materials_ tab, it can be configured with the _Smoothness_ slider, which controls the _perceptual smoothness_, which is then converted to the roughness. Perceptual smoothness feels more linear when working with it and it's also what LabPBR 1.3 uses for roughness maps.

![image](https://user-images.githubusercontent.com/5544859/103827432-442d0c80-5079-11eb-8a24-1eca895f62de.png)
