### PR TITLE
Minor optimisations 2

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -58,7 +58,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     RegionChangeWatcher regionWatcher = new RegionChangeWatcher(this, mapView);
 
     // Start worker threads.
-    RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", "3"))];
+    RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", "12"))];
     for (int i = 0; i < regionParsers.length; ++i) {
       regionParsers[i] = new RegionParser(this, regionQueue, mapView);
       regionParsers[i].start();

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -58,7 +58,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     RegionChangeWatcher regionWatcher = new RegionChangeWatcher(this, mapView);
 
     // Start worker threads.
-    RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", "12"))];
+    RegionParser[] regionParsers = new RegionParser[Integer.parseInt(System.getProperty("chunky.mapLoaderThreads", String.valueOf(PersistentSettings.getNumThreads())))];
     for (int i = 0; i < regionParsers.length; ++i) {
       regionParsers[i] = new RegionParser(this, regionQueue, mapView);
       regionParsers[i].start();

--- a/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
@@ -16,10 +16,11 @@
  */
 package se.llbit.chunky.world;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -29,7 +30,7 @@ import java.util.Map;
  */
 public class WorldTexture {
 
-  private final Map<Long, ChunkTexture> map = new HashMap<>();
+  private final Long2ObjectOpenHashMap<ChunkTexture> map = new Long2ObjectOpenHashMap<>();
 
   /**
    * Timestamp of last serialization.

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -21,9 +21,9 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
 import org.apache.commons.math3.util.FastMath;
 
-import org.apache.commons.math3.util.Pair;
 import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.Water;
@@ -67,7 +67,7 @@ public class Octree {
     int getData(NodeId node);
     default void startFinalization() {}
     default void endFinalization() {}
-    default Pair<NodeId, Integer> getWithLevel(int x, int y, int z) {
+    default IntObjectImmutablePair<NodeId> getWithLevel(int x, int y, int z) {
       NodeId node = getRoot();
       int level = getDepth();
       while(isBranch(node)) {
@@ -77,7 +77,7 @@ public class Octree {
         int lz = z >>> level;
         node = getChild(node, (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)));
       }
-      return new Pair<>(node, level);
+      return new IntObjectImmutablePair<>(level, node);
     }
   }
 
@@ -496,9 +496,9 @@ public class Octree {
       if (lx != 0 || ly != 0 || lz != 0)
         return false; // outside of octree!
 
-      Pair<NodeId, Integer> nodeAndLevel = implementation.getWithLevel(x, y, z);
-      NodeId node = nodeAndLevel.getFirst();
-      int level = nodeAndLevel.getSecond();
+      IntObjectImmutablePair<NodeId> nodeAndLevel = implementation.getWithLevel(x, y, z);
+      NodeId node = nodeAndLevel.right();
+      int level = nodeAndLevel.leftInt();
 
       lx = x >>> level;
       ly = y >>> level;
@@ -628,9 +628,9 @@ public class Octree {
         return false; // outside of octree!
 
       // Descend the tree to find the current leaf node
-      Pair<NodeId, Integer> nodeAndLevel = implementation.getWithLevel(x, y, z);
-      NodeId node = nodeAndLevel.getFirst();
-      int level = nodeAndLevel.getSecond();
+      IntObjectImmutablePair<NodeId> nodeAndLevel = implementation.getWithLevel(x, y, z);
+      NodeId node = nodeAndLevel.right();
+      int level = nodeAndLevel.leftInt();
 
       lx = x >>> level;
       ly = y >>> level;

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -68,7 +68,7 @@ public class Octree {
     int getData(NodeId node);
     default void startFinalization() {}
     default void endFinalization() {}
-    default void getWithLevel(IntIntMutablePair typeAndLevel, int x, int y, int z) {
+    default void getWithLevel(IntIntMutablePair outTypeAndLevel, int x, int y, int z) {
       NodeId node = getRoot();
       int level = getDepth();
       while(isBranch(node)) {
@@ -78,7 +78,7 @@ public class Octree {
         int lz = z >>> level;
         node = getChild(node, (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1)));
       }
-      typeAndLevel.right(level).left(getType(node));
+      outTypeAndLevel.right(level).left(getType(node));
     }
   }
 

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.math;
 
+import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
 import org.apache.commons.math3.util.Pair;
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
@@ -371,7 +372,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * x, y, z are in octree coordinates, NOT world coordinates.
    */
   @Override
-  public Pair<Octree.NodeId, Integer> getWithLevel(int x, int y, int z) {
+  public IntObjectImmutablePair<Octree.NodeId> getWithLevel(int x, int y, int z) {
     int nodeIndex = 0;
     int level = depth;
     while(treeData[nodeIndex] > 0) {
@@ -381,7 +382,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int lz = z >>> level;
       nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1));
     }
-    return new Pair<>(new NodeId(nodeIndex), level);
+    return new IntObjectImmutablePair<>(level, new NodeId(nodeIndex));
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.math;
 
+import it.unimi.dsi.fastutil.ints.IntIntMutablePair;
 import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
 import org.apache.commons.math3.util.Pair;
 import se.llbit.chunky.block.UnknownBlock;
@@ -135,6 +136,10 @@ public class PackedOctree implements Octree.OctreeImplementation {
   @Override
   public int getType(Octree.NodeId node) {
     return -treeData[((NodeId) node).nodeIndex];
+  }
+
+  private int getTypeFromIndex(int nodeIndex) {
+    return -treeData[nodeIndex];
   }
 
   @Override
@@ -372,7 +377,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    * x, y, z are in octree coordinates, NOT world coordinates.
    */
   @Override
-  public IntObjectImmutablePair<Octree.NodeId> getWithLevel(int x, int y, int z) {
+  public void getWithLevel(IntIntMutablePair typeAndLevel, int x, int y, int z) {
     int nodeIndex = 0;
     int level = depth;
     while(treeData[nodeIndex] > 0) {
@@ -382,7 +387,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int lz = z >>> level;
       nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1));
     }
-    return new IntObjectImmutablePair<>(level, new NodeId(nodeIndex));
+    typeAndLevel.left(getTypeFromIndex(nodeIndex)).right(level);
   }
 
   /**

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -374,7 +374,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
    *
    * @param outTypeAndLevel is the reusable output type and level parameters, this is to save on allocation of {@code org.apache.commons.math3.util.Pair} and {@code PackedOctree.NodeId}
    *
-   * @param x,y,z are in octree coordinates, NOT world coordinates.
+   * x, y, z are in octree coordinates, NOT world coordinates.
    */
   @Override
   public void getWithLevel(IntIntMutablePair outTypeAndLevel, int x, int y, int z) {

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -372,12 +372,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
   /**
    * Gets a NodeID and depth of the node that is (or contains) the specified block.
    *
-   * Note: The creation of the Pair\<\> object seems to be a major time consumer in the actual tracing algorithm. (called from Octree.enterBlock)
+   * @param outTypeAndLevel is the reusable output type and level parameters, this is to save on allocation of {@code org.apache.commons.math3.util.Pair} and {@code PackedOctree.NodeId}
    *
-   * x, y, z are in octree coordinates, NOT world coordinates.
+   * @param x,y,z are in octree coordinates, NOT world coordinates.
    */
   @Override
-  public void getWithLevel(IntIntMutablePair typeAndLevel, int x, int y, int z) {
+  public void getWithLevel(IntIntMutablePair outTypeAndLevel, int x, int y, int z) {
     int nodeIndex = 0;
     int level = depth;
     while(treeData[nodeIndex] > 0) {
@@ -387,7 +387,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
       int lz = z >>> level;
       nodeIndex = treeData[nodeIndex] + (((lx & 1) << 2) | ((ly & 1) << 1) | (lz & 1));
     }
-    typeAndLevel.left(getTypeFromIndex(nodeIndex)).right(level);
+    outTypeAndLevel.left(getTypeFromIndex(nodeIndex)).right(level);
   }
 
   /**


### PR DESCRIPTION
Some random optimisations I saw looking through the codebase

In my testing outside of the chunky environment (in a similar use-case), there is so much noise in results inside chunky that it's probably unreasonable to draw any conclusions from such small tweaks
The `Pair` implementation is ~9% faster
The `HashMap` implementation is ~7% faster