### PR TITLE
Fix module-path if javafxDir contains spaces

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ChunkyLauncher {
 
-  public static final String LAUNCHER_VERSION = "v1.12.0";
+  public static final String LAUNCHER_VERSION = "v1.12.1";
 
   /**
    * Print a launch error message to the console.

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -60,9 +60,10 @@ public class JavaFxLocator {
     // add the options again so the launcher can use them for chunky
     cmd.add("--javaOptions");
     StringBuilder javaOptions = new StringBuilder();
-    javaOptions.append("--module-path \\\"");
-    javaOptions.append(javafxDir.toAbsolutePath().toString());
-    javaOptions.append("\\\" --add-modules ");
+    javaOptions.append("--module-path ");
+    // Escape the path twice to make the second launcher pass the options to Chunky retaining the double speechmarks (fixes paths with spaces)
+    javaOptions.append("\\\"" + javafxDir.toAbsolutePath().toString() + "\\\"");
+    javaOptions.append(" --add-modules ");
     javaOptions.append("javafx.controls,javafx.fxml");
     cmd.add(javaOptions.toString());
 

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -60,9 +60,9 @@ public class JavaFxLocator {
     // add the options again so the launcher can use them for chunky
     cmd.add("--javaOptions");
     StringBuilder javaOptions = new StringBuilder();
-    javaOptions.append("--module-path ");
+    javaOptions.append("--module-path \\\"");
     javaOptions.append(javafxDir.toAbsolutePath().toString());
-    javaOptions.append(" --add-modules ");
+    javaOptions.append("\\\" --add-modules ");
     javaOptions.append("javafx.controls,javafx.fxml");
     cmd.add(javaOptions.toString());
 


### PR DESCRIPTION
Adds double quotes around javafxDir fixing launch issues with directories like `C:\Program Files\AdoptOpenJDK\jdk-11.0.9.11-hotspot\lib`.

And increment the ChunkyLauncher version to `v1.12.1`.