### PR TITLE
Metalness

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -223,15 +223,21 @@ public class BlockPalette {
     materialProperties.put("minecraft:black_stained_glass_pane", glassConfig);
     materialProperties.put("minecraft:gold_block", block -> {
       block.specular = 0.04f;
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.9);
     });
     materialProperties.put("minecraft:diamond_block", block -> {
       block.specular = 0.04f;
     });
     materialProperties.put("minecraft:iron_block", block -> {
       block.specular = 0.04f;
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.9);
     });
     materialProperties.put("minecraft:iron_bars", block -> {
       block.specular = 0.04f;
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.9);
     });
     materialProperties.put("minecraft:redstone_torch", block -> {
       block.emittance = 1.0f;
@@ -356,9 +362,18 @@ public class BlockPalette {
         }
       }
     });
-    Consumer<Block> copperConfig = block -> { block.specular = 0.04f; };
-    Consumer<Block> lightlyWeatheredCopperConfig = block -> { block.specular = 0.66f * 0.04f; };
-    Consumer<Block> semiWeatheredCopperConfig = block -> { block.specular = 0.33f * 0.04f; };
+    Consumer<Block> copperConfig = block -> {
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.75);
+    };
+    Consumer<Block> lightlyWeatheredCopperConfig = block -> {
+      block.metalness = 0.66f;
+      block.setPerceptualSmoothness(0.75);
+    };
+    Consumer<Block> semiWeatheredCopperConfig = block -> {
+      block.metalness = 0.66f;
+      block.setPerceptualSmoothness(0.75);
+    };
     materialProperties.put("minecraft:copper_block", copperConfig);
     materialProperties.put("minecraft:lightly_weathered_copper_block", lightlyWeatheredCopperConfig);
     materialProperties.put("minecraft:semi_weathered_copper_block", semiWeatheredCopperConfig);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -125,8 +125,11 @@ public class PathTracer implements RayTracer {
         continue;
       }
 
-      if (pSpecular > Ray.EPSILON && random.nextFloat() < pSpecular) {
-        // Specular reflection.
+      float pMetal = currentMat.metalness;
+      boolean doMetal = pMetal > Ray.EPSILON && random.nextFloat() < pMetal;
+
+      if (doMetal || (pSpecular > Ray.EPSILON && random.nextFloat() < pSpecular)) {
+        // Specular reflection (metals only do specular reflection).
 
         firstReflection = false;
 
@@ -135,9 +138,16 @@ public class PathTracer implements RayTracer {
           reflected.specularReflection(ray, random);
 
           if (pathTrace(scene, reflected, state, 1, false)) {
-            ray.color.x = reflected.color.x;
-            ray.color.y = reflected.color.y;
-            ray.color.z = reflected.color.z;
+            if (doMetal) {
+              // use the albedo color as specular color
+              ray.color.x *= reflected.color.x;
+              ray.color.y *= reflected.color.y;
+              ray.color.z *= reflected.color.z;
+            } else {
+              ray.color.x = reflected.color.x;
+              ray.color.y = reflected.color.y;
+              ray.color.z = reflected.color.z;
+            }
             hit = true;
           }
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3065,6 +3065,16 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * Modifies the metalness property for the given material.
+   */
+  public void setMetalness(String materialName, float value) {
+    JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
+    material.set("metalness", Json.of(value));
+    materials.put(materialName, material);
+    refresh(ResetReason.MATERIALS_CHANGED);
+  }
+
+  /**
    * Renders a fog effect over the sky near the horizon.
    */
   public void addSkyFog(Ray ray) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/MaterialsTab.java
@@ -52,6 +52,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
   private final DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
+  private final DoubleAdjuster metalness = new DoubleAdjuster();
   private final ListView<String> listView;
 
   public MaterialsTab() {
@@ -63,6 +64,8 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     ior.setRange(0, 5);
     perceptualSmoothness.setName("Smoothness");
     perceptualSmoothness.setRange(0, 1);
+    metalness.setName("Metalness");
+    metalness.setRange(0, 1);
     ObservableList<String> blockIds = FXCollections.observableArrayList();
     blockIds.addAll(MaterialStore.collections.keySet());
     blockIds.addAll(ExtraMaterials.idMap.keySet());
@@ -78,7 +81,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, specular, perceptualSmoothness, ior,
+        emittance, specular, perceptualSmoothness, ior, metalness,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);
@@ -107,17 +110,20 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       double specAcc = 0;
       double iorAcc = 0;
       double perceptualSmoothnessAcc = 0;
+      double metalnessAcc = 0;
       Collection<Block> blocks = MaterialStore.collections.get(materialName);
       for (Block block : blocks) {
         emAcc += block.emittance;
         specAcc += block.specular;
         iorAcc += block.ior;
         perceptualSmoothnessAcc += block.getPerceptualSmoothness();
+        metalnessAcc += block.metalness;
       }
       emittance.set(emAcc / blocks.size());
       specular.set(specAcc / blocks.size());
       ior.set(iorAcc / blocks.size());
       perceptualSmoothness.set(perceptualSmoothnessAcc / blocks.size());
+      metalness.set(metalnessAcc / blocks.size());
       materialExists = true;
     } else if (ExtraMaterials.idMap.containsKey(materialName)) {
       Material material = ExtraMaterials.idMap.get(materialName);
@@ -126,6 +132,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
         specular.set(material.specular);
         ior.set(material.ior);
         perceptualSmoothness.set(material.getPerceptualSmoothness());
+        metalness.set(material.metalness);
         materialExists = true;
       }
     } else if (MaterialStore.blockIds.contains(materialName)) {
@@ -135,6 +142,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       specular.set(block.specular);
       ior.set(block.ior);
       perceptualSmoothness.set(block.getPerceptualSmoothness());
+      metalness.set(block.metalness);
       materialExists = true;
     }
     if (materialExists) {
@@ -142,11 +150,13 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       specular.onValueChange(value -> scene.setSpecular(materialName, value.floatValue()));
       ior.onValueChange(value -> scene.setIor(materialName, value.floatValue()));
       perceptualSmoothness.onValueChange(value -> scene.setPerceptualSmoothness(materialName, value.floatValue()));
+      metalness.onValueChange(value -> scene.setMetalness(materialName, value.floatValue()));
     } else {
       emittance.onValueChange(value -> {});
       specular.onValueChange(value -> {});
       ior.onValueChange(value -> {});
       perceptualSmoothness.onValueChange(value -> {});
+      metalness.onValueChange(value -> {});
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -67,6 +67,15 @@ public abstract class Material {
   public float roughness = 0f;
 
   /**
+   * The metalness value controls how metal-y a block appears. In reality this is a boolean value
+   * but in practice usually a float is used in PBR to allow adding dirt or scratches on metals
+   * without increasing the texture resolution.
+   * Metals only do specular reflection for certain wavelengths (effectively tinting the reflection)
+   * and have no diffuse reflection. The albedo color is used for tinting.
+   */
+  public float metalness = 0;
+
+  /**
    * Subsurface scattering property.
    */
   public boolean subSurfaceScattering = false;
@@ -125,6 +134,7 @@ public abstract class Material {
     specular = json.get("specular").floatValue(specular);
     emittance = json.get("emittance").floatValue(emittance);
     roughness = json.get("roughness").floatValue(roughness);
+    metalness = json.get("metalness").floatValue(metalness);
   }
 
   public boolean isWater() {


### PR DESCRIPTION
This PR adds metalness to the material properties. In the real world, that's a boolean variable but in PBR it's usually a float that can be used to make things less metallic, e.g. to account for dust or scratches. Metals only have a specular color and absorb some colors (= they tint the color). Also works fine with roughness.


|This PR|Previously|
|---|---|
|![image](https://user-images.githubusercontent.com/5544859/105617705-a3f91680-5de0-11eb-963f-ffa00b36bad8.png)|![image](https://user-images.githubusercontent.com/5544859/105617723-ce4ad400-5de0-11eb-8473-a76d5c872587.png)|

Specular vs. metalness:
![00-metalness-1000](https://user-images.githubusercontent.com/5544859/105617637-17e6ef00-5de0-11eb-8434-48f53ea6cf81.png)
