### PR TITLE
Update camera controls in Help tab

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -270,14 +270,6 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
           renderScene.camera().moveDown(modifier);
           e.consume();
           break;
-        case J:
-          renderScene.camera().moveBackward(modifier);
-          e.consume();
-          break;
-        case K:
-          renderScene.camera().moveForward(modifier);
-          e.consume();
-          break;
         case SPACE:
           synchronized (renderScene) {
             if (renderScene.getMode() == RenderMode.RENDERING) {

--- a/chunky/src/res/se/llbit/chunky/ui/render/HelpTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/HelpTab.fxml
@@ -12,7 +12,7 @@
       <padding>
          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
       </padding>
-      <Label text="Camera key bindings (standard projection):">
+      <Label text="Camera key bindings:">
          <font>
             <Font name="System Bold" size="12.0"/>
          </font>
@@ -23,8 +23,6 @@
       <Label text="D strafe right"/>
       <Label text="R move up"/>
       <Label text="F move down"/>
-      <Label text="K move forward"/>
-      <Label text="J move backward"/>
       <Label/>
       <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Holding SHIFT makes the basic movement keys move 0.1 of the normal speed." wrappingWidth="251.2109375" />
       <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Holding CTRL makes the basic movement keys move 100 of the normal speed." wrappingWidth="251.2109375" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/HelpTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/HelpTab.fxml
@@ -12,7 +12,7 @@
       <padding>
          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
       </padding>
-      <Label text="Camera key bindings:">
+      <Label text="Camera key bindings (standard projection):">
          <font>
             <Font name="System Bold" size="12.0"/>
          </font>
@@ -23,10 +23,10 @@
       <Label text="D strafe right"/>
       <Label text="R move up"/>
       <Label text="F move down"/>
-      <Label text="U toggle fullscreen mode"/>
-      <Label text="K move forward x100"/>
-      <Label text="J move backward x100"/>
+      <Label text="K move forward"/>
+      <Label text="J move backward"/>
       <Label/>
       <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Holding SHIFT makes the basic movement keys move 0.1 of the normal speed." wrappingWidth="251.2109375" />
+      <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Holding CTRL makes the basic movement keys move 100 of the normal speed." wrappingWidth="251.2109375" />
    </VBox>
 </fx:root>


### PR DESCRIPTION
Camera key bindings work slightly differently with different projections; Controls listed are for standard projection which is typically what people use. Fullscreen has been removed thus `U` does nothing. `K` & `J` only move by 1 unit thus redundant. Added a mention of the `CTRL` modifier key.