### PR TITLE
RegionParser only clears chunk data if modified

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -146,10 +146,11 @@ public class Chunk {
   /**
    * Parse the chunk from the region file and render the current
    * layer, surface and cave maps.
+   * @return whether the input chunkdata was modified
    */
-  public synchronized void loadChunk(ChunkData chunkData, int yMax) {
+  public synchronized boolean loadChunk(ChunkData chunkData, int yMax) {
     if (!shouldReloadChunk()) {
-      return;
+      return false;
     }
 
     Set<String> request = new HashSet<>();
@@ -160,7 +161,7 @@ public class Chunk {
     Map<String, Tag> data = getChunkData(request);
     // TODO: improve error handling here.
     if (data == null) {
-      return;
+      return false;
     }
 
     surfaceTimestamp = dataTimestamp;
@@ -173,6 +174,7 @@ public class Chunk {
       loadBiomes(data, chunkData);
     }
     world.chunkUpdated(position);
+    return true;
   }
 
   private void loadSurface(Map<String, Tag> data, ChunkData chunkData, int yMax) {

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -84,8 +84,8 @@ public class EmptyChunk extends Chunk {
     // Do nothing.
   }
 
-  @Override public synchronized void loadChunk(ChunkData chunkData, int yMax) {
-    // Do nothing.
+  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMax) {
+    return false;
   }
 
   @Override public String toString() {

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -84,8 +84,8 @@ public class EmptyRegionChunk extends Chunk {
     // do nothing
   }
 
-  @Override public synchronized void loadChunk(ChunkData chunkData, int yMax) {
-    // do nothing
+  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMax) {
+    return false;
   }
 
   @Override public String toString() {

--- a/chunky/src/java/se/llbit/chunky/world/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/RegionParser.java
@@ -68,9 +68,10 @@ public class RegionParser extends Thread {
         }
         for (Chunk chunk : region) {
           if (map.shouldPreload(chunk)) {
-            chunk.loadChunk(chunkData, mapView.getYMax());
+            if(chunk.loadChunk(chunkData, mapView.getYMax())) {
+              chunkData.clear();
+            }
           }
-          chunkData.clear();
         }
       }
     }


### PR DESCRIPTION
`Chunk#loadChunk` now returns whether the input `ChunkData` object was modified, which is used to prevent useless calls to `ChunkData#clear`