### PR TITLE
Fix water level information being dropped on chunk borders.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -989,6 +989,10 @@ public class Scene implements JsonSerializable, Refreshable {
                                 | (corner2 << Water.CORNER_2)
                                 | (corner3 << Water.CORNER_3)));
                       }
+                    } else {
+                      // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
+                      waterNode = new Octree.Node(
+                          palette.getWaterId(((Water) block).level, 0));
                     }
                   }
                   waterOctree.set(waterNode, x, cy - origin.y, z);


### PR DESCRIPTION
Fixes #775, which is a regression introduced in #638