### PR TITLE
Speed up isChunkLoaded by not checking the color.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/ChunkData.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/ChunkData.java
@@ -92,4 +92,9 @@ public interface ChunkData {
    * Reset the internal data to the initial state
    */
   void clear();
+
+  /**
+   * @return <code>true</code> if this is an empty (non-existing) chunk
+   */
+  boolean isEmpty();
 }

--- a/chunky/src/java/se/llbit/chunky/chunk/EmptyChunkData.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/EmptyChunkData.java
@@ -1,11 +1,18 @@
 package se.llbit.chunky.chunk;
 
+import java.util.Collection;
+import java.util.Collections;
 import se.llbit.nbt.CompoundTag;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 public class EmptyChunkData implements ChunkData {
+
+  /**
+   * Singleton instance.
+   */
+  public static final EmptyChunkData INSTANCE = new EmptyChunkData();
+
+  private EmptyChunkData(){}
+
   @Override
   public int minY() {
     return 0;
@@ -31,7 +38,7 @@ public class EmptyChunkData implements ChunkData {
 
   @Override
   public Collection<CompoundTag> getTileEntities() {
-    return new ArrayList<>();
+    return Collections.emptyList();
   }
 
   @Override
@@ -39,7 +46,7 @@ public class EmptyChunkData implements ChunkData {
 
   @Override
   public Collection<CompoundTag> getEntities() {
-    return new ArrayList<>();
+    return Collections.emptyList();
   }
 
   @Override
@@ -54,5 +61,12 @@ public class EmptyChunkData implements ChunkData {
   public void setBiomeAt(int x, int y, int z, byte biome) { }
 
   @Override
-  public void clear() { }
+  public void clear() {
+    throw new IllegalStateException("EmptyChunkData may not be re-used, this is a bug. Please report it!");
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return true;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/chunk/GenericChunkData.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/GenericChunkData.java
@@ -114,6 +114,11 @@ public class GenericChunkData implements ChunkData {
     return result;
   }
 
+  @Override
+  public boolean isEmpty() {
+    return sections.isEmpty() && entities.isEmpty() && tileEntities.isEmpty();
+  }
+
   private static class SectionData {
     public final int sectionY;
     public final int[] blocks;

--- a/chunky/src/java/se/llbit/chunky/chunk/SimpleChunkData.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/SimpleChunkData.java
@@ -25,12 +25,14 @@ public class SimpleChunkData implements ChunkData {
   private final byte[] biomes;
   private final Collection<CompoundTag> tileEntities;
   private final Collection<CompoundTag> entities;
+  private boolean isEmpty;
 
   public SimpleChunkData() {
     blocks = new int[X_MAX * Y_MAX * Z_MAX];
     biomes = new byte[X_MAX * Z_MAX];
     tileEntities = new ArrayList<>();
     entities = new ArrayList<>();
+    isEmpty = true;
   }
 
   @Override public int minY() {
@@ -49,11 +51,12 @@ public class SimpleChunkData implements ChunkData {
   }
 
   @Override public void setBlockAt(int x, int y, int z, int block) {
-    if(block == 0)
-      return;
     if(y < 0 || y > 255) {
       return;
     }
+    isEmpty = false;
+    if(block == 0)
+      return;
     blocks[chunkIndex(x & (X_MAX - 1), y, z & (Z_MAX - 1))] = block;
   }
 
@@ -68,6 +71,7 @@ public class SimpleChunkData implements ChunkData {
   @Override
   public void addTileEntity(CompoundTag tileEntity) {
     tileEntities.add(tileEntity);
+    isEmpty = false;
   }
 
   @Override public Collection<CompoundTag> getEntities() {
@@ -77,6 +81,7 @@ public class SimpleChunkData implements ChunkData {
   @Override
   public void addEntity(CompoundTag entity) {
     entities.add(entity);
+    isEmpty = false;
   }
 
   @Override public byte getBiomeAt(int x, int y, int z) {
@@ -93,6 +98,7 @@ public class SimpleChunkData implements ChunkData {
     System.arraycopy(emptyBiomes, 0, biomes, 0, emptyBiomes.length);
     tileEntities.clear();
     entities.clear();
+    isEmpty = true;
   }
 
   @Override public boolean equals(Object o) {
@@ -107,5 +113,10 @@ public class SimpleChunkData implements ChunkData {
     result = 31 * result + Arrays.hashCode(blocks);
     result = 31 * result + Arrays.hashCode(biomes);
     return result;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return isEmpty;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -93,7 +93,7 @@ public class PreviewRayTracer implements RayTracer {
       hit = scene.sky().cloudIntersection(scene, ray);
     }
     if (scene.isWaterPlaneEnabled()) {
-      hit = waterIntersection(scene, ray) || hit;
+      hit = waterPlaneIntersection(scene, ray) || hit;
     }
     if (scene.intersect(ray)) {
       // Octree tracer handles updating distance.
@@ -110,7 +110,7 @@ public class PreviewRayTracer implements RayTracer {
     }
   }
 
-  private static boolean waterIntersection(Scene scene, Ray ray) {
+  private static boolean waterPlaneIntersection(Scene scene, Ray ray) {
     double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
     if (scene.getWaterPlaneChunkClip()) {
       Vector3 pos = new Vector3(ray.o);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2490,11 +2490,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Query if a position is loaded.
    */
   public boolean isChunkLoaded(int x, int z) {
-    if (waterTexture != null && waterTexture.contains(x, z)) {
-      float[] color = waterTexture.get(x, z);
-      return color[0] > 0 || color[1] > 0 || color[2] > 0;
-    }
-    return false;
+    return waterTexture != null && waterTexture.contains(x, z);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1830,6 +1830,11 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
+  /**
+   * Check if water plane chunk clipping is enabled. If so, the water plane is hidden in loaded
+   * chunks (i.e. it is ignored inside of loaded chunks).
+   * @return {@code true} if the water plane chunk clipping is enabled
+   */
   public boolean getWaterPlaneChunkClip() {
     return waterPlaneChunkClip;
   }
@@ -2520,7 +2525,13 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public boolean isInWater(Ray ray) {
     if (isWaterPlaneEnabled() && ray.o.y < getEffectiveWaterPlaneHeight()) {
-      return true;
+      if (getWaterPlaneChunkClip()) {
+        if (!isChunkLoaded((int)Math.floor(ray.o.x), (int)Math.floor(ray.o.z))) {
+          return true;
+        }
+      } else {
+        return true;
+      }
     }
     if (waterOctree.isInside(ray.o)) {
       int x = (int) QuickMath.floor(ray.o.x);

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -16,12 +16,18 @@
  */
 package se.llbit.chunky.world;
 
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.Lava;
 import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
+import se.llbit.chunky.chunk.EmptyChunkData;
 import se.llbit.chunky.chunk.GenericChunkData;
 import se.llbit.chunky.map.AbstractLayer;
 import se.llbit.chunky.map.BiomeLayer;
@@ -37,10 +43,6 @@ import se.llbit.nbt.SpecificTag;
 import se.llbit.nbt.Tag;
 import se.llbit.util.BitBuffer;
 import se.llbit.util.NotNull;
-
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.util.*;
 
 /**
  * This class represents a loaded or not-yet-loaded chunk in the world.
@@ -435,8 +437,9 @@ public class Chunk {
   /**
    * Load the block data for this chunk.
    *
-   * @param reuseChunkData to be reused, if null one is created
-   * @param palette
+   * @param reuseChunkData ChunkData object to be reused, if null one is created
+   * @param palette Block palette
+   * @return Loaded chunk data, guaranteed to be reuseChunkData unless null or EmptyChunkData was passed
    */
   public synchronized ChunkData getChunkData(ChunkData reuseChunkData, BlockPalette palette) {
     Set<String> request = new HashSet<>();
@@ -446,7 +449,7 @@ public class Chunk {
     request.add(LEVEL_ENTITIES);
     request.add(LEVEL_TILEENTITIES);
     Map<String, Tag> data = getChunkData(request);
-    if(reuseChunkData == null) {
+    if(reuseChunkData == null || reuseChunkData instanceof EmptyChunkData) {
       reuseChunkData = new GenericChunkData();
     } else {
       reuseChunkData.clear();

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -47,7 +47,7 @@ public class EmptyChunk extends Chunk {
 
   @Override public synchronized ChunkData getChunkData(ChunkData reuseChunkData, BlockPalette palette) {
     if (reuseChunkData == null) {
-      reuseChunkData = new EmptyChunkData();
+      reuseChunkData = EmptyChunkData.INSTANCE;
     } else {
       reuseChunkData.clear();
     }

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -47,7 +47,7 @@ public class EmptyRegionChunk extends Chunk {
 
   @Override public synchronized ChunkData getChunkData(ChunkData reuseChunkData, BlockPalette palette) {
     if (reuseChunkData == null) {
-      reuseChunkData = new EmptyChunkData();
+      reuseChunkData = EmptyChunkData.INSTANCE;
     } else {
       reuseChunkData.clear();
     }


### PR DESCRIPTION
Forgot to stage this in the last PR. A world texture contains a chunk texture iff that chunk is loaded, no need to get or check the color.