### PR TITLE
BitmapImage Nameing & Array Copy Fix

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
@@ -90,39 +90,37 @@ public class BitmapImage {
    * @return a copy of this bitmap that is vertically flipped.
    */
   public BitmapImage vFlipped() {
-    BitmapImage rotated = new BitmapImage(width, height);
+    BitmapImage flipped = new BitmapImage(width, height);
     for (int y = 0; y < height; ++y) {
-      for (int x = 0; x < width; ++x) {
-        rotated.setPixel(x, height - y - 1, getPixel(x, y));
-      }
+      System.arraycopy(data, width*y, flipped.data, width*(height-y-1), width);
     }
-    return rotated;
+    return flipped;
   }
 
   /**
    * @return a copy of this bitmap that is horizontally flipped.
    */
   public BitmapImage hFlipped() {
-    BitmapImage rotated = new BitmapImage(width, height);
+    BitmapImage flipped = new BitmapImage(width, height);
     for (int y = 0; y < height; ++y) {
       for (int x = 0; x < width; ++x) {
-        rotated.setPixel(width - x - 1, y, getPixel(x, y));
+        flipped.setPixel(width - x - 1, y, getPixel(x, y));
       }
     }
-    return rotated;
+    return flipped;
   }
 
   /**
    * @return a copy of this bitmap that is flipped in the diagonal.
    */
   public BitmapImage diagonalFlipped() {
-    BitmapImage rotated = new BitmapImage(height, width);
+    BitmapImage flipped = new BitmapImage(height, width);
     for (int y = 0; y < height; ++y) {
       for (int x = 0; x < width; ++x) {
-        rotated.setPixel(y, x, getPixel(x, y));
+        flipped.setPixel(y, x, getPixel(x, y));
       }
     }
-    return rotated;
+    return flipped;
   }
 
   /**


### PR DESCRIPTION
The "flipping" methods' local variables were _flipping_ named rotated!!!

`System.arraycopy` of rows in vertical flip would be faster than individually copying each pixel. (Used in bed & chest texturing)