### PR TITLE
Sky cache bug fixes.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/NishitaSky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/NishitaSky.java
@@ -65,6 +65,8 @@ public class NishitaSky implements SimulatedSky {
       sunIntensity = sun.getIntensity();
 
       this.horizonOffset = horizonOffset;
+      sunPosition.y += horizonOffset;
+      sunPosition.normalize();
 
       return true;
     }
@@ -86,7 +88,8 @@ public class NishitaSky implements SimulatedSky {
     // Render from just above the surface of "earth"
     Vector3 origin = new Vector3(0, ray.o.y + EARTH_RADIUS + 1, 0);
     Vector3 direction = ray.d;
-    direction.y += horizonOffset * (1 - direction.y);
+    direction.y += horizonOffset;
+    direction.normalize();
 
     // Calculate the distance from the origin to the edge of the atmosphere
     double distance = sphereIntersect(origin, direction, EARTH_RADIUS + ATM_THICKNESS);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -427,9 +427,7 @@ public class Sky implements JsonSerializable {
         getSkyDiffuseColorInner(ray);
       }
     }
-    if (scene.sunEnabled) {
-      addSunColor(ray);
-    }
+    addSunColor(ray);
     //ray.color.scale(skyLightModifier);
     ray.color.w = 1;
   }
@@ -439,9 +437,7 @@ public class Sky implements JsonSerializable {
    */
   public void getSkySpecularColor(Ray ray) {
     getSkyColor(ray);
-    if (scene.sunEnabled) {
-      addSunColor(ray);
-    }
+    addSunColor(ray);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SkyCache.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SkyCache.java
@@ -34,8 +34,6 @@ public class SkyCache {
   private SimulatedSky simSky;
   private Sky sky;
 
-  private int version = 0;
-
   /**
    * An on-the-fly sky cache. Automatically calculates sky colors as they are requested and caches them. Any repeat
    * requests will pull from the cache.
@@ -52,25 +50,14 @@ public class SkyCache {
 
   /** Sync this cache with another cache */
   public void syncCache(SkyCache cache) {
-    if (this.skyResolution != cache.skyResolution) {
-      setSkyResolution(cache.skyResolution);
-    }
-
-    if (this.simSky != cache.simSky) {
-      this.simSky = cache.simSky;
-      skyTexture = null;
-    }
-
-    if (this.version != cache.version) {
-      this.version = cache.version;
-      skyTexture = null;
-    }
+    this.skyResolution = cache.skyResolution;
+    this.simSky = cache.simSky;
+    skyTexture = null;
   }
 
   /** Reset the sky cache */
   public void reset(Sky sky) {
     simSky = sky.getSimulatedSky();
-    version += 1;
 
     // Sky has not yet been initialized. No need to reset.
     if (skyTexture == null) {

--- a/chunky/src/java/se/llbit/math/ColorUtil.java
+++ b/chunky/src/java/se/llbit/math/ColorUtil.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2012 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2012-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -272,7 +273,7 @@ public final class ColorUtil {
       hue = (((r - g) / delta) + 4) / 6.0;
     }
 
-    hsl.set(hue, cmax == 0 ? 0 : delta / (1 - FastMath.abs(2*lightness - 1)), lightness);
+    hsl.set(hue, delta < Ray.EPSILON ? 0 : delta / (1 - FastMath.abs(2*lightness - 1)), lightness);
   }
 
   public static Vector3 RGBtoHSL(double r, double g, double b) {


### PR DESCRIPTION
More aggressive sky cache synchronization, fixed black regions in the sky, fixed Nishita horizon offset. Sun is now drawn if `Draw Sun` is enabled but `Enable Sunlight` is disabled.