### PR TITLE
21w03a

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/GlowLichen.java
+++ b/chunky/src/java/se/llbit/chunky/block/GlowLichen.java
@@ -1,0 +1,53 @@
+package se.llbit.chunky.block;
+
+import se.llbit.chunky.model.GlowLichenModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.chunky.world.BlockData;
+import se.llbit.math.Ray;
+
+public class GlowLichen extends MinecraftBlockTranslucent {
+
+  private final String description;
+  private final int connections;
+
+  public GlowLichen(boolean north, boolean south, boolean east, boolean west, boolean up,
+      boolean down) {
+    super("glow_lichen", Texture.glowLichen);
+    this.description = String.format("north=%s, south=%s, east=%s, west=%s, up=%s, down=%s",
+        north, south, east, west, up, down);
+    localIntersect = true;
+    solid = false;
+
+    int connections = 0;
+    if (north) {
+      connections |= BlockData.CONNECTED_NORTH;
+    }
+    if (south) {
+      connections |= BlockData.CONNECTED_SOUTH;
+    }
+    if (east) {
+      connections |= BlockData.CONNECTED_EAST;
+    }
+    if (west) {
+      connections |= BlockData.CONNECTED_WEST;
+    }
+    if (up) {
+      connections |= BlockData.CONNECTED_ABOVE;
+    }
+    if (down) {
+      connections |= BlockData.CONNECTED_BELOW;
+    }
+    this.connections = connections;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    return GlowLichenModel.intersect(ray, connections);
+  }
+
+  @Override
+  public String description() {
+    return description;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -306,6 +306,7 @@ public class MinecraftBlockProvider implements BlockProvider {
       "minecraft:glass",
       "minecraft:glass_pane",
       "minecraft:glowstone",
+      "minecraft:glow_lichen",
       "minecraft:gold_block",
       "minecraft:gold_ore",
       "minecraft:granite",
@@ -2718,6 +2719,15 @@ public class MinecraftBlockProvider implements BlockProvider {
             tag.get("Properties").get("waterlogged").stringValue("").equals("true"));
       case "sculk_sensor":
         return new SculkSensor(tag.get("Properties").get("sculk_sensor_phase").stringValue("cooldown"));
+      case "glow_lichen":
+        return new GlowLichen(
+            tag.get("Properties").get("north").stringValue("false").equals("true"),
+            tag.get("Properties").get("south").stringValue("false").equals("true"),
+            tag.get("Properties").get("east").stringValue("false").equals("true"),
+            tag.get("Properties").get("west").stringValue("false").equals("true"),
+            tag.get("Properties").get("up").stringValue("false").equals("true"),
+            tag.get("Properties").get("down").stringValue("false").equals("true")
+        );
       case "structure_void":
       case "barrier":
         // Invisible.

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -410,6 +410,9 @@ public class BlockPalette {
         block.emittance = 1.0f / 15f;
       }
     });
+    materialProperties.put("minecraft:glow_lichen", block -> {
+      block.emittance = 1.0f / 15f * 7;
+    });
     return materialProperties;
   }
 

--- a/chunky/src/java/se/llbit/chunky/model/GlowLichenModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/GlowLichenModel.java
@@ -1,0 +1,63 @@
+package se.llbit.chunky.model;
+
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.DoubleSidedQuad;
+import se.llbit.math.Quad;
+import se.llbit.math.QuickMath;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+public class GlowLichenModel {
+
+  protected static final Quad[] quads = {
+      // North
+      new DoubleSidedQuad(new Vector3(0, 0, 0.01 / 16), new Vector3(1, 0, 0.01 / 16),
+          new Vector3(0, 1, 0.01 / 16), new Vector4(0, 1, 0, 1)),
+
+      // South
+      new DoubleSidedQuad(new Vector3(1, 0, 15.99 / 16), new Vector3(0, 0, 15.99 / 16),
+          new Vector3(1, 1, 15.99 / 16), new Vector4(1, 0, 0, 1)),
+
+      // East
+      new DoubleSidedQuad(new Vector3(15.99 / 16, 0, 0), new Vector3(15.99 / 16, 0, 1),
+          new Vector3(15.99 / 16, 1, 0), new Vector4(0, 1, 0, 1)),
+
+      // West
+      new DoubleSidedQuad(new Vector3(0.01 / 16, 0, 1), new Vector3(0.01 / 16, 0, 0),
+          new Vector3(0.01 / 16, 1, 1), new Vector4(1, 0, 0, 1)),
+
+      // Top
+      new DoubleSidedQuad(new Vector3(0, 15.99 / 16, 0), new Vector3(1, 15.99 / 16, 0),
+          new Vector3(0, 15.99 / 16, 1), new Vector4(0, 1, 0, 1)),
+
+      // Bottom
+      new DoubleSidedQuad(new Vector3(0, 0.01 / 16, 0), new Vector3(1, 0.01 / 16, 0),
+          new Vector3(0, 0.01 / 16, 1), new Vector4(0, 1, 0, 1)),
+  };
+
+  public static boolean intersect(Ray ray, int connections) {
+    boolean hit = false;
+    ray.t = Double.POSITIVE_INFINITY;
+    for (int i = 0; i < quads.length; ++i) {
+      if ((connections & (1 << i)) != 0) {
+        Quad quad = quads[i];
+        if (quad.intersect(ray)) {
+          float[] color = Texture.glowLichen.getColor(ray.u, ray.v);
+          if (color[3] > Ray.EPSILON) {
+            ray.color.set(color);
+            ray.t = ray.tNext;
+            ray.n.set(quad.n);
+            ray.n.scale(QuickMath.signum(-ray.d.dot(quad.n)));
+            hit = true;
+          }
+        }
+      }
+    }
+    if (hit) {
+      ray.distance += ray.t;
+      ray.o.scaleAdd(ray.t, ray.d);
+    }
+    return hit;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/VineModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/VineModel.java
@@ -27,27 +27,27 @@ import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 
 public class VineModel {
+
   protected static final Quad[] quads = {
-      // North.
-      new DoubleSidedQuad(new Vector3(0, 0, 1 / 16.), new Vector3(1, 0, 1 / 16.),
-          new Vector3(0, 1, 1 / 16.), new Vector4(0, 1, 0, 1)),
+      // North
+      new DoubleSidedQuad(new Vector3(0, 0, 0.8 / 16), new Vector3(1, 0, 0.8 / 16),
+          new Vector3(0, 1, 0.8 / 16), new Vector4(0, 1, 0, 1)),
 
-      // South.
-      new DoubleSidedQuad(new Vector3(1, 0, 15 / 16.), new Vector3(0, 0, 15 / 16.),
-          new Vector3(1, 1, 15 / 16.), new Vector4(1, 0, 0, 1)),
+      // South
+      new DoubleSidedQuad(new Vector3(1, 0, 15.2 / 16), new Vector3(0, 0, 15.2 / 16),
+          new Vector3(1, 1, 15.2 / 16), new Vector4(1, 0, 0, 1)),
 
-      // East.
-      new DoubleSidedQuad(new Vector3(15 / 16., 0, 0), new Vector3(15 / 16., 0, 1),
-          new Vector3(15 / 16., 1, 0), new Vector4(0, 1, 0, 1)),
+      // East
+      new DoubleSidedQuad(new Vector3(15.2 / 16, 0, 0), new Vector3(15.2 / 16, 0, 1),
+          new Vector3(15.2 / 16, 1, 0), new Vector4(0, 1, 0, 1)),
 
-      // West.
-      new DoubleSidedQuad(new Vector3(1 / 16., 0, 1), new Vector3(1 / 16., 0, 0),
-          new Vector3(1 / 16., 1, 1), new Vector4(1, 0, 0, 1)),
+      // West
+      new DoubleSidedQuad(new Vector3(0.8 / 16, 0, 1), new Vector3(0.8 / 16, 0, 0),
+          new Vector3(0.8 / 16, 1, 1), new Vector4(1, 0, 0, 1)),
 
-      // Top.
-      new DoubleSidedQuad(new Vector3(0, 1, 0), new Vector3(1, 1, 0), new Vector3(0, 1, 1),
-          new Vector4(0, 1, 0, 1)),
-
+      // Top
+      new DoubleSidedQuad(new Vector3(0, 15.2 / 16, 0), new Vector3(1, 15.2 / 16, 0),
+          new Vector3(0, 15.2 / 16, 1), new Vector4(0, 1, 0, 1)),
   };
 
   public static boolean intersect(Ray ray, Scene scene) {

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -942,6 +942,7 @@ public class Texture {
   public static final Texture sculkSensorTendrilActive = new Texture();
   public static final Texture sculkSensorTendrilInactive = new Texture();
   public static final Texture sculkSensorTop = new Texture();
+  public static final Texture glowLichen = new Texture();
 
   /** Banner base texture. */
   public static final Texture bannerBase = new Texture();

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3568,6 +3568,7 @@ public class TexturePackLoader {
     addSimpleTexture("assets/minecraft/textures/block/sculk_sensor_tendril_active", Texture.sculkSensorTendrilActive);
     addSimpleTexture("assets/minecraft/textures/block/sculk_sensor_tendril_inactive", Texture.sculkSensorTendrilInactive);
     addSimpleTexture("assets/minecraft/textures/block/sculk_sensor_top", Texture.sculkSensorTop);
+    addSimpleTexture("assets/minecraft/textures/block/glow_lichen", Texture.glowLichen);
   }
 
   private static void addSimpleTexture(String file, Texture texture) {


### PR DESCRIPTION
Partially implements #789 
Item frames are not loaded yet for 1.17 worlds due to entities not being stored inside the region files anymore. I'll add it in another branch for <= 1.16 worlds (the non-glowing variant).