### PR TITLE
Actually use the heightmap information in the region files

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -53,10 +53,19 @@ public class Chunk {
 
   public static final String DATAVERSION = ".DataVersion";
   public static final String LEVEL_HEIGHTMAP = ".Level.HeightMap";
+  public static final String LEVEL_HEIGHTMAPS = ".Level.Heightmaps";
   public static final String LEVEL_SECTIONS = ".Level.Sections";
   public static final String LEVEL_BIOMES = ".Level.Biomes";
   private static final String LEVEL_ENTITIES = ".Level.Entities";
   private static final String LEVEL_TILEENTITIES = ".Level.TileEntities";
+
+  /**
+   * Describes which long to get a value at index I for values per bits N
+   * The MAGIC values come in triples
+   * longer explanation above {@link Chunk#extractHeightmapPost20w17a}
+   */
+  private static final int[] MAGIC = new int[]{-1, -1, 0, Integer.MIN_VALUE, 0, 0, 1431655765, 1431655765, 0, Integer.MIN_VALUE, 0, 1, 858993459, 858993459, 0, 715827882, 715827882, 0, 613566756, 613566756, 0, Integer.MIN_VALUE, 0, 2, 477218588, 477218588, 0, 429496729, 429496729, 0, 390451572, 390451572, 0, 357913941, 357913941, 0, 330382099, 330382099, 0, 306783378, 306783378, 0, 286331153, 286331153, 0, Integer.MIN_VALUE, 0, 3, 252645135, 252645135, 0, 238609294, 238609294, 0, 226050910, 226050910, 0, 214748364, 214748364, 0, 204522252, 204522252, 0, 195225786, 195225786, 0, 186737708, 186737708, 0, 178956970, 178956970, 0, 171798691, 171798691, 0, 165191049, 165191049, 0, 159072862, 159072862, 0, 153391689, 153391689, 0, 148102320, 148102320, 0, 143165576, 143165576, 0, 138547332, 138547332, 0, Integer.MIN_VALUE, 0, 4, 130150524, 130150524, 0, 126322567, 126322567, 0, 122713351, 122713351, 0, 119304647, 119304647, 0, 116080197, 116080197, 0, 113025455, 113025455, 0, 110127366, 110127366, 0, 107374182, 107374182, 0, 104755299, 104755299, 0, 102261126, 102261126, 0, 99882960, 99882960, 0, 97612893, 97612893, 0, 95443717, 95443717, 0, 93368854, 93368854, 0, 91382282, 91382282, 0, 89478485, 89478485, 0, 87652393, 87652393, 0, 85899345, 85899345, 0, 84215045, 84215045, 0, 82595524, 82595524, 0, 81037118, 81037118, 0, 79536431, 79536431, 0, 78090314, 78090314, 0, 76695844, 76695844, 0, 75350303, 75350303, 0, 74051160, 74051160, 0, 72796055, 72796055, 0, 71582788, 71582788, 0, 70409299, 70409299, 0, 69273666, 69273666, 0, 68174084, 68174084, 0, Integer.MIN_VALUE, 0, 5};
+
 
   /** Chunk width. */
   public static final int X_MAX = 16;
@@ -155,6 +164,7 @@ public class Chunk {
     request.add(Chunk.LEVEL_SECTIONS);
     request.add(Chunk.LEVEL_BIOMES);
     request.add(Chunk.LEVEL_HEIGHTMAP);
+    request.add(Chunk.LEVEL_HEIGHTMAPS);
     Map<String, Tag> data = getChunkData(request);
     // TODO: improve error handling here.
     if (data == null) {
@@ -255,13 +265,88 @@ public class Chunk {
     Tag heightmapTag = data.get(LEVEL_HEIGHTMAP);
     if (heightmapTag.isIntArray(X_MAX * Z_MAX)) {
       return heightmapTag.intArray();
-    } else {
-      int[] fallback = new int[X_MAX * Z_MAX];
-      for (int i = 0; i < fallback.length; ++i) {
-        fallback[i] = chunkData.maxY()-1;
-      }
-      return fallback;
     }
+    Tag heightmapsTag = data.get(LEVEL_HEIGHTMAPS);
+    if(heightmapsTag.isCompoundTag()) {
+      Tag world_surface = heightmapsTag.asCompound().get("WORLD_SURFACE");
+      if(world_surface.isLongArray(0)) {
+        if (data.get(DATAVERSION).intValue() >= DATAVERSION_20w17a) { //elements are not packed between longs
+          return extractHeightmapPost20w17a(world_surface.longArray());
+        } else { //elements are packed between longs
+          return extractHeightmapPre20w17a(world_surface.longArray());
+        }
+      }
+    }
+
+    int[] fallback = new int[X_MAX * Z_MAX];
+    for (int i = 0; i < fallback.length; ++i) {
+      fallback[i] = chunkData.maxY()-1;
+    }
+    return fallback;
+  }
+
+  /**
+   * This is an explanation of heightmap indexing
+   * height values are stored in a long array, with exact numbers of bits to store the height range of the world
+   * The 20w17a version differs to the one previous as it prevents values spanning over two longs in the array, where
+   * the previous implementation allowed it. The reason for doing this is most likely choosing game performance over
+   * optimum region file size
+   *
+   * to give an example: for an element with, 10 bits per value, therefore 6 values per long
+   * MAGIC values for that: 715827882, 715827882, 0
+   * to get index 45 we'd do:
+   * longIdx = 45L * 715827882L + 715827882L >> Integer.SIZE >> 0
+   * longVal = longArray[longIdx]
+   * rightShift = (45 - longIdx * 6) * 10
+   * so our value is: (int) (longVal >> rightShift & (1 << 10) - 1)
+   */
+  private static int[] extractHeightmapPost20w17a(long[] heightmapBitArray) {
+    int[] heightmap = new int[Chunk.X_MAX * Chunk.Z_MAX];
+    int elementBits = heightmapBitArray.length * Long.SIZE / (Chunk.X_MAX * Chunk.Z_MAX);
+    int elementMask = (1 << elementBits) - 1;
+    int valuesPerLong = Long.SIZE / elementBits;
+
+    int magicIdx = 3 * (valuesPerLong - 1);
+    long mul = ((long) MAGIC[magicIdx + 0]) & 0xffffffffL;
+    long add = ((long) MAGIC[magicIdx + 1]) & 0xffffffffL;
+    long shift = ((long) MAGIC[magicIdx + 2]) & 0xffffffffL;
+
+    int index = 0;
+    for (int x = 0; x < X_MAX; x++) {
+      for (int z = 0; z < Z_MAX; z++) {
+        int i = (int) ((long) index * mul + add >> 32 >> shift);
+        long l = heightmapBitArray[i];
+        int rightShift = (index - i * valuesPerLong) * elementBits;
+        int v = (int) (l >> rightShift & elementMask);
+        heightmap[x * X_MAX + z] = v;
+        index++;
+      }
+    }
+    return heightmap;
+  }
+
+  private static int[] extractHeightmapPre20w17a(long[] heightmapBitArray) {
+    int[] heightmap = new int[Chunk.X_MAX * Chunk.Z_MAX];
+    int elementBits = heightmapBitArray.length * Long.SIZE / (Chunk.X_MAX * Chunk.Z_MAX);
+    int elementMask = (1 << elementBits) - 1;
+
+    int index = 0;
+    for (int x = 0; x < X_MAX; x++) {
+      for (int z = 0; z < Z_MAX; z++) {
+        int startBit = index * elementBits;
+        int firstIdx = startBit >> 6;
+        int secondIdx = (index + 1) * elementBits - 1 >> 6;
+        int firstRightShift = startBit ^ firstIdx << 6;
+        if (firstIdx == secondIdx) {
+          heightmap[x * X_MAX + z] = (int) (heightmapBitArray[firstIdx] >>> firstRightShift & elementMask);
+        } else {
+          int secondLeftShift = 64 - firstRightShift;
+          heightmap[x * X_MAX + z] = (int) ((heightmapBitArray[firstIdx] >>> firstRightShift | heightmapBitArray[secondIdx] << secondLeftShift) & elementMask);
+        }
+        index++;
+      }
+    }
+    return heightmap;
   }
 
   /** Detect Minecraft version that generated the chunk. */

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -268,12 +268,12 @@ public class Chunk {
     }
     Tag heightmapsTag = data.get(LEVEL_HEIGHTMAPS);
     if(heightmapsTag.isCompoundTag()) {
-      Tag world_surface = heightmapsTag.asCompound().get("WORLD_SURFACE");
-      if(world_surface.isLongArray(0)) {
+      Tag oceanFloor = heightmapsTag.asCompound().get("OCEAN_FLOOR");
+      if(oceanFloor.isLongArray(0)) {
         if (data.get(DATAVERSION).intValue() >= DATAVERSION_20w17a) { //elements are not packed between longs
-          return extractHeightmapPost20w17a(world_surface.longArray());
+          return extractHeightmapPost20w17a(oceanFloor.longArray());
         } else { //elements are packed between longs
-          return extractHeightmapPre20w17a(world_surface.longArray());
+          return extractHeightmapPre20w17a(oceanFloor.longArray());
         }
       }
     }


### PR DESCRIPTION
I assume the previous implementation was for 1.12 heightmaps, though I could be wrong, I haven't removed it.

Basically if the heightmap information is found, it starts the internal heightmap at the given positions, which (provided minecraft's heightmaps are correct) means that `updateHeightmap` should be nearly instant sampling one block, rather than taking up 1/2 of chunk parse time for the map view, sampling from the top of the chunk to the highest block