### PR TITLE
Make sea pickles emit light.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/SeaPickle.java
+++ b/chunky/src/java/se/llbit/chunky/block/SeaPickle.java
@@ -752,8 +752,8 @@ public class SeaPickle extends MinecraftBlockTranslucent {
   };
 
   private final String description;
-  private final boolean live;
-  private int pickles;
+  public final boolean live;
+  public final int pickles;
 
   public SeaPickle(int pickles, boolean live) {
     super("sea_pickle", Texture.seaPickle);

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -377,6 +377,13 @@ public class BlockPalette {
     materialProperties.put("minecraft:tall_seagrass", block -> {
       block.waterlogged = true;
     });
+    materialProperties.put("minecraft:sea_pickle", block -> {
+      if (block instanceof SeaPickle) {
+        if (((SeaPickle) block).live) {
+          block.emittance = 1.0f / 15f * (3 * ((SeaPickle) block).pickles + 1);
+        }
+      }
+    });
     materialProperties.put("minecraft:campfire", block -> {
       if (block instanceof Campfire && ((Campfire)block).isLit) {
         block.emittance = 1.0f;


### PR DESCRIPTION
Turns out [sea pickles are supposed to emit light](https://minecraft.fandom.com/wiki/Sea_Pickle#Usage) depending on the number of pickles (3, 6, 12, 15) if they are waterlogged.

![image](https://user-images.githubusercontent.com/5544859/114316202-dd4d4280-9b02-11eb-8dbe-e63fd2995ea2.png)
