### PR TITLE
Fix unnecessary octree resaving.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1969,15 +1969,20 @@ public class Scene implements JsonSerializable, Refreshable {
       task.update(1);
       Log.info("Saving octree " + fileName);
 
+      boolean saved = false;
       try (DataOutputStream out = new DataOutputStream(new FastBufferedOutputStream(new GZIPOutputStream(context.getSceneFileOutputStream(fileName))))) {
         OctreeFileFormat.store(out, worldOctree, waterOctree, palette,
             grassTexture, foliageTexture, waterTexture);
-        worldOctree.setTimestamp(context.fileTimestamp(fileName));
+        saved = true;
 
         task.update(2);
         Log.info("Octree saved");
       } catch (IOException e) {
         Log.warn("Failed to save the octree", e);
+      }
+
+      if (saved) {
+        worldOctree.setTimestamp(context.fileTimestamp(fileName));
       }
     }
   }


### PR DESCRIPTION
Setting the octree last serialization timestamp before the file being written to closed was causing issues with the timestamp being a couple of milliseconds behind. Now, the timestamp is only set after the file is closed if saving completed without error. This fixes #844.