### PR TITLE
Beam upgrades

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -97,6 +97,7 @@ public class BeaconBeam extends Entity implements Poseable {
           firstColor = color;
           foundFirst = true;
         } else {
+          //If this is not the first block to change the color, the new beam color is the average of the first color and the color of this block
           float[] foundColor = new float[3];
           float[] baseColor = new float[3];
 
@@ -172,7 +173,7 @@ public class BeaconBeam extends Entity implements Poseable {
         }
       }
     }
-    return -1;
+    return -1; // Return -1 if block doesn't change beam color
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -70,7 +70,7 @@ public class BeaconBeam extends Entity implements Poseable {
 
     JsonObject materialsList = json.get("beamMaterials").object();
     for (JsonMember obj : materialsList.members) {
-      BeaconBeamMaterial mat = new BeaconBeamMaterial(0xF9FFFE);
+      BeaconBeamMaterial mat = new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR);
       mat.loadMaterialProperties(obj.value.object());
       materials.put(Integer.parseInt(obj.name), mat);
     }
@@ -78,9 +78,9 @@ public class BeaconBeam extends Entity implements Poseable {
 
   @Override
   public void loadDataFromOctree(Octree octree, BlockPalette palette, Vector3i origin) {
-    int firstColor = 0xF9FFFE;
+    int firstColor = BeaconBeamMaterial.DEFAULT_COLOR;
     boolean foundFirst = false;
-    this.materials.put(0, new BeaconBeamMaterial(0xF9FFFE));
+    this.materials.put(0, new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR));
 
     //Start i at 1 so the first beacon is not checked.
     //Stop i at 256 even if the beam is taller because the Octree will wrap the coordinates.
@@ -176,7 +176,7 @@ public class BeaconBeam extends Entity implements Poseable {
   public Collection<Primitive> primitives(Vector3 offset) {
     Vector3 allPose = JsonUtil.vec3FromJsonArray(this.pose.get("all"));
     ArrayList<Primitive> faces = new ArrayList<>();
-    BeaconBeamMaterial using = new BeaconBeamMaterial(0xFFFFFF);
+    BeaconBeamMaterial using = new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR);
     //Have 1 block tall model and repeat it for height * scale.
     //This addresses the texture stretching problem and
     //allows for the height to be changed.

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -74,7 +74,7 @@ public class BeaconBeam extends Entity implements Poseable {
   public Collection<Primitive> primitives(Vector3 offset) {
     Vector3 allPose = JsonUtil.vec3FromJsonArray(this.pose.get("all"));
     ArrayList<Primitive> faces = new ArrayList<>();
-    BeaconBeamMaterial using = new BeaconBeamMaterial(0x000000);
+    BeaconBeamMaterial using = new BeaconBeamMaterial(0xFFFFFF);
     //Have 1 block tall model and repeat it for height * scale.
     //This addresses the texture stretching problem and
     //allows for the height to be changed.

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -66,22 +66,22 @@ public class BeaconBeam extends Entity implements Poseable {
   @Override
   public Collection<Primitive> primitives(Vector3 offset) {
     Vector3 allPose = JsonUtil.vec3FromJsonArray(this.pose.get("all"));
-    return primitives(Transform.NONE
-        .translate(-0.5, -0.5, -0.5)
-        .scale(scale)
-        .rotateY(allPose.y) // Ignore x and z rotation because it breaks the beam into segments
-        .translate(0.5, 0.5, 0.5)
-        .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z));
-  }
-
-  public Collection<Primitive> primitives(Transform transform) {
     ArrayList<Primitive> faces = new ArrayList<>();
     //Have 1 block tall model and repeat it for height * scale.
     //This addresses the texture stretching problem and
     //allows for the height to be changed.
     for (int i = 0; i < height; i++) {
       for (Quad quad : beam) {
-        quad.addTriangles(faces, beaconBeamMaterial, transform.translate(0.0, 1.0 * i * scale, 0.0));
+        quad.addTriangles(faces, beaconBeamMaterial,
+            Transform.NONE.translate(-0.5, -0.5, -0.5)
+                .scale(scale)
+                .translate(0.0, i * scale, 0.0)
+                .rotateX(allPose.x)
+                .rotateY(allPose.y)
+                .rotateZ(allPose.z)
+                .translate(0.5, 0.5, 0.5)
+                .translate(position.x + offset.x, position.y + offset.y, position.z + offset.z)
+        );
       }
     }
     return faces;

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -54,6 +54,7 @@ public class BeaconBeam extends Entity implements Poseable {
     super(position);
     this.pose = new JsonObject();
     pose.add("all", JsonUtil.vec3ToJson(new Vector3(0, 0, 0)));
+    materials.put(0, new BeaconBeamMaterial(0xFFFFFF));
   }
 
   public BeaconBeam(JsonObject json) {

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -1,12 +1,6 @@
 package se.llbit.chunky.entity;
 
-import se.llbit.chunky.block.Beacon;
-import se.llbit.chunky.resources.Texture;
-import se.llbit.chunky.resources.texturepack.ColoredTexture;
-import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.material.BeaconBeamMaterial;
-import se.llbit.chunky.world.material.TextureMaterial;
-import se.llbit.json.JsonArray;
 import se.llbit.json.JsonMember;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonValue;

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -45,6 +45,13 @@ abstract public class Entity {
 
   public Grid.EmitterPosition[] getEmitterPosition() { return new Grid.EmitterPosition[0]; }
 
+  /**
+   * Called on every entity in a scene to allow it to load it's data from other blocks in the Octree.
+   *
+   * @param octree The scene's worldOctree
+   * @param palette The scene's block palate
+   * @param origin The Octree's origin
+   */
   public void loadDataFromOctree(Octree octree, BlockPalette palette, Vector3i origin) {}
 
   /**

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -18,10 +18,14 @@
 package se.llbit.chunky.entity;
 
 import java.util.Collection;
+
+import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonValue;
 import se.llbit.math.Grid;
+import se.llbit.math.Octree;
 import se.llbit.math.Vector3;
+import se.llbit.math.Vector3i;
 import se.llbit.math.primitive.Primitive;
 
 /**
@@ -40,6 +44,8 @@ abstract public class Entity {
   abstract public Collection<Primitive> primitives(Vector3 offset);
 
   public Grid.EmitterPosition[] getEmitterPosition() { return new Grid.EmitterPosition[0]; }
+
+  public void loadDataFromOctree(Octree octree, BlockPalette palette, Vector3i origin) {}
 
   /**
    * Marshalls this entity to JSON.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1184,6 +1184,10 @@ public class Scene implements JsonSerializable, Refreshable {
       waterOctree.endFinalization();
     }
 
+    for (Entity entity : actors) {
+      entity.loadDataFromOctree(worldOctree, palette, origin);
+    }
+
     if(emitterGrid != null)
       emitterGrid.prepare();
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1188,6 +1188,10 @@ public class Scene implements JsonSerializable, Refreshable {
       entity.loadDataFromOctree(worldOctree, palette, origin);
     }
 
+    for (Entity entity : entities) {
+      entity.loadDataFromOctree(worldOctree, palette, origin);
+    }
+
     if(emitterGrid != null)
       emitterGrid.prepare();
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -46,7 +46,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.stage.FileChooser;
 import javafx.util.converter.NumberStringConverter;
 import se.llbit.chunky.entity.ArmorStand;

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -367,7 +367,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         Button addButton = new Button("Add");
         addButton.setOnAction(e -> {
           if (!beam.getMaterials().keySet().contains(layerHeightProp.get())) {
-            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(0xF9FFFE));
+            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR));
             colorHeightList.getItems().add(layerHeightProp.get());
             scene.rebuildActorBvh();
           }

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -368,7 +368,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         Button addButton = new Button("Add");
         addButton.setOnAction(e -> {
           if (!beam.getMaterials().keySet().contains(layerHeightProp.get())) {
-            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(0xFFFFFF));
+            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(0xF9FFFE));
             colorHeightList.getItems().add(layerHeightProp.get());
             scene.rebuildActorBvh();
           }

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -24,15 +24,21 @@ import java.util.HashSet;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.function.Consumer;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
+import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -40,7 +46,9 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.FileChooser;
+import javafx.util.converter.NumberStringConverter;
 import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.BeaconBeam;
 import se.llbit.chunky.entity.Book;
@@ -55,9 +63,12 @@ import se.llbit.chunky.ui.AngleAdjuster;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.IntegerAdjuster;
 import se.llbit.chunky.ui.RenderControlsFxController;
+import se.llbit.chunky.world.material.BeaconBeamMaterial;
+import se.llbit.fx.LuxColorPicker;
 import se.llbit.json.Json;
 import se.llbit.json.JsonArray;
 import se.llbit.json.JsonObject;
+import se.llbit.math.ColorUtil;
 import se.llbit.math.Vector3;
 
 public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initializable {
@@ -268,6 +279,106 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
           scene.rebuildActorBvh();
         });
         controls.getChildren().add(height);
+
+        HBox beamColor = new HBox();
+        VBox listControls = new VBox();
+        VBox propertyControls = new VBox();
+
+        listControls.setMaxWidth(200);
+        beamColor.setPadding(new Insets(10));
+        beamColor.setSpacing(15);
+        propertyControls.setSpacing(10);
+
+        DoubleAdjuster emittance = new DoubleAdjuster();
+        emittance.setName("Emittance");
+        emittance.setRange(0, 100);
+
+        DoubleAdjuster specular = new DoubleAdjuster();
+        specular.setName("Specular");
+        specular.setRange(0, 1);
+
+        DoubleAdjuster ior = new DoubleAdjuster();
+        ior.setName("IoR");
+        ior.setRange(0, 5);
+
+        DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
+        perceptualSmoothness.setName("Smoothness");
+        perceptualSmoothness.setRange(0, 1);
+
+        LuxColorPicker beamColorPicker = new LuxColorPicker();
+
+        ObservableList<Integer> colorHeights = FXCollections.observableArrayList();
+        colorHeights.addAll(beam.getMaterials().keySet());
+        ListView<Integer> colorHeightList = new ListView<>(colorHeights);
+        colorHeightList.setMaxHeight(150.0);
+        colorHeightList.getSelectionModel().selectedItemProperty().addListener(
+            (observable, oldValue, heightIndex) -> {
+
+              BeaconBeamMaterial beamMat = beam.getMaterials().get(heightIndex);
+              emittance.set(beamMat.emittance);
+              specular.set(beamMat.specular);
+              ior.set(beamMat.ior);
+              perceptualSmoothness.set(beamMat.getPerceptualSmoothness());
+              beamColorPicker.setColor(ColorUtil.toFx(beamMat.getColorInt()));
+
+              emittance.onValueChange(value -> {
+                beamMat.emittance = value.floatValue();
+                scene.rebuildActorBvh();
+              });
+              specular.onValueChange(value -> {
+                beamMat.specular = value.floatValue();
+                scene.rebuildActorBvh();
+              });
+              ior.onValueChange(value -> {
+                beamMat.ior = value.floatValue();
+                scene.rebuildActorBvh();
+              });
+              perceptualSmoothness.onValueChange(value -> {
+                beamMat.setPerceptualSmoothness(value);
+                scene.rebuildActorBvh();
+              });
+            }
+        );
+        beamColorPicker.colorProperty().addListener(
+            (observableColor, oldColorValue, newColorValue) -> {
+              Integer index = colorHeightList.getSelectionModel().getSelectedItem();
+              if (index != null) {
+                beam.getMaterials().get(index).updateColor(ColorUtil.getRGB(ColorUtil.fromFx(newColorValue)));
+                scene.rebuildActorBvh();
+              }
+            }
+        );
+        
+        HBox listButtons = new HBox();
+        listButtons.setPadding(new Insets(10));
+        listButtons.setSpacing(15);
+        Button deleteButton = new Button("Delete");
+        deleteButton.setOnAction(e -> { 
+          Integer index = colorHeightList.getSelectionModel().getSelectedItem();
+          if (index != null && index != 0) { //Prevent removal of the bottom layer
+            beam.getMaterials().remove(index);
+            colorHeightList.getItems().removeAll(index);
+            scene.rebuildActorBvh();
+          }
+        });
+        IntegerProperty layerHeightProp = new SimpleIntegerProperty();
+        TextField layerInput = new TextField();
+        layerInput.setMaxWidth(50);
+        layerInput.textProperty().bindBidirectional(layerHeightProp, new NumberStringConverter());
+        Button addButton = new Button("Add");
+        addButton.setOnAction(e -> {
+          if (!beam.getMaterials().keySet().contains(layerHeightProp.get())) {
+            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(0xFFFFFF));
+            colorHeightList.getItems().add(layerHeightProp.get());
+            scene.rebuildActorBvh();
+          }
+        });
+        
+        listButtons.getChildren().addAll(deleteButton, layerInput, addButton);
+        propertyControls.getChildren().addAll(emittance, specular, perceptualSmoothness, ior, beamColorPicker);
+        listControls.getChildren().addAll(new Label("Start Height:"), colorHeightList, listButtons);
+        beamColor.getChildren().addAll(listControls, propertyControls);
+        controls.getChildren().add(beamColor);
       }
 
       DoubleAdjuster scale = new DoubleAdjuster();

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -366,7 +366,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         layerInput.textProperty().bindBidirectional(layerHeightProp, new NumberStringConverter());
         Button addButton = new Button("Add");
         addButton.setOnAction(e -> {
-          if (!beam.getMaterials().keySet().contains(layerHeightProp.get())) {
+          if (!beam.getMaterials().containsKey(layerHeightProp.get())) { //Don't allow duplicate indices
             beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR));
             colorHeightList.getItems().add(layerHeightProp.get());
             scene.rebuildActorBvh();

--- a/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
+++ b/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
@@ -35,7 +35,6 @@ public class ExtraMaterials {
     idMap.put("candle_flame", Candle.flameMaterial);
     idMap.put("campfire_flame", Campfire.flameMaterial);
     idMap.put("soul_campfire_flame", Campfire.soulFlameMaterial);
-    idMap.put("beacon_beam", BeaconBeam.beaconBeamMaterial);
   }
 
   public static void loadDefaultMaterialProperties() {
@@ -49,8 +48,5 @@ public class ExtraMaterials {
 
     Campfire.soulFlameMaterial.restoreDefaults();
     Campfire.soulFlameMaterial.emittance = 0.6f;
-
-    BeaconBeam.beaconBeamMaterial.restoreDefaults();
-    BeaconBeam.beaconBeamMaterial.emittance = 1.0f;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
+++ b/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
@@ -19,9 +19,7 @@ package se.llbit.chunky.world;
 import java.util.HashMap;
 import java.util.Map;
 
-import se.llbit.chunky.block.Beacon;
 import se.llbit.chunky.block.Candle;
-import se.llbit.chunky.entity.BeaconBeam;
 import se.llbit.chunky.entity.Campfire;
 import se.llbit.chunky.world.material.CloudMaterial;
 

--- a/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
@@ -8,6 +8,7 @@ import se.llbit.math.Ray;
 
 public class BeaconBeamMaterial extends Material {
 
+    public static final int DEFAULT_COLOR = 0xF9FFFE;
     private int color;
     private float[] beamColor = new float[4];
 
@@ -52,7 +53,7 @@ public class BeaconBeamMaterial extends Material {
     @Override
     public void loadMaterialProperties(JsonObject json) {
         super.loadMaterialProperties(json);
-        updateColor(json.get("color").asInt(0xF9FFFE));
+        updateColor(json.get("color").asInt(DEFAULT_COLOR));
     }
 
     public void saveMaterialProperties(JsonObject json) {

--- a/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
@@ -1,0 +1,61 @@
+package se.llbit.chunky.world.material;
+
+import se.llbit.chunky.resources.Texture;
+import se.llbit.chunky.world.Material;
+import se.llbit.json.JsonObject;
+import se.llbit.math.ColorUtil;
+import se.llbit.math.Ray;
+
+public class BeaconBeamMaterial extends Material {
+
+    private int color;
+    private float[] beamColor = new float[4];
+
+    public BeaconBeamMaterial(int color) {
+        super("beacon_beam", Texture.beaconBeam);
+        this.emittance = 1.0f;
+        updateColor(color);
+    }
+
+    private void updateColor(int color) {
+        this.color = color;
+        ColorUtil.getRGBAComponents(color, beamColor);
+        ColorUtil.toLinear(beamColor);
+    }
+
+    @Override
+    public void getColor(Ray ray) {
+        super.getColor(ray);
+        if (ray.color.w > Ray.EPSILON) {
+            ray.color.x *= beamColor[0];
+            ray.color.y *= beamColor[1];
+            ray.color.z *= beamColor[2];
+        }
+    }
+
+    @Override
+    public float[] getColor(double u, double v) {
+        float[] color = super.getColor(u, v);
+        if (color[3] > Ray.EPSILON) {
+            color = color.clone();
+            color[0] *= beamColor[0];
+            color[1] *= beamColor[1];
+            color[2] *= beamColor[2];
+        }
+        return color;
+    }
+
+    @Override
+    public void loadMaterialProperties(JsonObject json) {
+        super.loadMaterialProperties(json);
+        updateColor(json.get("color").asInt(0xFFFFFF));
+    }
+
+    public void saveMaterialProperties(JsonObject json) {
+        json.add("ior", this.ior);
+        json.add("specular", this.specular);
+        json.add("emittance", this.emittance);
+        json.add("roughness", this.roughness);
+        json.add("color", this.color);
+    }
+}

--- a/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
@@ -52,7 +52,7 @@ public class BeaconBeamMaterial extends Material {
     @Override
     public void loadMaterialProperties(JsonObject json) {
         super.loadMaterialProperties(json);
-        updateColor(json.get("color").asInt(0xFFFFFF));
+        updateColor(json.get("color").asInt(0xF9FFFE));
     }
 
     public void saveMaterialProperties(JsonObject json) {

--- a/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
@@ -17,10 +17,14 @@ public class BeaconBeamMaterial extends Material {
         updateColor(color);
     }
 
-    private void updateColor(int color) {
+    public void updateColor(int color) {
         this.color = color;
         ColorUtil.getRGBAComponents(color, beamColor);
         ColorUtil.toLinear(beamColor);
+    }
+
+    public int getColorInt() {
+        return color;
     }
 
     @Override


### PR DESCRIPTION
This is a big one compared to what I normally do. This PR includes changes to Beacon Beams including allowing rotation, saving and loading custom colors, and loading colors from the octree.

![default_2021-01-22_12-27-45-500](https://user-images.githubusercontent.com/30638248/105531516-0d790800-5caf-11eb-81cf-f356056e8562.png)

I've removed the beacon_beam material from the Materials Tab and put that functionality into the Entities Tab to enable the user to change those properties for any beam segment along with the color.

![image](https://user-images.githubusercontent.com/30638248/105531707-5cbf3880-5caf-11eb-8d8e-21c9eed45b44.png)

Related to #41 