### PR TITLE
Reduce aliasing artifacts from fit-to-screen.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -313,8 +313,8 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     layout();
 
     if (fitToScreen) {
-      setVvalue((getVmin() + getVmax())/2);
-      setHvalue((getHmin() + getHmax())/2);
+      setVvalue(0.5);
+      setHvalue(0.5);
     } else {
       double scaleX = canvas.getScaleX();
       double scrollX = getHvalue();
@@ -349,7 +349,10 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     double scaleX = fitWidth / width;
     double scaleY = fitHeight / height;
 
-    updateCanvasScale(Math.min(scaleX, scaleY) * 0.95);
+    double scale = Math.min(scaleX, scaleY);
+    scale = Math.floor(scale * 0.99 * 8) / 8;
+
+    updateCanvasScale(scale);
   }
 
   @Override public void repaint() {


### PR DESCRIPTION
When the view window and canvas sizes aren't a good ratio, there are aliasing artifacts. (Image works best fullscreen, notice the repeated grid-like aliasing and smeared pixels).
![image](https://user-images.githubusercontent.com/42661490/111242606-bca1d380-85bc-11eb-82c4-23c5f2c044bf.png)

This fixes it by rounding the scale ratio down to the nearest 12.5% (1/8) which reduces artifacts while still allowing a reasonable range in scales.
![image](https://user-images.githubusercontent.com/42661490/111242799-1d311080-85bd-11eb-995c-48b396a738ef.png)
