### PR TITLE
Use the JavaFX gradle plugin when building with Java 10 or later.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,19 @@ if (project.version =~ /\d+\.\d+(\.\d+)?-.+/) {
   println 'Building snapshot version.'
 }
 
+plugins {
+  id 'org.openjfx.javafxplugin' version '0.0.8' apply false
+}
+
+if (JavaVersion.current().isJava11Compatible()) {
+  apply plugin: 'org.openjfx.javafxplugin'
+
+  javafx {
+    version = "11"
+    modules = ['javafx.controls', 'javafx.fxml']
+  }
+}
+
 allprojects {
   repositories {
     mavenCentral()

--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -1,3 +1,16 @@
+plugins {
+  id 'org.openjfx.javafxplugin' version '0.0.8' apply false
+}
+
+if (JavaVersion.current().isJava11Compatible()) {
+  apply plugin: 'org.openjfx.javafxplugin'
+
+  javafx {
+    version = "11"
+    modules = ['javafx.controls', 'javafx.fxml']
+  }
+}
+
 apply plugin: 'application'
 apply plugin: 'maven'
 apply plugin: 'signing'

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,3 +1,16 @@
+plugins {
+  id 'org.openjfx.javafxplugin' version '0.0.8' apply false
+}
+
+if (JavaVersion.current().isJava11Compatible()) {
+  apply plugin: 'org.openjfx.javafxplugin'
+
+  javafx {
+    version = "11"
+    modules = ['javafx.controls', 'javafx.fxml']
+  }
+}
+
 dependencies {
   compile project(':lib')
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,3 +1,16 @@
+plugins {
+  id 'org.openjfx.javafxplugin' version '0.0.8' apply false
+}
+
+if (JavaVersion.current().isJava11Compatible()) {
+  apply plugin: 'org.openjfx.javafxplugin'
+
+  javafx {
+    version = "11"
+    modules = ['javafx.controls', 'javafx.fxml']
+  }
+}
+
 sourceSets.main.java {
   srcDir 'src'
 }


### PR DESCRIPTION
Based on @aTom3333's snapshot. This doesn't break the build with Java 8 but can someone verify that it works as intended with Java 10+?

Fixes #787 