### PR TITLE
Added accessors/made things public

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -17,7 +17,7 @@
 package se.llbit.chunky.chunk;
 
 import se.llbit.chunky.block.*;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.math.Octree;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.IntTag;
@@ -483,7 +483,7 @@ public class BlockPalette {
     return materialProperties;
   }
 
-  @API
+  @PluginApi
   public List<Block> getPalette() {
     return palette;
   }

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2019-2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.chunk;
 
 import se.llbit.chunky.block.*;
@@ -464,6 +480,10 @@ public class BlockPalette {
       }
     });
     return materialProperties;
+  }
+
+  public List<Block> getPalette() {
+    return palette;
   }
 
   /** Writes the block specifications to file. */

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.chunk;
 
 import se.llbit.chunky.block.*;
+import se.llbit.chunky.plugin.API;
 import se.llbit.math.Octree;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.IntTag;
@@ -482,6 +483,7 @@ public class BlockPalette {
     return materialProperties;
   }
 
+  @API
   public List<Block> getPalette() {
     return palette;
   }

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -22,6 +22,7 @@ import se.llbit.chunky.block.BlockProvider;
 import se.llbit.chunky.block.BlockSpec;
 import se.llbit.chunky.block.MinecraftBlockProvider;
 import se.llbit.chunky.main.CommandLineOptions.Mode;
+import se.llbit.chunky.plugin.API;
 import se.llbit.chunky.plugin.ChunkyPlugin;
 import se.llbit.chunky.plugin.TabTransformer;
 import se.llbit.chunky.renderer.ConsoleProgressListener;
@@ -329,6 +330,7 @@ public class Chunky {
     return renderController != null;
   }
 
+  @API
   public void setRendererFactory(RendererFactory rendererFactory) {
     this.rendererFactory = rendererFactory;
   }

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2010-2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2010-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2010-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -326,6 +327,10 @@ public class Chunky {
 
   public boolean sceneInitialized() {
     return renderController != null;
+  }
+
+  public void setRendererFactory(RendererFactory rendererFactory) {
+    this.rendererFactory = rendererFactory;
   }
 
   public RenderController getRenderController() {

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -22,7 +22,7 @@ import se.llbit.chunky.block.BlockProvider;
 import se.llbit.chunky.block.BlockSpec;
 import se.llbit.chunky.block.MinecraftBlockProvider;
 import se.llbit.chunky.main.CommandLineOptions.Mode;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.plugin.ChunkyPlugin;
 import se.llbit.chunky.plugin.TabTransformer;
 import se.llbit.chunky.renderer.ConsoleProgressListener;
@@ -330,7 +330,7 @@ public class Chunky {
     return renderController != null;
   }
 
-  @API
+  @PluginApi
   public void setRendererFactory(RendererFactory rendererFactory) {
     this.rendererFactory = rendererFactory;
   }

--- a/chunky/src/java/se/llbit/chunky/plugin/API.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/API.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.plugin;
+
+/** Mark something that is only used by plugins. Check before removing/modifying anything marked with this. */
+public @interface API {
+}

--- a/chunky/src/java/se/llbit/chunky/plugin/PluginApi.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/PluginApi.java
@@ -18,5 +18,5 @@
 package se.llbit.chunky.plugin;
 
 /** Mark something that is only used by plugins. Check before removing/modifying anything marked with this. */
-public @interface API {
+public @interface PluginApi {
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Chunky contributors
+/* Copyright (c) 2013-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -3062,6 +3062,14 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public void setOctreeImplementation(String octreeImplementation) {
     this.octreeImplementation = octreeImplementation;
+  }
+
+  public Octree getWorldOctree() {
+    return worldOctree;
+  }
+
+  public Octree getWaterOctree() {
+    return waterOctree;
   }
 
   public EmitterSamplingStrategy getEmitterSamplingStrategy() {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -33,7 +33,7 @@ import se.llbit.chunky.entity.Lectern;
 import se.llbit.chunky.entity.PaintingEntity;
 import se.llbit.chunky.entity.PlayerEntity;
 import se.llbit.chunky.entity.Poseable;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.renderer.renderdump.RenderDump;
@@ -3065,12 +3065,12 @@ public class Scene implements JsonSerializable, Refreshable {
     this.octreeImplementation = octreeImplementation;
   }
 
-  @API
+  @PluginApi
   public Octree getWorldOctree() {
     return worldOctree;
   }
 
-  @API
+  @PluginApi
   public Octree getWaterOctree() {
     return waterOctree;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -33,6 +33,7 @@ import se.llbit.chunky.entity.Lectern;
 import se.llbit.chunky.entity.PaintingEntity;
 import se.llbit.chunky.entity.PlayerEntity;
 import se.llbit.chunky.entity.Poseable;
+import se.llbit.chunky.plugin.API;
 import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.renderer.renderdump.RenderDump;
@@ -3064,10 +3065,12 @@ public class Scene implements JsonSerializable, Refreshable {
     this.octreeImplementation = octreeImplementation;
   }
 
+  @API
   public Octree getWorldOctree() {
     return worldOctree;
   }
 
+  @API
   public Octree getWaterOctree() {
     return waterOctree;
   }

--- a/chunky/src/java/se/llbit/math/BVH.java
+++ b/chunky/src/java/se/llbit/math/BVH.java
@@ -17,7 +17,7 @@
  */
 package se.llbit.math;
 
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.math.primitive.MutableAABB;
 import se.llbit.math.primitive.Primitive;
 
@@ -45,7 +45,7 @@ public class BVH {
     SAH_MA,
   }
 
-  @API
+  @PluginApi
   public static abstract class Node {
     public final AABB bb;
     public final Primitive[] primitives;
@@ -73,7 +73,7 @@ public class BVH {
     abstract public int size();
   }
 
-  @API
+  @PluginApi
   public static class Group extends Node {
     public final Node child1;
     public final Node child2;
@@ -127,7 +127,7 @@ public class BVH {
     }
   }
 
-  @API
+  @PluginApi
   public static class Leaf extends Node {
 
     public Leaf(Primitive[] primitives) {

--- a/chunky/src/java/se/llbit/math/BVH.java
+++ b/chunky/src/java/se/llbit/math/BVH.java
@@ -127,7 +127,7 @@ public class BVH {
   }
 
 
-  static class Leaf extends Node {
+  public static class Leaf extends Node {
 
     public Leaf(Primitive[] primitives) {
       super(primitives);

--- a/chunky/src/java/se/llbit/math/BVH.java
+++ b/chunky/src/java/se/llbit/math/BVH.java
@@ -45,7 +45,7 @@ public class BVH {
     SAH_MA,
   }
 
-  @PluginApi
+  /** Note: this is public for some plugins. Stability is not guaranteed. */
   public static abstract class Node {
     public final AABB bb;
     public final Primitive[] primitives;
@@ -73,7 +73,7 @@ public class BVH {
     abstract public int size();
   }
 
-  @PluginApi
+  /** Note: this is public for some plugins. Stability is not guaranteed. */
   public static class Group extends Node {
     public final Node child1;
     public final Node child2;
@@ -127,7 +127,7 @@ public class BVH {
     }
   }
 
-  @PluginApi
+  /** Note: this is public for some plugins. Stability is not guaranteed. */
   public static class Leaf extends Node {
 
     public Leaf(Primitive[] primitives) {

--- a/chunky/src/java/se/llbit/math/BVH.java
+++ b/chunky/src/java/se/llbit/math/BVH.java
@@ -17,6 +17,7 @@
  */
 package se.llbit.math;
 
+import se.llbit.chunky.plugin.API;
 import se.llbit.math.primitive.MutableAABB;
 import se.llbit.math.primitive.Primitive;
 
@@ -44,7 +45,7 @@ public class BVH {
     SAH_MA,
   }
 
-
+  @API
   public static abstract class Node {
     public final AABB bb;
     public final Primitive[] primitives;
@@ -72,7 +73,7 @@ public class BVH {
     abstract public int size();
   }
 
-
+  @API
   public static class Group extends Node {
     public final Node child1;
     public final Node child2;
@@ -126,7 +127,7 @@ public class BVH {
     }
   }
 
-
+  @API
   public static class Leaf extends Node {
 
     public Leaf(Primitive[] primitives) {

--- a/chunky/src/java/se/llbit/math/BVH.java
+++ b/chunky/src/java/se/llbit/math/BVH.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2014 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2014-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2014-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -44,9 +45,9 @@ public class BVH {
   }
 
 
-  static abstract class Node {
-    protected final AABB bb;
-    protected final Primitive[] primitives;
+  public static abstract class Node {
+    public final AABB bb;
+    public final Primitive[] primitives;
 
     /**
      * Create a new BVH node.
@@ -72,9 +73,9 @@ public class BVH {
   }
 
 
-  static class Group extends Node {
-    protected final Node child1;
-    protected final Node child2;
+  public static class Group extends Node {
+    public final Node child1;
+    public final Node child2;
     private final int numPrimitives;
 
     /**
@@ -538,4 +539,7 @@ public class BVH {
     return root.bb.hitTest(ray) && root.anyIntersection(ray);
   }
 
+  public Node getRoot() {
+    return root;
+  }
 }

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -43,8 +43,8 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
    *    and the lower 32 bits are the node data (that way, for a leaf node the sign bit will be set
    *    and the long can simply be compared with 0 to determine if it is a branch or a leaf)
    *
+   * Note: This is public for some plugins. Stability is not guaranteed.
    */
-  @PluginApi
   public ArrayList<long[]> treeData = new ArrayList<>();
 
   /**

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -18,6 +18,7 @@ package se.llbit.math;
 
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.plugin.API;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -43,6 +44,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
    *    and the long can simply be compared with 0 to determine if it is a branch or a leaf)
    *
    */
+  @API
   public ArrayList<long[]> treeData = new ArrayList<>();
 
   /**

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -18,7 +18,7 @@ package se.llbit.math;
 
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -44,7 +44,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
    *    and the long can simply be compared with 0 to determine if it is a branch or a leaf)
    *
    */
-  @API
+  @PluginApi
   public ArrayList<long[]> treeData = new ArrayList<>();
 
   /**

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2020-2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.math;
 
 import se.llbit.chunky.block.UnknownBlock;
@@ -27,7 +43,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
    *    and the long can simply be compared with 0 to determine if it is a branch or a leaf)
    *
    */
-  private ArrayList<long[]> treeData = new ArrayList<>();
+  public ArrayList<long[]> treeData = new ArrayList<>();
 
   /**
    * The max size of an array we allow is a bit less than the max value an integer can have

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -30,6 +30,7 @@ import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.model.TexturedBlockModel;
 import se.llbit.chunky.model.WaterModel;
+import se.llbit.chunky.plugin.API;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 import se.llbit.log.Log;
@@ -780,6 +781,7 @@ public class Octree {
     tempFile.delete();
   }
 
+  @API
   public OctreeImplementation getImplementation() {
     return implementation;
   }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -780,6 +780,10 @@ public class Octree {
     tempFile.delete();
   }
 
+  public OctreeImplementation getImplementation() {
+    return implementation;
+  }
+
   public static void addImplementationFactory(String name, ImplementationFactory factory) {
     factories.put(name, factory);
   }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -30,7 +30,7 @@ import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.model.TexturedBlockModel;
 import se.llbit.chunky.model.WaterModel;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.world.Material;
 import se.llbit.log.Log;
@@ -781,7 +781,7 @@ public class Octree {
     tempFile.delete();
   }
 
-  @API
+  @PluginApi
   public OctreeImplementation getImplementation() {
     return implementation;
   }

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -19,6 +19,7 @@ package se.llbit.math;
 import org.apache.commons.math3.util.Pair;
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.plugin.API;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -50,6 +51,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * When this occurs this implementation wan no longer be used and we must fallback on another one.
    * Here we'll throw an exception that the caller can catch.
    */
+  @API
   public int[] treeData;
 
   /**

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -50,7 +50,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * When this occurs this implementation wan no longer be used and we must fallback on another one.
    * Here we'll throw an exception that the caller can catch.
    */
-  private int[] treeData;
+  public int[] treeData;
 
   /**
    * The max size of an array we allow is a bit less than the max value an integer can have

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -19,7 +19,7 @@ package se.llbit.math;
 import org.apache.commons.math3.util.Pair;
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.plugin.API;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.world.Material;
 
 import java.io.DataInputStream;
@@ -51,7 +51,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * When this occurs this implementation wan no longer be used and we must fallback on another one.
    * Here we'll throw an exception that the caller can catch.
    */
-  @API
+  @PluginApi
   public int[] treeData;
 
   /**

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -50,8 +50,9 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * When dealing with huge octree, the maximum size of an array may be a limitation.
    * When this occurs this implementation wan no longer be used and we must fallback on another one.
    * Here we'll throw an exception that the caller can catch.
+   *
+   * Note: This is public for some plugins. Stability is not guaranteed.
    */
-  @PluginApi
   public int[] treeData;
 
   /**

--- a/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
+++ b/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
@@ -30,16 +30,18 @@ import se.llbit.math.Vector3;
 public class TexturedTriangle implements Primitive {
 
   private static final double EPSILON = 0.000001;
-  private final Vector3 e1 = new Vector3(0, 0, 0);
-  private final Vector3 e2 = new Vector3(0, 0, 0);
-  private final Vector3 o = new Vector3(0, 0, 0);
-  private final Vector3 n = new Vector3(0, 0, 0);
-  private final AABB bounds;
-  private final Vector2 t1;
-  private final Vector2 t2;
-  private final Vector2 t3;
-  private final Material material;
-  private final boolean doubleSided;
+
+  /** Note: this is public for some plugins. Stability is not guaranteed. */
+  public final Vector3 e1 = new Vector3(0, 0, 0);
+  public final Vector3 e2 = new Vector3(0, 0, 0);
+  public final Vector3 o = new Vector3(0, 0, 0);
+  public final Vector3 n = new Vector3(0, 0, 0);
+  public final AABB bounds;
+  public final Vector2 t1;
+  public final Vector2 t2;
+  public final Vector2 t3;
+  public final Material material;
+  public final boolean doubleSided;
 
   /**
    * @param c1 first corner


### PR DESCRIPTION
This should cover most of the things that are required to hack on a new renderer through a plugin.
 - Added a setter to `Chunky.java` for changing the `RendererFactory`
 - Added accessors for both the world and water octree in `Scene.java`
 - Added a getter for the block palette list in `BlockPalette.java`
 - Added a getter for the octree implementation and made `treeData` public in `PackedOctree.java` and `BigPackedOctree.java`
 - Made the classes in `BVH.java` public and added an accessor for the root node