### PR TITLE
Fixed freeze on load and added common thread pool.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -213,9 +213,10 @@ public class Chunky {
 
     int exitCode = 0;
     if (cmdline.mode != CommandLineOptions.Mode.NOTHING) {
+      commonThreads = new ForkJoinPool(PersistentSettings.getNumThreads());
+
       Chunky chunky = new Chunky(cmdline.options);
       chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.SNAPSHOT;
-      commonThreads = new ForkJoinPool(PersistentSettings.getNumThreads());
       chunky.loadPlugins();
 
       try {
@@ -330,6 +331,9 @@ public class Chunky {
    * Get the common thread pool.
    */
   public static ForkJoinPool getCommonThreads() {
+    if (commonThreads == null) {
+      commonThreads = new ForkJoinPool(PersistentSettings.getNumThreads());
+    }
     return commonThreads;
   }
 

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Chunky is a Minecraft mapping and rendering tool created byJesper Öqvist (jesper@llbit.se).
@@ -96,6 +97,8 @@ public class Chunky {
   private RenderControlsTabTransformer renderControlsTabTransformer = tabs -> tabs;
   private TabTransformer mainTabTransformer = tabs -> tabs;
   private boolean headless = false;
+
+  private static ForkJoinPool commonThreads;
 
   /**
    * @return The title of the main window. Includes the current version string.
@@ -212,6 +215,7 @@ public class Chunky {
     if (cmdline.mode != CommandLineOptions.Mode.NOTHING) {
       Chunky chunky = new Chunky(cmdline.options);
       chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.SNAPSHOT;
+      commonThreads = new ForkJoinPool(PersistentSettings.getNumThreads());
       chunky.loadPlugins();
 
       try {
@@ -320,6 +324,13 @@ public class Chunky {
       e.printStackTrace();
       return 1;
     }
+  }
+
+  /**
+   * Get the common thread pool.
+   */
+  public static ForkJoinPool getCommonThreads() {
+    return commonThreads;
   }
 
   public synchronized SceneManager getSceneManager() {

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2012-2019 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2012-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -30,6 +31,7 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.ScrollEvent;
 import javafx.stage.PopupWindow;
+import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.map.MapBuffer;
 import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
@@ -53,6 +55,7 @@ import se.llbit.math.Vector3;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * UI component for the 2D world map.
@@ -188,9 +191,10 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     ChunkView mapView = new ChunkView(view);  // Make thread-local copy.
     GraphicsContext gc = canvas.getGraphicsContext2D();
     gc.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
-    // TODO: this can block for a long time, so it should ideally not be done on the JavaFX application thread.
+
+    // `withSceneProtected` may block for a long time here, so submit it to the common thread pool. ChunkyMap must be run on the main thread.
     controller.getChunky().getRenderController().getSceneProvider().withSceneProtected(
-        scene -> ChunkMap.drawViewBounds(gc, mapView, scene));
+            scene -> Platform.runLater(() -> ChunkMap.drawViewBounds(gc, mapView, scene)));
   }
 
   protected synchronized void selectWithinRect() {

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -192,7 +192,6 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
   protected void drawViewBounds(Canvas canvas) {
     ChunkView mapView = new ChunkView(view);  // Make thread-local copy.
     GraphicsContext gc = canvas.getGraphicsContext2D();
-    gc.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
 
     // `withSceneProtected` will block for a long time when a new scene is loaded. This bocks in the JavaFX thread and
     // freezes the user interface. Here we check if there has already been an update scheduled, and if not will schedule
@@ -201,6 +200,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       scheduledUpdate.set(true);
       Chunky.getCommonThreads().submit(() -> controller.getChunky().getRenderController().getSceneProvider().withSceneProtected(
               scene -> Platform.runLater(() -> {
+                gc.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
                 ChunkMap.drawViewBounds(gc, mapView, scene);
                 scheduledUpdate.set(false);
               }


### PR DESCRIPTION
- Added a common thread pool that is accessible through `Chunky.getCommonThreads()`
- Modified existing methods to use this.
- Modified `ChunkMap.drawViewBounds` to wait for scene synchronization on a separate thread (if it is already waiting, subsequent requests do not create new jobs and instead are ignored).
- This fixes #415