### PR TITLE
Add carved pumpkin and dragon head skulls, fix wearing other skulls

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
@@ -472,8 +472,7 @@ public class ArmorStand extends Entity implements Poseable, Geared {
         .rotateY(allPose.y)
         .rotateZ(allPose.z)
         .translate(worldOffset);
-    PlayerEntity.addArmor(primitives, gear, pose, armWidth, worldTransform,
-        headScale);
+    PlayerEntity.addArmor(primitives, gear, pose, armWidth, worldTransform, headScale);
 
     Transform transform = Transform.NONE.translate(-0.5, 0, -0.5).translate(worldOffset);
 

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -201,9 +201,7 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
         .rotateZ(allPose.z)
         .translate(worldOffset);
     Collection<Primitive> primitives = new LinkedList<>();
-    if (!gear.get("head").object().get("id").stringValue("").equals("minecraft:player_head") &&
-        !gear.get("head").object().get("id").stringValue("").equals("minecraft:skull")
-    ) {
+    if (!shouldHidePlayerHead(gear.get("head").object().get("id").stringValue(""))) {
       Box head = new Box(-4 / 16., 4 / 16., -4 / 16., 4 / 16., -4 / 16., 4 / 16.);
       head.transform(Transform.NONE
           .translate(0, 4 / 16., 0)
@@ -307,6 +305,21 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
 
     addArmor(primitives, gear, pose, armWidth, worldTransform, headScale);
     return primitives;
+  }
+
+  private static boolean shouldHidePlayerHead(String helmetItemId) {
+    switch (helmetItemId) {
+      case "minecraft:skull":
+      case "minecraft:skeleton_skull":
+      case "minecraft:player_head":
+      case "minecraft:zombie_head":
+      case "minecraft:wither_skeleton_skull":
+      case "minecraft:creeper_head":
+      case "minecraft:dragon_head":
+        return true;
+      default:
+        return false;
+    }
   }
 
   public static void addArmor(Collection<Primitive> faces,
@@ -544,8 +557,11 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           json = parseJson(skullJson);
           break;
       }
-    } else if (id.equals("minecraft:player_head")) {
+    } else if (id.equals("minecraft:player_head") || id.equals("minecraft:zombie_head")) {
       json = parseJson(headJson);
+    } else if (id.equals("minecraft:skeleton_skull") || id.equals("minecraft:wither_skeleton_skull")
+        || id.equals("minecraft:creeper_head")) {
+      json = parseJson(skullJson);
     }
     Map<String, Texture> textureMap = Collections.singletonMap("#texture", getTexture(item));
     return new CubeModel(JsonModel.fromJson(json), 16, textureMap);
@@ -619,13 +635,27 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
               break;
             case 5:
               // Dragon head.
-              // TODO: fixme
-              textureId = "entity/skeleton/wither_skeleton";
+              textureId = "entity/enderdragon/dragon";
               break;
           }
           loader = simpleTexture(textureId, texture);
           break;
         }
+        case "skeleton_skull":
+          loader = simpleTexture("entity/skeleton/skeleton", texture);
+          break;
+        case "wither_skeleton_skull":
+          loader = simpleTexture("entity/skeleton/wither_skeleton", texture);
+          break;
+        case "zombie_head":
+          loader = simpleTexture("entity/zombie/zombie", texture);
+          break;
+        case "creeper_head":
+          loader = simpleTexture("entity/creeper/creeper", texture);
+          break;
+        case "dragon_head":
+          loader = simpleTexture("entity/enderdragon/dragon", texture);
+          break;
         case "leather_boots":
         case "leather_helmet":
         case "leather_chestplate":

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -346,7 +346,30 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           .rotateZ(headPose.z)
           .translate(0, (28 - 4) / 16.0, 0)
           .chain(worldTransform);
-      addModel(faces, getHelmModel(headItem), transform);
+      String headItemId = headItem.get("id").asString("");
+      if (headItemId.equals("minecraft:dragon_head")) {
+        SkullEntity skull = new SkullEntity(new Vector3(), Kind.DRAGON, 0, 1);
+        faces.addAll(skull.dragonHeadPrimitives(Transform.NONE.translate(0.5, 0.5, 0.5).scale(1.2).chain(transform)));
+      } else if (headItemId.equals("minecraft:carved_pumpkin")) {
+        Box hat = new Box(-4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16., -4.25 / 16., 4.25 / 16.);
+        hat.transform(Transform.NONE
+            .translate(0, 4 / 16., 0)
+            .scale(headScale)
+            .rotateX(headPose.x)
+            .rotateY(headPose.y)
+            .rotateZ(headPose.z)
+            .translate(0, -4 / 16., 0)
+            .translate(0, 28.2 / 16., 0)
+            .chain(worldTransform));
+        hat.addFrontFaces(faces, Texture.pumpkinFront, new Vector4(0, 1, 0, 1));
+        hat.addBackFaces(faces, Texture.pumpkinSide, new Vector4(1, 0, 0, 1));
+        hat.addLeftFaces(faces, Texture.pumpkinSide, new Vector4(0, 1, 0, 1));
+        hat.addRightFaces(faces, Texture.pumpkinSide, new Vector4(0, 1, 0, 1));
+        hat.addTopFaces(faces, Texture.pumpkinTop, new Vector4(1, 0, 1, 0));
+        hat.addBottomFaces(faces, Texture.pumpkinTop, new Vector4(0, 1, 0, 1));
+      } else {
+        addModel(faces, getHelmModel(headItem), transform);
+      }
     }
 
     // Add chest armor.
@@ -714,6 +737,9 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           if (!skin.isEmpty()) {
             texture = HeadEntity.downloadTexture(skin);
           }
+          break;
+        case "carved_pumpkin":
+          // nothing to do but this item is supported
           break;
         default:
           Log.warnf("Unknown item ID: %s%n", id);

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.entity;
 
 import se.llbit.chunky.block.Head;
+import se.llbit.chunky.entity.SkullEntity.Kind;
 import se.llbit.chunky.renderer.scene.PlayerModel;
 import se.llbit.chunky.resources.EntityTexture;
 import se.llbit.chunky.resources.Texture;
@@ -42,6 +43,7 @@ import se.llbit.math.Quad;
 import se.llbit.math.QuickMath;
 import se.llbit.math.Transform;
 import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Box;
 import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
@@ -736,6 +738,8 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
           String skin = item.get("skin").asString("");
           if (!skin.isEmpty()) {
             texture = HeadEntity.downloadTexture(skin);
+          } else {
+            loader = simpleTexture("entity/steve", texture);
           }
           break;
         case "carved_pumpkin":

--- a/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
@@ -350,7 +350,7 @@ public class SkullEntity extends Entity {
     return faces;
   }
 
-  private Collection<Primitive> dragonHeadPrimitives(Transform transform) {
+  public Collection<Primitive> dragonHeadPrimitives(Transform transform) {
     transform = Transform.NONE.translate(-0.5, -0.5, -0.5 - 1.5 / 16.)
         .chain(transform)
         .translate(0, 0.5 - 4/16., 0);


### PR DESCRIPTION
This PR brings back support for players and armor stands wearing (wither) skeleton, creeper, zombie and player heads. It also adds support for carved pumpkins and dragon heads.

![image](https://user-images.githubusercontent.com/5544859/104846106-2e211680-58d9-11eb-9814-7c5c6935885a.png)
