### PR TITLE
Ratelimit for javafx refresh when loading chunks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -328,7 +328,7 @@ public class Chunky {
   }
 
   /**
-   * Get the common thread pool.
+   * Get the common thread pool. This should only be used for parallelized processing, not for wait tasks.
    */
   public static ForkJoinPool getCommonThreads() {
     if (commonThreads == null) {

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -55,7 +55,6 @@ import se.llbit.math.Vector3;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * UI component for the 2D world map.
@@ -63,6 +62,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Jesper Öqvist <jesper@llbit.se>
  */
 public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraViewListener {
+  /** Minimum time between JavaFX draws due to chunk updates. */
+  private final long MAX_CHUNK_UPDATE_RATE = 1000/3;
+
   /** Controls the selection area when selecting visible chunks. */
   private static final double CHUNK_SELECT_RADIUS = -8 * 1.4142;
   protected final WorldMapLoader mapLoader;
@@ -101,10 +103,10 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
   private final Canvas canvas;
   private final Canvas mapOverlay;
 
-  volatile boolean repaintQueued = false;
+  private volatile boolean repaintQueued = false;
+  private volatile boolean scheduledUpdate = false;
+  private volatile long lastRedraw = 0;
   private Runnable onViewDragged = () -> {};
-
-  private AtomicBoolean scheduledUpdate = new AtomicBoolean(false);
 
   public ChunkMap(WorldMapLoader loader, ChunkyFxController controller,
       MapView mapView, ChunkSelectionTracker chunkSelection,
@@ -164,10 +166,10 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
   @Override public void chunkUpdated(ChunkPosition chunk) {
     if (view.chunkScale >= 16) {
       mapBuffer.drawTile(mapLoader, chunk, chunkSelection);
+      repaintRatelimited();
     } else {
       regionUpdated(chunk.getRegionPosition());
     }
-    repaintDeferred();
   }
 
   protected final void repaintDirect() {
@@ -186,6 +188,33 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     }
   }
 
+  protected final void repaintRatelimited() {
+    if (lastRedraw == -1) {
+      return;
+    }
+
+    long redrawTime = lastRedraw + MAX_CHUNK_UPDATE_RATE;
+    if (System.currentTimeMillis() < redrawTime) {
+
+      // Prevent redraw from occurring until this is done.
+      lastRedraw = -1;
+
+      Chunky.getCommonThreads().execute(() -> {
+        long delay = redrawTime - System.currentTimeMillis();
+        if (delay > 0) {
+          try { Thread.sleep(delay); }
+          catch (InterruptedException ignored) {}
+        }
+        lastRedraw = System.currentTimeMillis();
+        repaintDeferred();
+      });
+    } else {
+      // No need to be ratelimited, redraw now
+      lastRedraw = System.currentTimeMillis();
+      repaintDeferred();
+    }
+  }
+
   /**
    * Draws a visualization of the 3D camera view on the 2D map.
    */
@@ -196,13 +225,13 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     // `withSceneProtected` will block for a long time when a new scene is loaded. This bocks in the JavaFX thread and
     // freezes the user interface. Here we check if there has already been an update scheduled, and if not will schedule
     // one. Draw view bounds must be run on the JavaFX thread.
-    if (!scheduledUpdate.get()) {
-      scheduledUpdate.set(true);
+    if (!scheduledUpdate) {
+      scheduledUpdate = true;
       Chunky.getCommonThreads().submit(() -> controller.getChunky().getRenderController().getSceneProvider().withSceneProtected(
               scene -> Platform.runLater(() -> {
                 gc.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
                 ChunkMap.drawViewBounds(gc, mapView, scene);
-                scheduledUpdate.set(false);
+                scheduledUpdate = false;
               }
       )));
     }
@@ -297,7 +326,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     if (view.scale < 16) {
       mapBuffer.drawTile(mapLoader, region, chunkSelection);
       mapLoader.regionUpdated(region);
-      repaintDeferred();
+      repaintRatelimited();
     }
   }
 


### PR DESCRIPTION
Currently only methods that are associated with loading chunks are ratelimited. I felt like 3 fps was decent just to show progress without giving the impression that Chunky has crashed, however larger values shouldn't have too big of a performance impact.

Also while I was here I cleaned up some code from my previous pull to just use a `volatile boolean` instead of an `AtomicBoolean`.