### PR TITLE
Better waterworld.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -21,9 +21,6 @@ public class Water extends MinecraftBlockTranslucent {
   public static final Water INSTANCE = new Water(0);
 
   public static final double TOP_BLOCK_GAP = 0.125;
-  
-  // Used only as starting material when camera is submerged.
-  public static final Water OCEAN_WATER = new Water(0, 1 << Water.FULL_BLOCK);
 
   public final int level;
   public final int data;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -110,8 +110,14 @@ public class PreviewRayTracer implements RayTracer {
   }
 
   private static boolean waterIntersection(Scene scene, Ray ray) {
+    double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
+    if (scene.waterPlaneClip) {
+      Vector3 pos = new Vector3(ray.o);
+      pos.scaleAdd(t, ray.d);
+      if (scene.isChunkLoaded((int) pos.x, (int) pos.z))
+        return false;
+    }
     if (ray.d.y < 0) {
-      double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
@@ -121,7 +127,6 @@ public class PreviewRayTracer implements RayTracer {
       }
     }
     if (ray.d.y > 0) {
-      double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -115,7 +115,7 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.getWaterPlaneChunkClip()) {
       Vector3 pos = new Vector3(ray.o);
       pos.scaleAdd(t, ray.d);
-      if (scene.isChunkLoaded((int) pos.x, (int) pos.z))
+      if (scene.isChunkLoaded((int)Math.floor(pos.x), (int)Math.floor(pos.z)))
         return false;
     }
     if (ray.d.y < 0) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -111,7 +111,7 @@ public class PreviewRayTracer implements RayTracer {
 
   private static boolean waterIntersection(Scene scene, Ray ray) {
     double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
-    if (scene.waterPlaneClip) {
+    if (scene.getWaterPlaneChunkClip()) {
       Vector3 pos = new Vector3(ray.o);
       pos.scaleAdd(t, ray.d);
       if (scene.isChunkLoaded((int) pos.x, (int) pos.z))

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -116,7 +116,7 @@ public class PreviewRayTracer implements RayTracer {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
         ray.n.set(0, 1, 0);
-        ray.setCurrentMaterial(Water.OCEAN_WATER);
+        ray.setCurrentMaterial(scene.getPalette().water);
         return true;
       }
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2013-2014 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2013-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2013-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -722,19 +722,17 @@ public class Scene implements JsonSerializable, Refreshable {
       hit = true;
     }
     if (start.getCurrentMaterial().isWater()) {
-      if(start.getCurrentMaterial() != Water.OCEAN_WATER) {
-        r = new Ray(start);
-        r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
-        if(waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
-          ray.t = r.distance;
-          ray.n.set(r.n);
-          ray.color.set(r.color);
-          ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
-          ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
-          hit = true;
-        } else if(ray.getPrevMaterial() == Air.INSTANCE) {
-          ray.setPrevMaterial(Water.INSTANCE, 1 << Water.FULL_BLOCK);
-        }
+      r = new Ray(start);
+      r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
+      if(waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
+        ray.t = r.distance;
+        ray.n.set(r.n);
+        ray.color.set(r.color);
+        ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
+        ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
+        hit = true;
+      } else if(ray.getPrevMaterial() == Air.INSTANCE) {
+        ray.setPrevMaterial(Water.INSTANCE, 1 << Water.FULL_BLOCK);
       }
     } else {
       r = new Ray(start);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -105,10 +105,21 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ListTag;
 import se.llbit.nbt.Tag;
+import se.llbit.pfm.PfmFileWriter;
+import se.llbit.png.ITXT;
+import se.llbit.png.PngFileWriter;
+import se.llbit.tiff.TiffFileWriter;
 import se.llbit.util.*;
 
 import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Encapsulates scene and render state.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -244,6 +244,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean waterPlaneEnabled = false;
   protected double waterPlaneHeight = World.SEA_LEVEL;
   protected boolean waterPlaneOffsetEnabled = true;
+  protected boolean waterPlaneClip = true;
 
   /**
    * Enables fast fog algorithm
@@ -486,6 +487,7 @@ public class Scene implements JsonSerializable, Refreshable {
     waterPlaneEnabled = other.waterPlaneEnabled;
     waterPlaneHeight = other.waterPlaneHeight;
     waterPlaneOffsetEnabled = other.waterPlaneOffsetEnabled;
+    waterPlaneClip = other.waterPlaneClip;
 
     spp = other.spp;
     renderTime = other.renderTime;
@@ -1794,6 +1796,17 @@ public class Scene implements JsonSerializable, Refreshable {
     return waterPlaneOffsetEnabled;
   }
 
+  public void setWaterPlaneClip(boolean enabled) {
+    if (enabled != waterPlaneClip) {
+      waterPlaneClip = enabled;
+      refresh();
+    }
+  }
+
+  public boolean getWaterPlaneClip() {
+    return waterPlaneClip;
+  }
+
   /**
    * @return the dumpFrequency
    */
@@ -2449,6 +2462,17 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * Query if a position is loaded.
+   */
+  public boolean isChunkLoaded(int x, int z) {
+    if (waterTexture != null && waterTexture.contains(x, z)) {
+      float[] color = waterTexture.get(x, z);
+      return color[0] > 0 || color[1] > 0 || color[2] > 0;
+    }
+    return false;
+  }
+
+  /**
    * Merge a render dump into this scene.
    */
   public void mergeDump(File dumpFile, TaskTracker taskTracker) {
@@ -2588,6 +2612,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("waterWorldEnabled", waterPlaneEnabled);
     json.add("waterWorldHeight", waterPlaneHeight);
     json.add("waterWorldHeightOffsetEnabled", waterPlaneOffsetEnabled);
+    json.add("waterWorldClipEnabled", waterPlaneClip);
     json.add("renderActors", renderActors);
 
     if (!worldPath.isEmpty()) {
@@ -2866,6 +2891,7 @@ public class Scene implements JsonSerializable, Refreshable {
       waterPlaneHeight = json.get("waterWorldHeight").doubleValue(waterPlaneHeight);
       waterPlaneOffsetEnabled = json.get("waterWorldHeightOffsetEnabled")
         .boolValue(waterPlaneOffsetEnabled);
+      waterPlaneClip = json.get("waterWorldClipEnabled").boolValue(waterPlaneClip);
     }
 
     renderActors = json.get("renderActors").boolValue(renderActors);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -105,21 +105,10 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ListTag;
 import se.llbit.nbt.Tag;
-import se.llbit.pfm.PfmFileWriter;
-import se.llbit.png.ITXT;
-import se.llbit.png.PngFileWriter;
-import se.llbit.tiff.TiffFileWriter;
 import se.llbit.util.*;
 
 import java.io.*;
-import java.text.SimpleDateFormat;
-import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-import java.util.stream.IntStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Encapsulates scene and render state.
@@ -244,7 +233,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean waterPlaneEnabled = false;
   protected double waterPlaneHeight = World.SEA_LEVEL;
   protected boolean waterPlaneOffsetEnabled = true;
-  protected boolean waterPlaneClip = true;
+  protected boolean waterPlaneChunkClip = true;
 
   /**
    * Enables fast fog algorithm
@@ -487,7 +476,7 @@ public class Scene implements JsonSerializable, Refreshable {
     waterPlaneEnabled = other.waterPlaneEnabled;
     waterPlaneHeight = other.waterPlaneHeight;
     waterPlaneOffsetEnabled = other.waterPlaneOffsetEnabled;
-    waterPlaneClip = other.waterPlaneClip;
+    waterPlaneChunkClip = other.waterPlaneChunkClip;
 
     spp = other.spp;
     renderTime = other.renderTime;
@@ -1796,15 +1785,15 @@ public class Scene implements JsonSerializable, Refreshable {
     return waterPlaneOffsetEnabled;
   }
 
-  public void setWaterPlaneClip(boolean enabled) {
-    if (enabled != waterPlaneClip) {
-      waterPlaneClip = enabled;
+  public void setWaterPlaneChunkClip(boolean enabled) {
+    if (enabled != waterPlaneChunkClip) {
+      waterPlaneChunkClip = enabled;
       refresh();
     }
   }
 
-  public boolean getWaterPlaneClip() {
-    return waterPlaneClip;
+  public boolean getWaterPlaneChunkClip() {
+    return waterPlaneChunkClip;
   }
 
   /**
@@ -2612,7 +2601,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("waterWorldEnabled", waterPlaneEnabled);
     json.add("waterWorldHeight", waterPlaneHeight);
     json.add("waterWorldHeightOffsetEnabled", waterPlaneOffsetEnabled);
-    json.add("waterWorldClipEnabled", waterPlaneClip);
+    json.add("waterWorldClipEnabled", waterPlaneChunkClip);
     json.add("renderActors", renderActors);
 
     if (!worldPath.isEmpty()) {
@@ -2891,7 +2880,7 @@ public class Scene implements JsonSerializable, Refreshable {
       waterPlaneHeight = json.get("waterWorldHeight").doubleValue(waterPlaneHeight);
       waterPlaneOffsetEnabled = json.get("waterWorldHeightOffsetEnabled")
         .boolValue(waterPlaneOffsetEnabled);
-      waterPlaneClip = json.get("waterWorldClipEnabled").boolValue(waterPlaneClip);
+      waterPlaneChunkClip = json.get("waterWorldClipEnabled").boolValue(waterPlaneChunkClip);
     }
 
     renderActors = json.get("renderActors").boolValue(renderActors);

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -49,6 +49,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
   @FXML private CheckBox waterPlaneEnabled;
   @FXML private DoubleAdjuster waterPlaneHeight;
   @FXML private CheckBox waterPlaneOffsetEnabled;
+  @FXML private CheckBox waterPlaneClip;
 
   private RenderControlsFxController renderControls;
   private RenderController controller;
@@ -88,6 +89,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneHeight.setRange(scene.yClipMin, scene.yClipMax);
     waterPlaneHeight.set(scene.getWaterPlaneHeight());
     waterPlaneOffsetEnabled.setSelected(scene.isWaterPlaneOffsetEnabled());
+    waterPlaneClip.setSelected(scene.getWaterPlaneClip());
   }
 
   @Override
@@ -150,6 +152,10 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
 
     waterPlaneOffsetEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneOffsetEnabled(newValue)
+    );
+
+    waterPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
+        scene.setWaterPlaneClip(newValue)
     );
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2016-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/WaterTab.java
@@ -89,7 +89,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneHeight.setRange(scene.yClipMin, scene.yClipMax);
     waterPlaneHeight.set(scene.getWaterPlaneHeight());
     waterPlaneOffsetEnabled.setSelected(scene.isWaterPlaneOffsetEnabled());
-    waterPlaneClip.setSelected(scene.getWaterPlaneClip());
+    waterPlaneClip.setSelected(scene.getWaterPlaneChunkClip());
   }
 
   @Override
@@ -155,7 +155,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     );
 
     waterPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
-        scene.setWaterPlaneClip(newValue)
+        scene.setWaterPlaneChunkClip(newValue)
     );
   }
 

--- a/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
@@ -31,7 +31,7 @@
           </padding>
           <DoubleAdjuster fx:id="waterPlaneHeight" />
           <CheckBox fx:id="waterPlaneOffsetEnabled" mnemonicParsing="false" text="Lower water by minecraft offset (default)" />
-          <CheckBox fx:id="waterPlaneClip" mnemonicParsing="false" text="Clip the water plane in loaded chunks" />
+          <CheckBox fx:id="waterPlaneClip" mnemonicParsing="false" text="Hide the water plane in loaded chunks" />
         </VBox>
       </TitledPane>
     </children>

--- a/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/WaterTab.fxml
@@ -31,6 +31,7 @@
           </padding>
           <DoubleAdjuster fx:id="waterPlaneHeight" />
           <CheckBox fx:id="waterPlaneOffsetEnabled" mnemonicParsing="false" text="Lower water by minecraft offset (default)" />
+          <CheckBox fx:id="waterPlaneClip" mnemonicParsing="false" text="Clip the water plane in loaded chunks" />
         </VBox>
       </TitledPane>
     </children>


### PR DESCRIPTION
Switch water-world to use the blockpalette water which allows for changing it's material properties.
Removed `Water.OCEAN_WATER` since it was not being used outside of water-world.
![image](https://user-images.githubusercontent.com/42661490/115079799-966e9c80-9eb6-11eb-85fd-24e5f75487a6.png)
