### PR TITLE
Increase Ray Precision

### DIFF
--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -33,9 +33,9 @@ import java.util.Random;
  */
 public class Ray {
 
-  public static final double EPSILON = 0.000005;
+  public static final double EPSILON = 0.00000005;
 
-  public static final double OFFSET = 0.0001;
+  public static final double OFFSET = 0.000001;
 
   /**
    * Ray direction.

--- a/chunky/src/java/se/llbit/util/RingBuffer.java
+++ b/chunky/src/java/se/llbit/util/RingBuffer.java
@@ -54,6 +54,8 @@ public class RingBuffer<T> {
     if (size == 0) {
       throw new NoSuchElementException("Buffer is empty.");
     }
+
+    @SuppressWarnings("unchecked")
     T result = (T) data[remove];
     remove = (remove + 1) % capacity;
     size -= 1;


### PR DESCRIPTION
No noticeable speed cost of increased precision, while reducing rays from hitting the "seams" between blocks, or leaking through diagonals. (Not a true fix, but reduces the problem by ~99%.) These seams are really only noticeable if you zoom in to the edge of a block now, and leaked rays are are fewer and would make much less of an impact (1/100 as many as the few that go through now should make them nigh invisible).

(And while I'm at this super short PR, may as well suppress the only warning, which due to how it is currently used, will never cause crash.)

---

Example of seams (zoomed in to the corner of a grass block):
![corner-of-grass-blocks](https://cdn.discordapp.com/attachments/498295918756495361/801981353334931486/lowresweirdness-100.png)

And if offset variable is increased to unreasonably large values, it shows the same artifact on a larger scale (I think this is 0.1 instead of 0.0001):
![block-corners-acting-weird](https://cdn.discordapp.com/attachments/498295918756495361/801984629473148938/lowresweirdness-100.png)

This is also noticeable where the different faces of a block have large differences in color, such as on a normal map in the denoiser. With the current values, a flat wall will have a spattering of pixels along block seams which are colored as a different direction, for when the ray hits gets in the seam and hits a different face of the block, instead of the outward facing face.

---

This also relates to #799 

For the following scene, the following were rendered with the `epsilon` and `offset` values multiplied by 10, 1, and 0.1 respectively, to compare light leakage through the block diagonals. SPS was similar for all three: ~850,000 for ray depth 4. (no visible difference between ray depth 4 and ray depth 100. I tested it.)

![DiagonalLightScene_preview](https://user-images.githubusercontent.com/4878558/106965672-c9e3bc80-66f8-11eb-8b4b-d5a4cd8fb83f.png)

The following are the exact same view, with only the four variables differing (ratio compared to the middle one in parenthesis):

offset: 0.001 (10x); sun intensity: 15 (.2x); sky intensity: 90 (.2x); epsilon: 0.00005 (10x) -> (10 000 spp at ~850 000 sps)
![DiagonalLightScene_E-3_10k](https://user-images.githubusercontent.com/4878558/106965208-1e3a6c80-66f8-11eb-8c8c-e16f1738d69f.png)

offset: 0.0001 (default); sun intensity: 75; sky intensity: 450; epsilon: 0.000005 (default) -> (60 000 spp at 829 900 sps)
![DiagonalLightScene_E-4_60k](https://user-images.githubusercontent.com/4878558/106965221-22ff2080-66f8-11eb-8618-e363e9039f80.png)

offset: 0.00001 (0.1x); sun intensity: 150 (2x); sky intensity: 900 (2x); epsilon: 0.0000005 (0.1x) -> (700 000 spp at 923 100 sps)
![DiagonalLightScene_E-5_700k](https://user-images.githubusercontent.com/4878558/106965498-838e5d80-66f8-11eb-9e4a-9bf2693dcdf4.png)

As you can see, the scene looks similar in brightness and noise levels, while light intensity needed to be greatly increased (5x then ~2.5x) to maintain similar lighting, while also requiring far far more spp to become clear over the noise (6x to 12x), per decimal added to epsilon and offset, while not contributing to sps costs.

---

If someone is not lighting a scene with just light leaking through corners, they would have no reason to increase brightness to absurd levels for the little light that leaks through to light or affect the scene in any meaningful way. With these more precise values, I would expect to see about a 100 to 1 reduction in fireflies caused by this (rays need to fit through a gap that is 100 times smaller), as well as a 100 to 1 reduction in the size of the "seams" between blocks. And from my tests, both listed here and not, there seems to be no noticeable performance impact with this change.