### PR TITLE
Reduce memory usage of sign texture

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -27,10 +27,7 @@ import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.json.JsonParser.SyntaxError;
 import se.llbit.json.JsonValue;
-import se.llbit.math.Quad;
-import se.llbit.math.Transform;
-import se.llbit.math.Vector3;
-import se.llbit.math.Vector4;
+import se.llbit.math.*;
 import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
@@ -64,6 +61,7 @@ public class SignEntity extends Entity {
 
     public final int id;
     public final int rgbColor;
+    public final float[] linearColor;
 
     private static final Map<String, Color> map = new HashMap<>();
 
@@ -89,14 +87,12 @@ public class SignEntity extends Entity {
     Color(int id, int color) {
       this.id = id;
       this.rgbColor = color;
+      this.linearColor = new float[4];
+      ColorUtil.getRGBAComponentsGammaCorrected(rgbColor, linearColor);
     }
 
     public static Color get(String color) {
-      if (map.containsKey(color)) {
-        return map.get(color);
-      } else {
-        return Color.BLACK;
-      }
+      return map.getOrDefault(color, Color.BLACK);
     }
 
     public static Color get(int id) {

--- a/chunky/src/java/se/llbit/chunky/resources/BinaryBitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/BinaryBitmapImage.java
@@ -1,0 +1,55 @@
+/* Copyright (c) 2020-2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.resources;
+
+/**
+ * A image type using 1 bit per pixel
+ */
+public class BinaryBitmapImage {
+  public final int width;
+  public final int height;
+  private final byte[] data;
+
+  public BinaryBitmapImage(int width, int height) {
+    this.width = width;
+    this.height = height;
+    int pixelCount = width*height;
+    int byteCount = (pixelCount + 7) / 8;
+    data = new byte[byteCount];
+  }
+
+  public void setPixel(int x, int y, boolean value) {
+    int index = y * width + x;
+    int byteIndex = index / 8;
+    int bitIndex = index % 8;
+    int bit = 1 << (7 - bitIndex);
+    if(value)
+      // set the bit
+      data[byteIndex] |= bit;
+    else
+      // clear the bit
+      data[byteIndex] &= ~bit;
+  }
+
+  public boolean getPixel(int x, int y) {
+    int index = y * width + x;
+    int byteIndex = index / 8;
+    int bitIndex = index % 8;
+    int bit = 1 << (7 - bitIndex);
+    return (data[byteIndex] & bit) != 0;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/resources/BinaryBitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/BinaryBitmapImage.java
@@ -36,7 +36,7 @@ public class BinaryBitmapImage {
     int index = y * width + x;
     int byteIndex = index / 8;
     int bitIndex = index % 8;
-    int bit = 1 << (7 - bitIndex);
+    int bit = 1 << bitIndex;
     if(value)
       // set the bit
       data[byteIndex] |= bit;
@@ -49,7 +49,7 @@ public class BinaryBitmapImage {
     int index = y * width + x;
     int byteIndex = index / 8;
     int bitIndex = index % 8;
-    int bit = 1 << (7 - bitIndex);
+    int bit = 1 << bitIndex;
     return (data[byteIndex] & bit) != 0;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/PalettizedBitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/PalettizedBitmapImage.java
@@ -17,7 +17,7 @@
 package se.llbit.chunky.resources;
 
 /**
- * A image type using 4 bit per pixel
+ * A image type using 4 bits per pixel, supporting up to 16 colors.
  */
 public class PalettizedBitmapImage {
   public final int width;

--- a/chunky/src/java/se/llbit/chunky/resources/PalettizedBitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/PalettizedBitmapImage.java
@@ -1,0 +1,52 @@
+/* Copyright (c) 2020-2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.resources;
+
+/**
+ * A image type using 4 bit per pixel
+ */
+public class PalettizedBitmapImage {
+  public final int width;
+  public final int height;
+  private final byte[] data;
+
+  public PalettizedBitmapImage(int width, int height) {
+    this.width = width;
+    this.height = height;
+    int pixelCount = width*height;
+    int byteCount = (pixelCount + 1) / 2;
+    data = new byte[byteCount];
+  }
+
+  public void setPixel(int x, int y, int value) {
+    value &= 0xf;
+    int index = y * width + x;
+    int byteIndex = index / 2;
+    int shift = index % 2 * 4;
+    byte mask = (byte) (0xf << shift);
+    data[byteIndex] &= ~mask; // Clear the pixel
+    data[byteIndex] |= value << shift; // Clear the pixel
+  }
+
+  public int getPixel(int x, int y) {
+    int index = y * width + x;
+    int byteIndex = index / 2;
+    int shift = index % 2 * 4;
+    byte mask = (byte) (0xf << shift);
+    return (data[byteIndex] & mask) >> shift;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/resources/SignTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/SignTexture.java
@@ -42,6 +42,14 @@ public class SignTexture extends Texture {
   private final PalettizedBitmapImage textColor;
   private final BinaryBitmapImage textMask;
 
+  static private boolean hasVisibleCharacter(JsonArray line) {
+    for(JsonValue textItem : line) {
+      if(!textItem.object().get("text").stringValue("").trim().isEmpty())
+        return true;
+    }
+    return false;
+  }
+
   public SignTexture(JsonArray[] text, Texture signTexture) {
     this.signTexture = signTexture;
     int ymargin = 1;
@@ -51,7 +59,7 @@ public class SignTexture extends Texture {
     int ystart = ymargin;
     boolean allEmpty = true;
     for(JsonArray line : text) {
-      if(!line.isEmpty()) {
+      if(hasVisibleCharacter(line)) {
         allEmpty = false;
         break;
       }
@@ -110,10 +118,8 @@ public class SignTexture extends Texture {
     int x = (int)(u * 96 - Ray.EPSILON);
     int y = (int) ((1 - v) * 48 - Ray.EPSILON);
     if(textMask != null && textMask.getPixel(x, y)) {
-      float[] result = new float[4];
       Color characterColor = Color.get(textColor.getPixel(x, y));
-      ColorUtil.getRGBAComponentsGammaCorrected(characterColor.rgbColor, result);
-      return result;
+      return characterColor.linearColor;
     } else {
       return signTexture.getColor(u * ww + u0, v * hh + v0);
     }


### PR DESCRIPTION
The way SignTexture works is it has 2 textures, one for the background, shared with all the other signs of the same material, and one texture for the text, unique per sign.
The text texture ends up consuming a lot of memory so I changed the way it is stored, instead of using a 32 bpp bitmap, I'm using a 4 bpp bitmap because the color of sign text is already limited to 16 choices. As I also need to represent transparency, I use an additional 1 bpp bitmap that acts as a mask. So in the end, I am using 5 bits per pixels instead of the 32 initially, dividing by a lit more than 6 the memory usage of those texture.
As an additional optimization, sign that don't contain any text don't have a text texture at all, leading to more savings. This is especially good as sign are often use without text for decoration.
Before the change, the retained memory for one SignTexture was 18 706 bytes. After this change it is 3 117 bytes for a sign with text and only 125 bytes for a sign without text.
With a sign heavy map like greenfield, the gain is substantial, ~3.4GB vs ~2.8GB process memory wise.