### PR TITLE
Fix null pointer exception when chunk loading times out.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -904,8 +904,13 @@ public class Scene implements JsonSerializable, Refreshable {
 
         try {
           nextChunkDataTask.get(50, TimeUnit.MILLISECONDS);
-        } catch(TimeoutException | InterruptedException ignored) { // If except, load the chunk synchronously
-          System.out.println(ignored.getCause().getMessage());
+        } catch(TimeoutException | InterruptedException logged) { // If except, load the chunk synchronously
+          if (logged instanceof TimeoutException) {
+            Log.info("Chunk loading timed out.");
+          } else {
+            Log.warn("Chunky loading interrupted.", logged);
+          }
+
           if(usingFirstChunkData) {
             world.getChunk(chunkPositions[i]).getChunkData(chunkData1, palette);
           }


### PR DESCRIPTION
Previously when chunk loading times out, `System.out.println(ignored.getCause().getMessage());` is called. However, `ignored.getCause()` returns null for timeout exceptions. I changed it to be more clear in logging and to use the `Log` utility instead of printing it to `stdout`. This should fix #853.