### PR TITLE
Improved water world mode

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -19,6 +19,8 @@ import java.util.List;
 public class Water extends MinecraftBlockTranslucent {
 
   public static final Water INSTANCE = new Water(0);
+
+  public static final double TOP_BLOCK_GAP = 0.125;
   
   // Used only as starting material when camera is submerged.
   public static final Water OCEAN_WATER = new Water(0, 1 << Water.FULL_BLOCK);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -111,7 +111,7 @@ public class PreviewRayTracer implements RayTracer {
 
   private static boolean waterIntersection(Scene scene, Ray ray) {
     if (ray.d.y < 0) {
-      double t = (scene.getWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
+      double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
@@ -121,7 +121,7 @@ public class PreviewRayTracer implements RayTracer {
       }
     }
     if (ray.d.y > 0) {
-      double t = (scene.getWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
+      double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -19,11 +19,10 @@ package se.llbit.chunky.renderer.scene;
 import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.MinecraftBlock;
 import se.llbit.chunky.block.Water;
-import se.llbit.chunky.model.WaterModel;
 import se.llbit.chunky.renderer.WorkerState;
-import se.llbit.chunky.world.BlockData;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
 
 /**
  * @author Jesper Öqvist <jesper@llbit.se>
@@ -92,7 +91,7 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.sky().cloudsEnabled()) {
       hit = scene.sky().cloudIntersection(scene, ray);
     }
-    if (scene.waterHeight > 0) {
+    if (scene.isWaterPlaneEnabled()) {
       hit = waterIntersection(scene, ray) || hit;
     }
     if (scene.intersect(ray)) {
@@ -112,7 +111,7 @@ public class PreviewRayTracer implements RayTracer {
 
   private static boolean waterIntersection(Scene scene, Ray ray) {
     if (ray.d.y < 0) {
-      double t = (scene.waterHeight - .125 - ray.o.y - scene.origin.y) / ray.d.y;
+      double t = (scene.getWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
@@ -122,7 +121,7 @@ public class PreviewRayTracer implements RayTracer {
       }
     }
     if (ray.d.y > 0) {
-      double t = (scene.waterHeight - .125 - ray.o.y - scene.origin.y) / ray.d.y;
+      double t = (scene.getWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -133,26 +133,60 @@ public class PreviewRayTracer implements RayTracer {
     return false;
   }
 
+  // Chunk pattern config
+  private static final double chunkPatternLineWidth = 0.5; // in blocks
+  private static final double chunkPatternLinePosition = 8 - chunkPatternLineWidth / 2;
+  private static final Vector4 chunkPatternFillColor =
+    new Vector4(0.8, 0.8, 0.8, 1.0);
+  private static final Vector4 chunkPatternLineColor =
+    new Vector4(0.25, 0.25, 0.25, 1.0);
+  private static final Vector4 chunkPatternFillColorSubmerged =
+    new Vector4(0.6, 0.6, 0.8, 1.0);
+  private static final Vector4 chunkPatternLineColorSubmerged =
+    new Vector4(0.05, 0.05, 0.25, 1.0);
+  private static final double chunkPatternInsideOctreeColorFactor = 0.75;
+
+  /**
+   * Projects a chunk border pattern onto the bottom plane of the octree (yMin).
+   * Changes colors for chunks inside the octree and submerged scenes.
+   * Use only in preview mode - the ray should hit the sky in a real render.
+   */
   private static boolean mapIntersection(Scene scene, Ray ray) {
-    if (ray.d.y < 0) {
-      double t = (scene.waterHeight - .125 - ray.o.y - scene.origin.y) / ray.d.y;
+    if (ray.d.y < 0) { // ray going below horizon
+      double t = (scene.yMin - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         Vector3 vec = new Vector3();
         vec.scaleAdd(t + Ray.OFFSET, ray.d, ray.o);
-        if (!scene.isInsideOctree(vec)) {
-          ray.t = t;
-          ray.o.set(vec);
-          double xm = (ray.o.x % 16.0 + 16.0) % 16.0;
-          double zm = (ray.o.z % 16.0 + 16.0) % 16.0;
-          if (xm > 0.6 && zm > 0.6) {
-            ray.color.set(0.8, 0.8, 0.8, 1);
+        // must be submerged if water plane is enabled otherwise ray already had collided with water
+        boolean isSubmerged = scene.isWaterPlaneEnabled();
+        boolean insideOctree = scene.isInsideOctree(vec);
+        ray.t = t;
+        ray.o.set(vec);
+        double xm = ((ray.o.x) % 16.0 + 16.0) % 16.0;
+        double zm = ((ray.o.z) % 16.0 + 16.0) % 16.0;
+        if (
+          (xm < chunkPatternLinePosition || xm > chunkPatternLinePosition + chunkPatternLineWidth) &&
+            (zm < chunkPatternLinePosition || zm > chunkPatternLinePosition + chunkPatternLineWidth)
+        ) { // chunk fill
+          if (isSubmerged) {
+            ray.color.set(chunkPatternFillColorSubmerged);
           } else {
-            ray.color.set(0.25, 0.25, 0.25, 1);
+            ray.color.set(chunkPatternFillColor);
           }
-          ray.setCurrentMaterial(MinecraftBlock.STONE);
-          ray.n.set(0, 1, 0);
-          return true;
+        } else { // chunk border
+          if (isSubmerged) {
+            ray.color.set(chunkPatternLineColorSubmerged);
+          } else {
+            ray.color.set(chunkPatternLineColor);
+          }
         }
+        if(insideOctree) {
+          ray.color.scale(chunkPatternInsideOctreeColorFactor);
+        }
+        // handle like a solid horizontal plane
+        ray.setCurrentMaterial(MinecraftBlock.STONE);
+        ray.n.set(0, 1, 0);
+        return true;
       }
     }
     return false;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -235,9 +235,11 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   protected double waterOpacity = PersistentSettings.getWaterOpacity();
   protected double waterVisibility = PersistentSettings.getWaterVisibility();
-  protected int waterHeight = PersistentSettings.getWaterHeight();
   protected boolean stillWater = PersistentSettings.getStillWater();
   protected boolean useCustomWaterColor = PersistentSettings.getUseCustomWaterColor();
+
+  protected int waterHeight = 0;
+
   /**
    * Enables fast fog algorithm
    */

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1732,9 +1732,6 @@ public class Scene implements JsonSerializable, Refreshable {
    * Set the water world mode ocean height.
    */
   public void setWaterPlaneHeight(double height) {
-    // do we really want to limit this?
-    height = Math.max(yMin, height);
-    height = Math.min(yMax, height);
     if (height != waterPlaneHeight) {
       waterPlaneHeight = height;
       refresh();
@@ -1745,17 +1742,16 @@ public class Scene implements JsonSerializable, Refreshable {
    * @return The water world mode ocean height
    */
   public double getWaterPlaneHeight() {
+    return waterPlaneHeight;
+  }
+  /**
+   * @return The effective water world mode ocean height influenced by waterPlaneOffsetEnabled
+   */
+  public double getEffectiveWaterPlaneHeight() {
     if(waterPlaneOffsetEnabled) {
       return waterPlaneHeight - Water.TOP_BLOCK_GAP;
     } else {
       return waterPlaneHeight;
-    }
-  }
-  public double getWaterPlaneHeight(boolean withoutOffset) {
-    if(withoutOffset) {
-      return waterPlaneHeight;
-    } else {
-      return getWaterPlaneHeight();
     }
   }
 
@@ -2430,7 +2426,7 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   public boolean isInWater(Ray ray) {
-    if (isWaterPlaneEnabled() && ray.o.y < getWaterPlaneHeight()) {
+    if (isWaterPlaneEnabled() && ray.o.y < getEffectiveWaterPlaneHeight()) {
       return true;
     }
     if (waterOctree.isInside(ray.o)) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -126,8 +126,6 @@ import java.util.zip.GZIPOutputStream;
  */
 public class Scene implements JsonSerializable, Refreshable {
 
-  private static final byte[] DUMP_FORMAT_MAGIC_NUMBER = {0x44, 0x55, 0x4D, 0x50};
-  private static final int DUMP_FORMAT_VERSION = 1;
   public static final int DEFAULT_DUMP_FREQUENCY = 500;
   public static final String EXTENSION = ".json";
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -118,12 +118,8 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     stillWater.selectedProperty()
         .addListener((observable, oldValue, newValue) -> scene.setStillWater(newValue));
 
-    int initialWaterHeight = PersistentSettings.getWaterHeight();
-    if (initialWaterHeight == 0) {
-      initialWaterHeight = World.SEA_LEVEL;
-    }
     waterHeight.textProperty().bindBidirectional(waterHeightProp, new NumberStringConverter());
-    waterHeightProp.set(initialWaterHeight);
+    waterHeightProp.set(World.SEA_LEVEL);
     waterHeightProp.addListener((observable, oldValue, newValue) -> {
       if (waterPlane.isSelected()) {
         scene.setWaterHeight(newValue.intValue());
@@ -153,7 +149,6 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       PersistentSettings.setStillWater(scene.stillWaterEnabled());
       PersistentSettings.setWaterOpacity(scene.getWaterOpacity());
       PersistentSettings.setWaterVisibility(scene.getWaterVisibility());
-      PersistentSettings.setWaterHeight(scene.getWaterHeight());
       boolean useCustomWaterColor = scene.getUseCustomWaterColor();
       PersistentSettings.setUseCustomWaterColor(useCustomWaterColor);
       if (useCustomWaterColor) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -86,7 +86,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
 
     waterPlaneEnabled.setSelected(scene.isWaterPlaneEnabled());
     waterPlaneHeight.setRange(scene.yClipMin, scene.yClipMax);
-    waterPlaneHeight.set(scene.getWaterPlaneHeight(true));
+    waterPlaneHeight.set(scene.getWaterPlaneHeight());
     waterPlaneOffsetEnabled.setSelected(scene.isWaterPlaneOffsetEnabled());
   }
 
@@ -142,12 +142,12 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneEnabled(newValue)
     );
+
     waterPlaneHeight.setName("Water height");
     waterPlaneHeight.setTooltip("The default ocean height is " + World.SEA_LEVEL + ".");
     waterPlaneHeight.clampBoth();
     waterPlaneHeight.onValueChange(value -> scene.setWaterPlaneHeight(value));
-    Slider slider = waterPlaneHeight.getSlider();
-    slider.setBlockIncrement(0.5);
+
     waterPlaneOffsetEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneOffsetEnabled(newValue)
     );

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -16,19 +16,13 @@
  */
 package se.llbit.chunky.ui.render;
 
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.TextField;
-import javafx.scene.control.Tooltip;
-import javafx.util.converter.NumberStringConverter;
+import javafx.scene.control.*;
+import javafx.scene.paint.Color;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.RenderController;
 import se.llbit.chunky.renderer.scene.Scene;
@@ -49,20 +43,20 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
   @FXML private CheckBox stillWater;
   @FXML private DoubleAdjuster waterVisibility;
   @FXML private DoubleAdjuster waterOpacity;
-  @FXML private CheckBox waterPlane;
-  @FXML private TextField waterHeight;
   @FXML private CheckBox useCustomWaterColor;
   @FXML private LuxColorPicker waterColor;
   @FXML private Button saveDefaults;
+  @FXML private CheckBox waterPlaneEnabled;
+  @FXML private DoubleAdjuster waterPlaneHeight;
+  @FXML private CheckBox waterPlaneOffsetEnabled;
 
-  private IntegerProperty waterHeightProp = new SimpleIntegerProperty();
   private RenderControlsFxController renderControls;
   private RenderController controller;
-  private final ChangeListener<javafx.scene.paint.Color> waterColorListener =
-      (observable, oldValue, newValue) -> {
-        scene.setWaterColor(ColorUtil.fromFx(newValue));
-        useCustomWaterColor.setSelected(true);
-      };
+  private final ChangeListener<Color> waterColorListener =
+    (observable, oldValue, newValue) -> {
+      scene.setWaterColor(ColorUtil.fromFx(newValue));
+      useCustomWaterColor.setSelected(true);
+    };
 
   public WaterTab() throws IOException {
     FXMLLoader loader = new FXMLLoader(getClass().getResource("WaterTab.fxml"));
@@ -71,18 +65,15 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     loader.load();
   }
 
-  @Override public void setController(RenderControlsFxController controller) {
+  @Override
+  public void setController(RenderControlsFxController controller) {
     renderControls = controller;
     this.controller = controller.getRenderController();
     scene = this.controller.getSceneManager().getScene();
   }
 
-  @Override public void update(Scene scene) {
-    int waterHeight = scene.getWaterHeight();
-    if (waterHeight != 0) {
-      waterHeightProp.set(scene.getWaterHeight());
-    }
-    waterPlane.setSelected(scene.getWaterHeight() != 0);
+  @Override
+  public void update(Scene scene) {
     useCustomWaterColor.setSelected(scene.getUseCustomWaterColor());
     stillWater.setSelected(scene.stillWaterEnabled());
     waterVisibility.set(scene.getWaterVisibility());
@@ -92,17 +83,25 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterColor.colorProperty().removeListener(waterColorListener);
     waterColor.setColor(ColorUtil.toFx(scene.getWaterColor()));
     waterColor.colorProperty().addListener(waterColorListener);
+
+    waterPlaneEnabled.setSelected(scene.isWaterPlaneEnabled());
+    waterPlaneHeight.setRange(scene.yClipMin, scene.yClipMax);
+    waterPlaneHeight.set(scene.getWaterPlaneHeight(true));
+    waterPlaneOffsetEnabled.setSelected(scene.isWaterPlaneOffsetEnabled());
   }
 
-  @Override public String getTabTitle() {
+  @Override
+  public String getTabTitle() {
     return "Water";
   }
 
-  @Override public Node getTabContent() {
+  @Override
+  public Node getTabContent() {
     return this;
   }
 
-  @Override public void initialize(URL location, ResourceBundle resources) {
+  @Override
+  public void initialize(URL location, ResourceBundle resources) {
     waterVisibility.setName("Water visibility");
     waterVisibility.setTooltip("Visibility depth under water.");
     waterVisibility.setRange(0, 50);
@@ -115,32 +114,13 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterOpacity.clampBoth();
     waterOpacity.onValueChange(value -> scene.setWaterOpacity(value));
 
-    stillWater.selectedProperty()
-        .addListener((observable, oldValue, newValue) -> scene.setStillWater(newValue));
+    stillWater.selectedProperty().addListener((observable, oldValue, newValue) ->
+      scene.setStillWater(newValue)
+    );
 
-    waterHeight.textProperty().bindBidirectional(waterHeightProp, new NumberStringConverter());
-    waterHeightProp.set(World.SEA_LEVEL);
-    waterHeightProp.addListener((observable, oldValue, newValue) -> {
-      if (waterPlane.isSelected()) {
-        scene.setWaterHeight(newValue.intValue());
-      } else {
-        scene.setWaterHeight(0);
-      }
-    });
-
-    waterPlane.setTooltip(
-        new Tooltip("In Water World mode, an infinite ocean surrounds the loaded chunks."));
-    waterPlane.selectedProperty().addListener((observable, oldValue, newValue) -> {
-      if (newValue) {
-        scene.setWaterHeight(waterHeightProp.get());
-      } else {
-        scene.setWaterHeight(0);
-      }
-    });
-
-    useCustomWaterColor.selectedProperty().addListener((observable, oldValue, newValue) -> {
-      scene.setUseCustomWaterColor(newValue);
-    });
+    useCustomWaterColor.selectedProperty().addListener((observable, oldValue, newValue) ->
+      scene.setUseCustomWaterColor(newValue)
+    );
 
     waterColor.colorProperty().addListener(waterColorListener);
 
@@ -156,6 +136,21 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
         PersistentSettings.setWaterColor(color.x, color.y, color.z);
       }
     });
+
+    waterPlaneEnabled.setTooltip(
+      new Tooltip("If enabled, an infinite ocean fills the scene. This ignores air from loaded chunks."));
+    waterPlaneEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
+      scene.setWaterPlaneEnabled(newValue)
+    );
+    waterPlaneHeight.setName("Water height");
+    waterPlaneHeight.setTooltip("The default ocean height is " + World.SEA_LEVEL + ".");
+    waterPlaneHeight.clampBoth();
+    waterPlaneHeight.onValueChange(value -> scene.setWaterPlaneHeight(value));
+    Slider slider = waterPlaneHeight.getSlider();
+    slider.setBlockIncrement(0.5);
+    waterPlaneOffsetEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
+      scene.setWaterPlaneOffsetEnabled(newValue)
+    );
   }
 
 }

--- a/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
@@ -3,10 +3,9 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
@@ -18,22 +17,22 @@
       <CheckBox fx:id="stillWater" mnemonicParsing="false" text="Still water" />
       <DoubleAdjuster fx:id="waterVisibility" />
       <DoubleAdjuster fx:id="waterOpacity" />
-      <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
-        <children>
-          <CheckBox fx:id="waterPlane" mnemonicParsing="false" text="Water Plane" />
-          <Separator orientation="VERTICAL" />
-          <Label text="Water height:" />
-          <TextField fx:id="waterHeight" />
-        </children>
-      </HBox>
-      <Separator prefWidth="200.0" />
       <HBox alignment="CENTER_LEFT" spacing="10.0">
-        <children>
-          <CheckBox fx:id="useCustomWaterColor" mnemonicParsing="false" text="Use custom water color:" />
-          <LuxColorPicker fx:id="waterColor" />
-        </children>
+        <CheckBox fx:id="useCustomWaterColor" mnemonicParsing="false" text="Use custom water color:"/>
+        <LuxColorPicker fx:id="waterColor"/>
       </HBox>
       <Button fx:id="saveDefaults" mnemonicParsing="false" text="Save as defaults" />
+      <Separator prefWidth="200.0" />
+      <CheckBox fx:id="waterPlaneEnabled" mnemonicParsing="false" text="Water world mode" />
+      <TitledPane fx:id="waterWorldModeDetailsPane" text="Water world mode settings">
+        <VBox spacing="10.0">
+          <padding>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+          </padding>
+          <DoubleAdjuster fx:id="waterPlaneHeight" />
+          <CheckBox fx:id="waterPlaneOffsetEnabled" mnemonicParsing="false" text="Lower water by minecraft offset (default)" />
+        </VBox>
+      </TitledPane>
     </children>
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -35,7 +35,6 @@ public final class PersistentSettings {
 
   public static final double DEFAULT_WATER_OPACITY = .42;
   public static final double DEFAULT_WATER_VISIBILITY = 9;
-  public static final int DEFAULT_WATER_HEIGHT = 0;
 
   public static final double DEFAULT_WATER_RED = 0.03;
   public static final double DEFAULT_WATER_GREEN = 0.13;
@@ -303,15 +302,6 @@ public final class PersistentSettings {
 
   public static double getWaterVisibility() {
     return settings.getDouble("waterVisibility", DEFAULT_WATER_VISIBILITY);
-  }
-
-  public static void setWaterHeight(int value) {
-    settings.setInt("waterHeight", value);
-    save();
-  }
-
-  public static int getWaterHeight() {
-    return settings.getInt("waterHeight", DEFAULT_WATER_HEIGHT);
   }
 
   public static void setUseCustomWaterColor(boolean value) {

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -73,10 +73,6 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     return max;
   }
 
-  public Slider getSlider() {
-    return valueSlider;
-  }
-
   /**
    * Make the adjuster use a logarithmic mapping for the slider position.
    */

--- a/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/SliderAdjuster.java
@@ -73,6 +73,10 @@ public abstract class SliderAdjuster<T extends Number> extends Adjuster<T> {
     return max;
   }
 
+  public Slider getSlider() {
+    return valueSlider;
+  }
+
   /**
    * Make the adjuster use a logarithmic mapping for the slider position.
    */


### PR DESCRIPTION
- fixes #854
- unify naming of water world mode
- rework config for the water world mode feature
- allow any water plane height (as a double)
- use slider for the water height
- add checkbox for default minecraft water height offset (-0.125 below full block)
- fallback for older scene files
- remove water plane height from persistent settings
- improve preview chunk grid (blue if submerged, darker grid for chunks in octree)
