### PR TITLE
Fixed Preetham sky rendering bug and sky not being set properly when loading a scene.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreethamSky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreethamSky.java
@@ -94,12 +94,18 @@ public class PreethamSky implements SimulatedSky {
 
   @Override
   public boolean updateSun(Sun sun, double horizonOffset) {
-    if (theta != sun.getAzimuth() || phi != sun.getAltitude() || this.horizonOffset != horizonOffset) {
+    // Clamp sky to be above horizon and follow sun properly
+    double alt = QuickMath.clamp(sun.getAltitude(), 0, PI);
+    if (alt > PI/2) {
+      alt = PI - alt;
+    }
+
+    if (theta != sun.getAzimuth() || phi != alt || this.horizonOffset != horizonOffset) {
       theta = sun.getAzimuth();
-      phi = sun.getAltitude();
+      phi = alt;
       double r = QuickMath.abs(FastMath.cos(phi));
       sw.set(FastMath.cos(theta) * r, FastMath.sin(phi), FastMath.sin(theta) * r);
-      updateSkylightValues(sun.getAltitude());
+      updateSkylightValues(alt);
 
       this.horizonOffset = horizonOffset;
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -644,6 +644,7 @@ public class Sky implements JsonSerializable {
 
         simulatedSkyMode = match.orElseGet(() -> simulatedSkyMode);
         simulatedSkyMode.updateSun(scene.sun(), horizonOffset);
+        skyCache.setSimulatedSkyMode(simulatedSkyMode);
         skyCache.precalculateSky();
         scene.refresh();
         break;


### PR DESCRIPTION
This fixes #840 by clamping the sky's internal sun position to be always above the horizon and follow the sun properly when above the horizon.

The `SkyCache` is now properly set when loading a scene (previously it would always be in `PreethamSky` until the `Sky&fog` menu is opened).