### PR TITLE
Include emittergrid files in scene exports. Ignore missing files.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -332,7 +332,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public static void delete(String name, File sceneDir) {
     String[] extensions = {
-        ".json", ".dump", ".octree2", ".foliage", ".grass", ".json.backup", ".dump.backup",
+        ".json", ".dump", ".octree2", ".emittergrid", ".foliage", ".grass", ".json.backup", ".dump.backup",
     };
     for (String extension : extensions) {
       File file = new File(sceneDir, name + extension);
@@ -347,7 +347,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Export the scene to a zip file.
    */
   public static void exportToZip(String name, File targetFile) {
-    String[] extensions = { ".json", ".dump", ".octree2", ".foliage", ".grass", };
+    String[] extensions = { ".json", ".dump", ".octree2", ".foliage", ".grass", ".emittergrid", };
     ZipExport.zip(targetFile, SynchronousSceneManager.resolveSceneDirectory(name), name, extensions);
   }
 

--- a/chunky/src/java/se/llbit/util/ZipExport.java
+++ b/chunky/src/java/se/llbit/util/ZipExport.java
@@ -46,7 +46,10 @@ public class ZipExport {
       ZipOutputStream zos = new ZipOutputStream(fos)
     ) {
       for (String extension : extensions) {
-        addToZipFile(zos, sceneDir, sceneName, sceneName + extension);
+        File file = new File(sceneDir, sceneName + extension);
+        if (file.exists()) {
+          addToZipFile(zos, sceneDir, sceneName, file);
+        }
       }
     } catch (IOException e) {
       Log.error(e);
@@ -54,10 +57,9 @@ public class ZipExport {
   }
 
   private static void addToZipFile(ZipOutputStream zos, File sceneDir, String prefix,
-      String fileName) throws IOException {
-    File file = new File(sceneDir, fileName);
+      File file) throws IOException {
     try (FileInputStream fis = new FileInputStream(file)) {
-      ZipEntry zipEntry = new ZipEntry(prefix + "/" + fileName);
+      ZipEntry zipEntry = new ZipEntry(prefix + "/" + file.getName());
       zos.putNextEntry(zipEntry);
 
       byte[] bytes = new byte[4096];


### PR DESCRIPTION
Fixes #800 

Keeping `.foliage` and `.grass` in the list of extensions so that exporting old scenes still works.