### PR TITLE
Fix skymaps not loading in headless mode without JavaFX.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -21,6 +21,7 @@ import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.texturepack.FontTexture;
+import se.llbit.fxutil.FxImageUtil;
 import se.llbit.math.ColorUtil;
 import se.llbit.math.QuickMath;
 import se.llbit.math.Ray;
@@ -1166,7 +1167,7 @@ public class Texture {
 
   public Image fxImage() {
     if (fxImage == null) {
-      fxImage = ImageTools.toFxImage(image);
+      fxImage = FxImageUtil.toFxImage(image);
     }
     return fxImage;
   }

--- a/chunky/src/java/se/llbit/fxutil/FxImageUtil.java
+++ b/chunky/src/java/se/llbit/fxutil/FxImageUtil.java
@@ -1,0 +1,19 @@
+package se.llbit.fxutil;
+
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.WritableImage;
+import se.llbit.chunky.resources.BitmapImage;
+
+public class FxImageUtil {
+
+  /**
+   * @return a JavaFX version of a BitmapImage.
+   */
+  public static Image toFxImage(BitmapImage image) {
+    WritableImage fxImage = new WritableImage(image.width, image.height);
+    fxImage.getPixelWriter().setPixels(0, 0, image.width, image.height,
+        PixelFormat.getIntArgbInstance(), image.data, 0, image.width);
+    return fxImage;
+  }
+}

--- a/chunky/src/java/se/llbit/util/ImageTools.java
+++ b/chunky/src/java/se/llbit/util/ImageTools.java
@@ -16,9 +16,6 @@
  */
 package se.llbit.util;
 
-import javafx.scene.image.Image;
-import javafx.scene.image.PixelFormat;
-import javafx.scene.image.WritableImage;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.math.ColorUtil;
 
@@ -57,13 +54,5 @@ public class ImageTools {
     } else {
       return ColorUtil.getArgb(ra / aa, ga / aa, ba / aa, aa / n);
     }
-  }
-
-  /** @return a JavaFX version of a BitmapImage. */
-  public static Image toFxImage(BitmapImage image) {
-    WritableImage fxImage = new WritableImage(image.width, image.height);
-    fxImage.getPixelWriter().setPixels(0, 0, image.width, image.height,
-        PixelFormat.getIntArgbInstance(), image.data, 0, image.width);
-    return fxImage;
   }
 }


### PR DESCRIPTION
Loading skymaps didn't work in headless mode:

```
java.lang.NoClassDefFoundError: javafx/scene/image/PixelFormat
    at se.llbit.chunky.world.SkymapTexture.setTexture(SkymapTexture.java:81)
    at se.llbit.chunky.resources.Texture.<init>(Texture.java:1004)
    at se.llbit.chunky.world.SkymapTexture.<init>(SkymapTexture.java:73)
    at se.llbit.chunky.renderer.scene.Sky.loadSkyTexture(Sky.java:697)
    at se.llbit.chunky.renderer.scene.Sky.loadSkymap(Sky.java:197)
    at se.llbit.chunky.renderer.scene.Sky.loadSkymap(Sky.java:178)
```

Headless mode shouldn't rely on JavaFX (especially since new JDKs don't ship with it).

