### PR TITLE
add support for 21w06a tall chunks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -744,11 +744,13 @@ public class Scene implements JsonSerializable, Refreshable {
       return;
     }
 
-    boolean isTallWorld = world.getVersionId() >= 2694;
-    if(isTallWorld) { //snapshot 21w06a, treat as -64 - 320
+    boolean isTallWorld = world.getVersionId() >= World.VERSION_21W06A;
+    if(isTallWorld) {
+      // snapshot 21w06a or later, treat as -64 - 320
       yMin = Math.max(-64, yClipMin);
       yMax = Math.min(320, yClipMax);
-    } else { //Treat as 0 - 256 world
+    } else {
+      // treat as 0 - 256 world
       yMin = Math.max(0, yClipMin);
       yMax = Math.min(256, yClipMax);
     }

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -43,6 +43,7 @@ import se.llbit.chunky.ui.RenderCanvasFx;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Icon;
+import se.llbit.chunky.world.World;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
@@ -205,14 +206,12 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     canvasSize.setEditable(true);
     canvasSize.getItems().addAll("400x400", "1024x768", "960x540", "1920x1080");
     canvasSize.valueProperty().addListener(canvasSizeListener);
-    yMax.setRange(-64, 320);
     yMax.setTooltip(
         "Blocks above this Y value are not loaded. Requires reloading chunks to take effect.");
     yMax.onValueChange(value -> {
       scene.setYClipMax(value);
       renderControls.showPopup("Reload the chunks for this to take effect.", yMax);
     });
-    yMin.setRange(-64, 320);
     yMin.setTooltip(
         "Blocks below this Y value are not loaded. Requires reloading chunks to take effect.");
     yMin.onValueChange(value -> {
@@ -295,7 +294,19 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     mapLoader.addWorldLoadListener(world -> {
       loadSelectedChunks.setDisable(world instanceof EmptyWorld || world == null);
     });
+    mapLoader.addWorldLoadListener(this::updateYClipSlidersRanges);
+    updateYClipSlidersRanges(mapLoader.getWorld());
     this.controller = controls.getRenderController();
     this.scene = this.controller.getSceneManager().getScene();
+  }
+
+  private void updateYClipSlidersRanges(World world) {
+    if (world != null && world.getVersionId() >= World.VERSION_21W06A) {
+      yMin.setRange(-64, 320);
+      yMax.setRange(-64, 320);
+    } else {
+      yMin.setRange(0, 256);
+      yMax.setRange(0, 256);
+    }
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -205,14 +205,14 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     canvasSize.setEditable(true);
     canvasSize.getItems().addAll("400x400", "1024x768", "960x540", "1920x1080");
     canvasSize.valueProperty().addListener(canvasSizeListener);
-    yMax.setRange(0, 256);
+    yMax.setRange(-64, 320);
     yMax.setTooltip(
         "Blocks above this Y value are not loaded. Requires reloading chunks to take effect.");
     yMax.onValueChange(value -> {
       scene.setYClipMax(value);
       renderControls.showPopup("Reload the chunks for this to take effect.", yMax);
     });
-    yMin.setRange(0, 256);
+    yMin.setRange(-64, 320);
     yMin.setTooltip(
         "Blocks below this Y value are not loaded. Requires reloading chunks to take effect.");
     yMin.onValueChange(value -> {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -287,7 +287,7 @@ public class Chunk {
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
         Tag yTag = section.get("Y");
-        int sectionY = yTag.byteValue() & 0xFF;
+        int sectionY = yTag.byteValue();
         int sectionMinBlockY = sectionY << 4;
 
         if (section.get("Palette").isList()) {

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -72,6 +72,9 @@ public class World implements Comparable<World> {
   /** Default sea water level. */
   public static final int SEA_LEVEL = 63;
 
+  /** Minimum level.dat data version of tall worlds (21w06a). */
+  public static final int VERSION_21W06A = 2694;
+
   private final Map<ChunkPosition, Region> regionMap = new HashMap<>();
 
   private final File worldDirectory;

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -93,6 +93,8 @@ public class World implements Comparable<World> {
 
   private int gameMode = 0;
 
+  private int versionId;
+
   private final long seed;
 
   /** Timestamp for level.dat when player data was last loaded. */
@@ -139,6 +141,7 @@ public class World implements Comparable<World> {
         DataInputStream in = new DataInputStream(gzin)) {
       Set<String> request = new HashSet<>();
       request.add(".Data.version");
+      request.add(".Data.Version.Id");
       request.add(".Data.RandomSeed");
       request.add(".Data.Player");
       request.add(".Data.LevelName");
@@ -150,6 +153,7 @@ public class World implements Comparable<World> {
         Log.warnf("The world format for the world %s is not supported by Chunky.\n" + "Will attempt to load the world anyway.",
             levelName);
       }
+      Tag versionId = result.get(".Data.Version.Id");
       Tag player = result.get(".Data.Player");
       Tag spawnX = player.get("SpawnX");
       Tag spawnY = player.get("SpawnY");
@@ -175,6 +179,7 @@ public class World implements Comparable<World> {
       world.spawnZ = spawnZ.intValue();
       world.gameMode = gameType.intValue(0);
       world.playerDimension = player.get("Dimension").intValue();
+      world.versionId = versionId.intValue();
       return world;
     } catch (FileNotFoundException e) {
       if (warnings == LoggedWarnings.NORMAL) {
@@ -579,6 +584,10 @@ public class World implements Comparable<World> {
    */
   public double spawnPosX() {
     return spawnX;
+  }
+
+  public int getVersionId() {
+    return versionId;
   }
 
   /**


### PR DESCRIPTION
initial support for tall chunks, in my testing it works as expected

Currently I'm setting `GeneralTab#yMin` and `GeneralTab#yMax` bounds to `-64` to `320` for all worlds. If you want this to change per-world, scene would probably need the `GeneralTab` instance passed to it on `Scene#loadChunks` or something

Also a sneaky bug fix in `Chunk@290`, preventing negative section positions
