### PR TITLE
Clip the torch model to the block box.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/model/TorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/TorchModel.java
@@ -119,24 +119,39 @@ public class TorchModel {
   public static boolean intersect(Ray ray, Texture texture, int rot) {
     boolean hit = false;
     ray.t = Double.POSITIVE_INFINITY;
-    float[] color;
+    float[] color = null;
     Quad[] quads = rot < 5 ? rotatedQuadsWall[rot] : quadsGround;
     for (Quad quad : quads) {
       if (quad.intersect(ray)) {
-        color = texture.getColor(ray.u, ray.v);
-        if (color[3] > Ray.EPSILON) {
-          ray.color.set(color);
+        float[] c = texture.getColor(ray.u, ray.v);
+        if (c[3] > Ray.EPSILON) {
+          color = c;
           ray.n.set(quad.n);
           ray.t = ray.tNext;
           hit = true;
         }
       }
     }
-
     if (hit) {
-      ray.distance += ray.t;
-      ray.o.scaleAdd(ray.t, ray.d);
+      if (rot < 5) {
+        // the wall torch model goes out of the 1x1x1 block range so we need to check if the hit
+        // is actually inside of the block and ignore it if it doesn't
+        double px = ray.o.x - Math.floor(ray.o.x + ray.d.x * Ray.OFFSET) + ray.d.x * ray.tNext;
+        double py = ray.o.y - Math.floor(ray.o.y + ray.d.y * Ray.OFFSET) + ray.d.y * ray.tNext;
+        double pz = ray.o.z - Math.floor(ray.o.z + ray.d.z * Ray.OFFSET) + ray.d.z * ray.tNext;
+        if (px >= 0 && px <= 1 && py >= 0 && py <= 1 && pz >= 0 && pz <= 1) {
+          ray.color.set(color);
+          ray.distance += ray.t;
+          ray.o.scaleAdd(ray.t, ray.d);
+          return true;
+        }
+      } else {
+        ray.color.set(color);
+        ray.distance += ray.t;
+        ray.o.scaleAdd(ray.t, ray.d);
+        return true;
+      }
     }
-    return hit;
+    return false;
   }
 }


### PR DESCRIPTION
Fixes a regression introduced in #877. The wall torch model goes out of the 1x1x1 block box and needs to be "clipped" (i.e. hits outside of the box must be ignored).

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5544859/113587330-ea63c080-962e-11eb-8d24-f721ac301031.png)|![image](https://user-images.githubusercontent.com/5544859/113587360-f780af80-962e-11eb-9c35-db61c45e33b4.png)|