### PR TITLE
Better dump merging UX.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
@@ -138,11 +138,15 @@ public class RenderManager extends AbstractRenderManager implements Renderer {
             finalizeAllFrames = scene.shouldFinalizeBuffer();
             updateRenderState(scene);
             if (reason == ResetReason.SCENE_LOADED) {
+              // Make sure frame is finalized
+              bufferedScene.postProcessFrame(renderTask);
+
               // Swap buffers so the render canvas will see the current frame.
               bufferedScene.swapBuffers();
 
-              // Notify the scene listeners (this triggers a canvas repaint).
+              // Notify the scene listeners.
               sendSceneStatus(bufferedScene.sceneStatus());
+              canvas.repaint();
             }
           });
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/DumpFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/DumpFormat.java
@@ -72,12 +72,16 @@ abstract class DumpFormat {
 
   public void merge(DataInputStream inputStream, Scene scene, TaskTracker taskTracker)
       throws IOException, IllegalStateException {
-    try (TaskTracker.Task task = taskTracker.task("Merging render dump", scene.canvasWidth() * scene.canvasHeight())) {
+    try (TaskTracker.Task task = taskTracker.task("Merging render dump", scene.canvasHeight())) {
+      int width = scene.canvasWidth();
       int previousSpp = scene.spp;
       long previousRenderTime = scene.renderTime;
 
       readHeader(inputStream, scene);
-      mergeSamples(inputStream, previousSpp, scene, task::update);
+      mergeSamples(inputStream, previousSpp, scene, prog -> {
+        if (prog % width == 0)
+          task.update(width);
+      });
       scene.spp += previousSpp;
       scene.renderTime += previousRenderTime;
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/DumpFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/DumpFormat.java
@@ -80,7 +80,7 @@ abstract class DumpFormat {
       readHeader(inputStream, scene);
       mergeSamples(inputStream, previousSpp, scene, prog -> {
         if (prog % width == 0)
-          task.update(width);
+          task.update(prog/width);
       });
       scene.spp += previousSpp;
       scene.renderTime += previousRenderTime;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1914,20 +1914,23 @@ public class Scene implements JsonSerializable, Refreshable {
    * <p>This is normally done by the render workers during rendering,
    * but in some cases an separate post processing pass is needed.
    */
+  public void postProcessFrame(TaskTracker.Task task) {
+    task.update("Finalizing frame", width, 0);
+    AtomicInteger done = new AtomicInteger(0);
+    Chunky.getCommonThreads().submit(() -> {
+      IntStream.range(0, width).parallel().forEach(x -> {
+        for (int y = 0; y < height; y++) {
+          finalizePixel(x, y);
+        }
+
+        task.update(width, done.incrementAndGet());
+      });
+    }).join();
+  }
+
   public void postProcessFrame(TaskTracker taskTracker) {
     try (TaskTracker.Task task = taskTracker.task("Finalizing frame")) {
-      AtomicInteger done = new AtomicInteger(0);
-      Chunky.getCommonThreads().submit(() -> {
-        IntStream.range(0, width).parallel().forEach(x -> {
-          for (int y = 0; y < height; y++) {
-            finalizePixel(x, y);
-          }
-
-          task.update(width, done.incrementAndGet());
-        });
-      }).get();
-    } catch (InterruptedException | ExecutionException e) {
-      Log.error("Finalizing frame failed", e);
+      postProcessFrame(task);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -249,13 +249,14 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
    */
   protected void mergeDump(File dumpFile) {
     synchronized (scene) {
-      renderer.withSampleBufferProtected((samples, width, height) ->{
+      renderer.withSampleBufferProtected((samples, width, height) -> {
         if (width != scene.width || height != scene.height) {
           throw new Error("Failed to merge render dump - wrong canvas size.");
         }
         scene.mergeDump(dumpFile, taskTracker);
       });
       scene.setResetReason(ResetReason.SCENE_LOADED);
+      scene.pauseRender();
     }
   }
 


### PR DESCRIPTION
- Merging through the GUI makes more sense (you can now merge even if the render is not started, merged frame will be displayed after merging is finished).
- Fixed merging task tracker lag (Apparently `Platform.runLater` does not being spammed with millions of tasks`).
- Improved CLI merging speed.