### PR TITLE
Fix dump loading progress indicator for ClassicDumpFormat

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/ClassicDumpFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/ClassicDumpFormat.java
@@ -33,7 +33,7 @@ class ClassicDumpFormat extends DumpFormat {
   @Override
   public void readSamples(DataInputStream inputStream, Scene scene, PixelConsumer consumer, IntConsumer pixelProgress)
       throws IOException {
-    int pixelIndex;
+    int pixelIndex, progress = 0;
     double r, g, b;
     // Warning: This format writes in columns instead of rows
     for (int x = 0; x < scene.width; ++x) {
@@ -43,7 +43,7 @@ class ClassicDumpFormat extends DumpFormat {
         g = inputStream.readDouble();
         b = inputStream.readDouble();
         consumer.consume(pixelIndex, r, g, b);
-        pixelProgress.accept(pixelIndex);
+        pixelProgress.accept(progress++);
       }
     }
   }

--- a/chunky/src/java/se/llbit/util/ProgressListener.java
+++ b/chunky/src/java/se/llbit/util/ProgressListener.java
@@ -23,12 +23,7 @@ package se.llbit.util;
  * @author Jesper Öqvist <jesper@llbit.se>
  */
 public interface ProgressListener {
-  ProgressListener NONE = new ProgressListener() {
-    @Override public void setProgress(String task, int done, int start, int target) {
-    }
-    @Override public void setProgress(String task, int done, int start, int target, String eta) {
-    }
-  };
+  ProgressListener NONE = (task, done, start, target) -> {};
 
   /**
    * Update progress without ETA.
@@ -38,5 +33,7 @@ public interface ProgressListener {
   /**
    * Update progress with ETA.
    */
-  void setProgress(String task, int done, int start, int target, String eta);
+  default void setProgress(String task, int done, int start, int target, String eta) {
+    setProgress(task, done, start, target);
+  }
 }

--- a/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTests.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTests.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.renderer.renderdump;
 
+import org.junit.Before;
 import org.junit.Test;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.ProgressListener;
@@ -31,6 +32,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class RenderDumpTests {
   protected static final int testWidth = Scene.MIN_CANVAS_WIDTH;
@@ -61,7 +63,22 @@ public class RenderDumpTests {
     }
   }
 
-  protected static final TaskTracker taskTracker = new TaskTracker(ProgressListener.NONE);
+  protected TaskTracker taskTracker;
+
+  @Before
+  public void init() {
+    taskTracker = new TaskTracker(new ProgressListener() {
+      final Map<String, Integer> previousProgress = new HashMap<>();
+
+      @Override
+      public void setProgress(String task, int done, int start, int target) {
+        int previous = previousProgress.getOrDefault(task, Integer.MIN_VALUE);
+        // check that progress is monotonically increasing
+        assertTrue("progress (" + done + ") should be greater or equal to previous progress (" + previous + ")", done >= previous);
+        previousProgress.put(task, done);
+      }
+    });
+  }
 
   protected Scene createTestScene(int width, int height, int spp, long renderTime) {
     Scene scene = new Scene();


### PR DESCRIPTION
- fixes #905 including "test"
- adds default fallback implementation for ProgressListener which ignores eta to allow creation of listeners as lambda