### PR TITLE
Precompute coefficient for intersection computation

### DIFF
--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -504,6 +504,9 @@ public class Octree {
       if (currentBlock.localIntersect) {
         // Other functions expect the ray origin to be in the block they test so here time
         // to update it
+        // Updating the origin also means that new offsetX/offsetY/offsetZ must be computed
+        // but that is done a after the intersection test only if necessary
+        // and not if we are leaving the function anyway
         ray.o.scaleAdd(distance, ray.d);
         ray.distance += distance;
         distance = 0;

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -459,10 +459,6 @@ public class Octree {
 
     double distance = Ray.EPSILON;
 
-    int x = (int) QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
-    int y = (int) QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
-    int z = (int) QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
-
     // floating point division are slower than multiplication so we cache them
     // We also try to limit the number of time the ray origin is updated
     // as it would require to recompute those values
@@ -479,6 +475,9 @@ public class Octree {
     while (true) {
       // Add small offset past the intersection to avoid
       // recursion to the same octree node!
+      int x = (int) Math.floor(ray.o.x + ray.d.x * distance);
+      int y = (int) Math.floor(ray.o.y + ray.d.y * distance);
+      int z = (int) Math.floor(ray.o.z + ray.d.z * distance);
 
       int lx = x >>> depth;
       int ly = y >>> depth;
@@ -517,9 +516,6 @@ public class Octree {
           offsetX = -ray.o.x * invDx;
           offsetY = -ray.o.y * invDy;
           offsetZ = -ray.o.z * invDz;
-          x = (int) QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
-          y = (int) QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
-          z = (int) QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
           continue;
         } else {
           // Exit ray from this local block.
@@ -528,9 +524,6 @@ public class Octree {
           offsetX = -ray.o.x * invDx;
           offsetY = -ray.o.y * invDy;
           offsetZ = -ray.o.z * invDz;
-          x = (int) QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
-          y = (int) QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
-          z = (int) QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
           continue;
         }
       } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
@@ -590,10 +583,9 @@ public class Octree {
         nx = ny = 0;
       }
 
+      ray.n.set(nx, ny, nz);
+
       distance = tNear + Ray.EPSILON;
-      x = (int) QuickMath.floor(ray.o.x + ray.d.x * (distance + Ray.OFFSET));
-      y = (int) QuickMath.floor(ray.o.y + ray.d.y * (distance + Ray.OFFSET));
-      z = (int) QuickMath.floor(ray.o.z + ray.d.z * (distance + Ray.OFFSET));
     }
   }
 


### PR DESCRIPTION
I tried to optimize a bit octree traversal, unfortunately some of the things I tried didn't give good result but here are some changes that seem to have a positive impact.
Basically the idea is to optimize the the computation for intersection ray/axis-aligned plane (and a computation of intersection ray-axis-aligned-box is made of 6 such computations). This is done by caching the coefficient of the computation such as the computation consist only in a multiplication and an addition. (division being substantially more expensive than multiplication or addition).
In addition, to avoid having to update those coefficient after each box test, I don't update the origin of the ray until it is needed (before returning from the function or before inking another function that expects the origin of the ray to be updated).
This means that during the intersection test, the origin of the ray isn't always inside the block so the 6 faces must be tested unconditionally (Note that this approach wouldn't work in general, the ray could not intersect the box and the code would say that it does as it tests infinite planes, here this is not an issue because x, y, z are still updated every iteration so the box we test against is one we know the ray intersects, we just need to know where).
In term of performance improvement, it seems to be about 4-7% reduction in render time