### PR TITLE
Add a y level slider to the map view

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/MapView.java
+++ b/chunky/src/java/se/llbit/chunky/map/MapView.java
@@ -51,7 +51,7 @@ public class MapView {
   public void setMapSize(int width, int height) {
     ChunkView mapView = map.get();
     if (width != mapView.width || height != mapView.height) {
-      map.set(new ChunkView(mapView.x, mapView.z, width, height, mapView.scale));
+      map.set(new ChunkView(mapView.x, mapView.z, width, height, mapView.scale, mapView.yMax));
       notifyViewUpdated();
     }
   }
@@ -76,7 +76,7 @@ public class MapView {
   public synchronized void panTo(double x, double z) {
     ChunkView mapView = map.get();
     map.set(new ChunkView(x, z,
-        mapView.width, mapView.height, mapView.scale));
+        mapView.width, mapView.height, mapView.scale, mapView.yMax));
     notifyViewUpdated();
   }
 
@@ -95,7 +95,7 @@ public class MapView {
     ChunkView mapView = map.get();
     blockScale = ChunkView.clampScale(blockScale);
     if (blockScale != mapView.scale) {
-      map.set(new ChunkView(mapView.x, mapView.z, mapView.width, mapView.height, blockScale));
+      map.set(new ChunkView(mapView.x, mapView.z, mapView.width, mapView.height, blockScale, mapView.yMax));
       notifyViewUpdated();
     }
   }
@@ -127,5 +127,20 @@ public class MapView {
    */
   public ObjectProperty<ChunkView> getMapViewProperty() {
     return map;
+  }
+
+  public int getYMax() {
+    return map.get().yMax;
+  }
+
+  /**
+   * Change the maximum y layer that is shown.
+   */
+  public void setYMax(int yMax) {
+    ChunkView mapView = map.get();
+    if (yMax != mapView.yMax) {
+      map.set(new ChunkView(mapView.x, mapView.z, mapView.width, mapView.height, mapView.scale, yMax));
+      notifyViewUpdated();
+    }
   }
 }

--- a/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
+++ b/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
@@ -49,14 +49,14 @@ public class SurfaceLayer extends BitmapLayer {
    * @param dim current dimension
    * @param chunkData data for the chunk
    */
-  public SurfaceLayer(int dim, ChunkData chunkData, BlockPalette palette) {
+  public SurfaceLayer(int dim, ChunkData chunkData, BlockPalette palette, int yMax) {
     bitmap = new int[Chunk.X_MAX * Chunk.Z_MAX];
     topo = new int[Chunk.X_MAX * Chunk.Z_MAX];
     for (int x = 0; x < Chunk.X_MAX; ++x) {
       for (int z = 0; z < Chunk.Z_MAX; ++z) {
 
         // Find the topmost non-empty block.
-        int y = chunkData.maxY()-1;
+        int y = Math.min(chunkData.maxY() - 1, yMax);
         int minY = chunkData.minY();
         for (; y > minY; --y) {
           if (palette.get(chunkData.getBlockAt(x, y, z)) != Air.INSTANCE) {

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.map;
 
+import java.util.function.BiConsumer;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.ChunkViewListener;
 import se.llbit.chunky.ui.ChunkyFxController;
@@ -50,7 +51,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
   /** The dimension to load in the current world. */
   private int currentDimension = PersistentSettings.getDimension();
 
-  private List<Consumer<World>> worldLoadListeners = new ArrayList<>();
+  private List<BiConsumer<World, Boolean>> worldLoadListeners = new ArrayList<>();
 
   public WorldMapLoader(ChunkyFxController controller, MapView mapView) {
     this.controller = controller;
@@ -82,12 +83,12 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
           PersistentSettings.setLastWorld(newWorldDir);
         }
       }
-      worldLoadListeners.forEach(listener -> listener.accept(newWorld));
+      worldLoadListeners.forEach(listener -> listener.accept(newWorld, false));
     }
   }
 
   /** Adds a listener to be notified when a new world has been loaded. */
-  public void addWorldLoadListener(Consumer<World> callback) {
+  public void addWorldLoadListener(BiConsumer<World, Boolean> callback) {
     worldLoadListeners.add(callback);
   }
 
@@ -139,7 +140,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     synchronized (this) {
       world = newWorld;
     }
-    worldLoadListeners.forEach(listener -> listener.accept(newWorld));
+    worldLoadListeners.forEach(listener -> listener.accept(newWorld, true));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -401,6 +401,9 @@ public class ChunkyFxController
 
     mapLoader.addWorldLoadListener(
         (world, reloaded) -> {
+          if (!reloaded) {
+            chunkSelection.clearSelection();
+          }
           world.addChunkDeletionListener(chunkSelection);
           Optional<Vector3> playerPos = world.playerPos();
           world.addChunkUpdateListener(map);
@@ -424,6 +427,9 @@ public class ChunkyFxController
 
           Platform.runLater(
               () -> {
+                if (!reloaded || trackPlayer.getValue()) {
+                  mapView.panTo(playerPos.orElse(new Vector3(0, 0, 0)));
+                }
                 if (!reloaded) {
                   if (mapLoader.getWorld().getVersionId() >= World.VERSION_21W06A) {
                     yMax.setRange(-64, 320);
@@ -433,7 +439,6 @@ public class ChunkyFxController
                     yMax.set(256);
                   }
                 }
-                mapView.panTo(playerPos.orElse(new Vector3(0, 0, 0)));
                 map.redrawMap();
                 mapName.setText(world.levelName());
                 showWorldMap();

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -128,6 +128,7 @@ public class ChunkyFxController
   @FXML private ToggleButton netherBtn;
   @FXML private ToggleButton endBtn;
   @FXML private IntegerAdjuster scale;
+  @FXML private IntegerAdjuster yMax;
   @FXML private ToggleButton trackPlayerBtn;
   @FXML private ToggleButton trackCameraBtn;
   @FXML private Tab mapViewTab;
@@ -399,8 +400,7 @@ public class ChunkyFxController
         mapCanvas, mapOverlay);
 
     mapLoader.addWorldLoadListener(
-        world -> {
-          chunkSelection.clearSelection();
+        (world, reloaded) -> {
           world.addChunkDeletionListener(chunkSelection);
           Optional<Vector3> playerPos = world.playerPos();
           world.addChunkUpdateListener(map);
@@ -424,6 +424,15 @@ public class ChunkyFxController
 
           Platform.runLater(
               () -> {
+                if (!reloaded) {
+                  if (mapLoader.getWorld().getVersionId() >= World.VERSION_21W06A) {
+                    yMax.setRange(-64, 320);
+                    yMax.set(320);
+                  } else {
+                    yMax.setRange(0, 256);
+                    yMax.set(256);
+                  }
+                }
                 mapView.panTo(playerPos.orElse(new Vector3(0, 0, 0)));
                 map.redrawMap();
                 mapName.setText(world.levelName());
@@ -491,6 +500,10 @@ public class ChunkyFxController
     }));
     scale.valueProperty().addListener(new GroupedChangeListener<>(group,
         (observable, oldValue, newValue) -> mapView.setScale(newValue.intValue())));
+    yMax.valueProperty().addListener(new GroupedChangeListener<>(group, (observable, oldValue, newValue) -> {
+      mapView.setYMax(newValue.intValue());
+      mapLoader.reloadWorld();
+    }));
 
     // Add map view listener to control the individual value properties.
     mapView.getMapViewProperty().addListener(new GroupedChangeListener<>(group,

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -291,10 +291,10 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     this.renderControls = controls;
     this.chunkyFxController = controls.getChunkyController();
     this.mapLoader = chunkyFxController.getMapLoader();
-    mapLoader.addWorldLoadListener(world -> {
+    mapLoader.addWorldLoadListener((world, reloaded) -> {
       loadSelectedChunks.setDisable(world instanceof EmptyWorld || world == null);
     });
-    mapLoader.addWorldLoadListener(this::updateYClipSlidersRanges);
+    mapLoader.addWorldLoadListener((world, reloaded) -> updateYClipSlidersRanges(world));
     updateYClipSlidersRanges(mapLoader.getWorld());
     this.controller = controls.getRenderController();
     this.scene = this.controller.getSceneManager().getScene();

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -187,7 +187,7 @@ public class Chunk {
         BlockPalette palette = new BlockPalette();
         loadBlockData(data, chunkData, palette);
         int[] heightmapData = extractHeightmapData(data, chunkData);
-        updateHeightmap(heightmap, position, chunkData, heightmapData, palette);
+        updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
         surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMax);
         queueTopography();
       } else if (version.equals("1.12")) {
@@ -351,11 +351,11 @@ public class Chunk {
    * and insert into a quadtree.
    */
   public static void updateHeightmap(Heightmap heightmap, ChunkPosition pos, ChunkData chunkData,
-      int[] chunkHeightmap, BlockPalette palette) {
+      int[] chunkHeightmap, BlockPalette palette, int yMax) {
     for (int x = 0; x < 16; ++x) {
       for (int z = 0; z < 16; ++z) {
         int y = chunkHeightmap[z * 16 + x];
-        y = Math.max(1, y - 1);
+        y = Math.max(1, Math.min(y - 1, yMax));
         for (; y > 1; --y) {
           Block block = palette.get(chunkData.getBlockAt(x, y, z));
           if (block != Air.INSTANCE && !block.isWater())

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -145,7 +145,7 @@ public class Chunk {
    * Parse the chunk from the region file and render the current
    * layer, surface and cave maps.
    */
-  public synchronized void loadChunk(ChunkData chunkData) {
+  public synchronized void loadChunk(ChunkData chunkData, int yMax) {
     if (!shouldReloadChunk()) {
       return;
     }
@@ -163,7 +163,7 @@ public class Chunk {
 
     surfaceTimestamp = dataTimestamp;
     version = chunkVersion(data);
-    loadSurface(data, chunkData);
+    loadSurface(data, chunkData, yMax);
     biomesTimestamp = dataTimestamp;
     if (surface == IconLayer.MC_1_12) {
       biomes = IconLayer.MC_1_12;
@@ -173,7 +173,7 @@ public class Chunk {
     world.chunkUpdated(position);
   }
 
-  private void loadSurface(Map<String, Tag> data, ChunkData chunkData) {
+  private void loadSurface(Map<String, Tag> data, ChunkData chunkData, int yMax) {
     if (data == null) {
       surface = IconLayer.CORRUPT;
       return;
@@ -188,7 +188,7 @@ public class Chunk {
         loadBlockData(data, chunkData, palette);
         int[] heightmapData = extractHeightmapData(data, chunkData);
         updateHeightmap(heightmap, position, chunkData, heightmapData, palette);
-        surface = new SurfaceLayer(world.currentDimension(), chunkData, palette);
+        surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMax);
         queueTopography();
       } else if (version.equals("1.12")) {
         surface = IconLayer.MC_1_12;

--- a/chunky/src/java/se/llbit/chunky/world/ChunkView.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkView.java
@@ -42,7 +42,7 @@ public class ChunkView {
   /**
    * A zero-size chunk view useful as a default chunk view for an uninitialized map.
    */
-  public static final ChunkView EMPTY = new ChunkView(0, 0, 0, 0, DEFAULT_BLOCK_SCALE) {
+  public static final ChunkView EMPTY = new ChunkView(0, 0, 0, 0, DEFAULT_BLOCK_SCALE, 0) {
     @Override public boolean isChunkVisible(int x, int z) {
       return false;
     }
@@ -89,13 +89,15 @@ public class ChunkView {
   /** The pixel width for rendering a chunk in this view. */
   public final int chunkScale;
 
+  /** The y level for rendering a chunk in this view. */
+  public final int yMax;
 
   /** Copies an existing chunk view. */
   public ChunkView(ChunkView other) {
-    this(other.x, other.z, other.width, other.height, other.scale);
+    this(other.x, other.z, other.width, other.height, other.scale, other.yMax);
   }
 
-  public ChunkView(double x, double z, int width, int height, int scale) {
+  public ChunkView(double x, double z, int width, int height, int scale, int yMax) {
     scale = clampScale(scale);
     this.scale = scale;
     if (this.scale <= 12) {
@@ -113,6 +115,7 @@ public class ChunkView {
     this.z1 = z + ch;
     this.width = width;
     this.height = height;
+    this.yMax = yMax;
     // Visible chunks (integer coordinates):
     cx0 = (int) QuickMath.floor(x0);
     cx1 = (int) QuickMath.floor(x1);

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -84,7 +84,7 @@ public class EmptyChunk extends Chunk {
     // Do nothing.
   }
 
-  @Override public synchronized void loadChunk(ChunkData chunkData) {
+  @Override public synchronized void loadChunk(ChunkData chunkData, int yMax) {
     // Do nothing.
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -84,7 +84,7 @@ public class EmptyRegionChunk extends Chunk {
     // do nothing
   }
 
-  @Override public synchronized void loadChunk(ChunkData chunkData) {
+  @Override public synchronized void loadChunk(ChunkData chunkData, int yMax) {
     // do nothing
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/RegionParser.java
@@ -68,7 +68,7 @@ public class RegionParser extends Thread {
         }
         for (Chunk chunk : region) {
           if (map.shouldPreload(chunk)) {
-            chunk.loadChunk(chunkData);
+            chunk.loadChunk(chunkData, mapView.getYMax());
           }
           chunkData.clear();
         }

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -96,6 +96,9 @@
           <VBox alignment="CENTER_LEFT">
             <IntegerAdjuster fx:id="scale" name="Scale"/>
           </VBox>
+          <VBox alignment="CENTER_LEFT">
+            <IntegerAdjuster fx:id="yMax" name="Y level"/>
+          </VBox>
           <Label text="Coordinates"/>
           <HBox alignment="CENTER_LEFT" spacing="10.0">
             <Label text="X="/>


### PR DESCRIPTION
As [suggested on Reddit](https://old.reddit.com/r/chunky/comments/mmw1ae/ylevel_view_slider_in_chunky_2/), this adds a control to change the y level in the map view which is useful if you are searching for underground structures to render.

This also changes the reload behavior to not clear the chunk selection anymore.