### PR TITLE
Automatically load backup scene description files

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/SceneHelper.java
+++ b/chunky/src/java/se/llbit/chunky/main/SceneHelper.java
@@ -34,7 +34,7 @@ public class SceneHelper {
    */
   public static List<File> getAvailableSceneFiles(File sceneDir) {
     //Get all the files with either a .json extension or get all directories in the given folder since scenes can be held in directories now.
-    File[] sceneList = sceneDir.listFiles((dir, name) ->  name.endsWith(Scene.EXTENSION) || new File(dir, name).isDirectory());
+    File[] sceneList = sceneDir.listFiles((dir, name) ->  name.endsWith(Scene.EXTENSION)  || name.endsWith(Scene.EXTENSION + ".backup")|| new File(dir, name).isDirectory());
     if (sceneList == null) {
       return Collections.emptyList();
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -484,7 +484,13 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public synchronized void loadScene(RenderContext context, String sceneName, TaskTracker taskTracker)
       throws IOException {
-    loadDescription(context.getSceneDescriptionInputStream(sceneName));
+    try {
+      loadDescription(context.getSceneDescriptionInputStream(sceneName));
+    } catch (FileNotFoundException e) {
+      // scene.json not found, try loading the backup file
+      Log.info("Scene description file not found, trying to load the backup file instead", e);
+      loadDescription(context.getSceneFileInputStream(sceneName + Scene.EXTENSION + ".backup"));
+    }
 
     if (sdfVersion < SDF_VERSION) {
       Log.warn("Old scene version detected! The scene may not have been loaded correctly.");

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -205,7 +205,9 @@ public class SceneChooserController implements Initializable {
     private final File sceneDirectory;
 
     private SceneListItem(JsonObject scene, File sceneFile) {
-      sceneName = sceneFile.getName().substring(0, sceneFile.getName().length() - Scene.EXTENSION.length());
+      sceneName = sceneFile.getName().substring(0, sceneFile.getName().length() - (
+          sceneFile.getName().endsWith(".backup") ? 7 + Scene.EXTENSION.length()
+              : Scene.EXTENSION.length()));
       sceneDirectory = sceneFile.getParentFile();
       chunkSize = scene.get("chunkList").array().size();
       dimensions = String.format("%sx%s", scene.get("width").intValue(400), scene.get("height").intValue(400));


### PR DESCRIPTION
… if the scene description file doesn't exist. Also show them in the scene chooser dialog.

This should make scenes that fail to save not just disappear anymore. Fixes #829 