### PR TITLE
Fix and optimize some blocks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/BrewingStand.java
+++ b/chunky/src/java/se/llbit/chunky/block/BrewingStand.java
@@ -11,7 +11,7 @@ public class BrewingStand extends MinecraftBlockTranslucent {
   private final String description;
 
   public BrewingStand(boolean bottle0, boolean bottle1, boolean bottle2) {
-    super("end_portal_frame", Texture.endPortalFrameSide);
+    super("brewing_stand", Texture.brewingStandBase);
     description = String.format("has_bottle_0=%s, has_bottle_1=%s, has_bottle_2=%s",
         bottle0, bottle1, bottle2);
     localIntersect = true;

--- a/chunky/src/java/se/llbit/chunky/block/DaylightDetector.java
+++ b/chunky/src/java/se/llbit/chunky/block/DaylightDetector.java
@@ -5,7 +5,7 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 
-public class DaylightDetector extends MinecraftBlock {
+public class DaylightDetector extends MinecraftBlockTranslucent {
   private final boolean inverted;
 
   public DaylightDetector(boolean inverted) {

--- a/chunky/src/java/se/llbit/chunky/block/Piston.java
+++ b/chunky/src/java/se/llbit/chunky/block/Piston.java
@@ -17,7 +17,7 @@ public class Piston extends MinecraftBlock {
     this.isSticky = sticky ? 1 : 0;
     this.isExtended = extended ? 1 : 0;
     localIntersect = true;
-    opaque = false;
+    opaque = !extended;
     solid = false;
     switch (facing) {
       case "down":

--- a/chunky/src/java/se/llbit/chunky/block/ShulkerBox.java
+++ b/chunky/src/java/se/llbit/chunky/block/ShulkerBox.java
@@ -5,7 +5,7 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 
-public class ShulkerBox extends MinecraftBlockTranslucent {
+public class ShulkerBox extends MinecraftBlock {
   private final int facing;
   private final Texture[] texture;
   private final String description;

--- a/chunky/src/java/se/llbit/chunky/block/Snow.java
+++ b/chunky/src/java/se/llbit/chunky/block/Snow.java
@@ -5,13 +5,14 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 
-public class Snow extends MinecraftBlockTranslucent {
+public class Snow extends MinecraftBlock {
   private final int layers;
 
   public Snow(int layers) {
     super("snow", Texture.snowBlock);
-    localIntersect = true;
     this.layers = layers;
+    localIntersect = layers < 8;
+    opaque = layers == 8;
   }
 
   @Override public boolean intersect(Ray ray, Scene scene) {


### PR DESCRIPTION
This back-ports block fixes and optimizations from #901. Marking blocks as opaque reduces memory usage because it allows us to replace the blocks they cover with a special _any_ block in the octree. Adjacent _any_ blocks can be stored more efficiently.

In this picture the daylight sensor is marked as opaque (also fixed by this PR) and thus the (as far as chunky is concerned) invisible dirt block was replaced with _any_ and rendered as stone.
![image](https://user-images.githubusercontent.com/5544859/115145981-d53a5900-a054-11eb-8788-e36e6e790cdc.png)
