### PR TITLE
Improve numeric fields

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -151,8 +151,8 @@ public class ChunkyFxController
   @FXML private Hyperlink guideLink;
   @FXML private Hyperlink gplv3;
   @FXML private Button creditsBtn;
-  @FXML private TextField xPosition;
-  @FXML private TextField zPosition;
+  @FXML private DoubleTextField xPosition;
+  @FXML private DoubleTextField zPosition;
   @FXML private Button deleteChunks;
   @FXML private Button exportZip;
   @FXML private Button renderPng;
@@ -489,8 +489,8 @@ public class ChunkyFxController
     DoubleProperty zProperty = new SimpleDoubleProperty(initialView.z);
 
     // Bind controls with properties.
-    xPosition.textProperty().bindBidirectional(xProperty, new NumberStringConverter());
-    zPosition.textProperty().bindBidirectional(zProperty, new NumberStringConverter());
+    xPosition.valueProperty().bindBidirectional(xProperty);
+    zPosition.valueProperty().bindBidirectional(zProperty);
     scale.setRange(ChunkView.BLOCK_SCALE_MIN, ChunkView.BLOCK_SCALE_MAX);
     scale.clampBoth();
     scale.set(initialView.scale);

--- a/chunky/src/java/se/llbit/chunky/ui/render/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/CameraTab.java
@@ -45,6 +45,7 @@ import se.llbit.chunky.renderer.scene.Camera;
 import se.llbit.chunky.renderer.scene.CameraPreset;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.ui.DoubleAdjuster;
+import se.llbit.chunky.ui.DoubleTextField;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.json.JsonMember;
 import se.llbit.json.JsonObject;
@@ -63,30 +64,22 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
   @FXML private Button duplicate;
   @FXML private Button removeCamera;
   @FXML private TitledPane positionOrientation;
-  @FXML private TextField posX;
-  @FXML private TextField posY;
-  @FXML private TextField posZ;
-  @FXML private TextField yawField;
-  @FXML private TextField pitchField;
-  @FXML private TextField rollField;
+  @FXML private DoubleTextField posX;
+  @FXML private DoubleTextField posY;
+  @FXML private DoubleTextField posZ;
+  @FXML private DoubleTextField yawField;
+  @FXML private DoubleTextField pitchField;
+  @FXML private DoubleTextField rollField;
   @FXML private Button cameraToPlayer;
   @FXML private Button centerCamera;
   @FXML private ChoiceBox<ProjectionMode> projectionMode;
   @FXML private DoubleAdjuster fov;
   @FXML private DoubleAdjuster dof;
   @FXML private DoubleAdjuster subjectDistance;
-  @FXML private TextField shiftX;
-  @FXML private TextField shiftY;
+  @FXML private DoubleTextField shiftX;
+  @FXML private DoubleTextField shiftY;
   @FXML private Button autofocus;
 
-  private DoubleProperty xpos = new SimpleDoubleProperty();
-  private DoubleProperty ypos = new SimpleDoubleProperty();
-  private DoubleProperty zpos = new SimpleDoubleProperty();
-  private DoubleProperty yaw = new SimpleDoubleProperty();
-  private DoubleProperty pitch = new SimpleDoubleProperty();
-  private DoubleProperty roll = new SimpleDoubleProperty();
-  private DoubleProperty xshift = new SimpleDoubleProperty();
-  private DoubleProperty yshift = new SimpleDoubleProperty();
   private MapView mapView;
   private CameraViewListener cameraViewListener;
 
@@ -126,7 +119,6 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
 
   private void updateDof() {
     dof.set(scene.camera().getDof());
-
   }
 
   private void updateFov() {
@@ -134,8 +126,8 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
   }
 
   private void updateShift() {
-    xshift.set(scene.camera().getShiftX());
-    yshift.set(scene.camera().getShiftY());
+    shiftX.valueProperty().setValue(scene.camera().getShiftX());
+    shiftY.valueProperty().setValue(scene.camera().getShiftY());
   }
 
   @Override public void initialize(URL location, ResourceBundle resources) {
@@ -213,29 +205,26 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
       }
     });
 
-    posX.textProperty().bindBidirectional(xpos, new NumberStringConverter());
-    posY.textProperty().bindBidirectional(ypos, new NumberStringConverter());
-    posZ.textProperty().bindBidirectional(zpos, new NumberStringConverter());
-
     EventHandler<KeyEvent> positionHandler = e -> {
       if (e.getCode() == KeyCode.ENTER) {
         scene.camera()
-            .setPosition(new Vector3(xpos.getValue(), ypos.get(), zpos.get()));
+            .setPosition(new Vector3(
+                posX.valueProperty().get(),
+                posY.valueProperty().get(),
+                posZ.valueProperty().get()));
       }
     };
     posX.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
     posY.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
     posZ.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
 
-    yawField.textProperty().bindBidirectional(yaw, new NumberStringConverter());
-    pitchField.textProperty().bindBidirectional(pitch, new NumberStringConverter());
-    rollField.textProperty().bindBidirectional(roll, new NumberStringConverter());
-
     EventHandler<KeyEvent> directionHandler = e -> {
       if (e.getCode() == KeyCode.ENTER) {
         scene.camera()
-            .setView(QuickMath.degToRad(yaw.get()), QuickMath.degToRad(pitch.get()),
-                QuickMath.degToRad(roll.get()));
+            .setView(
+                QuickMath.degToRad(yawField.valueProperty().get()),
+                QuickMath.degToRad(pitchField.valueProperty().get()),
+                QuickMath.degToRad(rollField.valueProperty().get()));
       }
     };
     yawField.setTooltip(new Tooltip("Camera yaw."));
@@ -293,13 +282,11 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     });
 
     shiftX.setTooltip(new Tooltip("Horizontal lens shift (relative to the image height)."));
-    shiftX.textProperty().bindBidirectional(xshift, new NumberStringConverter());
     shiftY.setTooltip(new Tooltip("Vertical lens shift (relative to the image height)."));
-    shiftY.textProperty().bindBidirectional(yshift, new NumberStringConverter());
 
     EventHandler<KeyEvent> shiftHandler = e -> {
       if (e.getCode() == KeyCode.ENTER) {
-        scene.camera().setShift(xshift.doubleValue(), yshift.doubleValue());
+        scene.camera().setShift(shiftX.valueProperty().get(), shiftY.valueProperty().get());
       }
     };
     shiftX.addEventFilter(KeyEvent.KEY_PRESSED, shiftHandler);
@@ -348,9 +335,9 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     Camera camera = scene.camera();
     Vector3 pos = camera.getPosition();
     if (positionOrientation.isExpanded()) {
-      xpos.set(pos.x);
-      ypos.set(pos.y);
-      zpos.set(pos.z);
+      posX.valueProperty().set(pos.x);
+      posY.valueProperty().set(pos.y);
+      posZ.valueProperty().set(pos.z);
     }
     if (PersistentSettings.getFollowCamera()) {
       mapView.panTo(pos);
@@ -361,9 +348,9 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
   private void updateCameraDirection() {
     if (positionOrientation.isExpanded()) {
       Camera camera = scene.camera();
-      yaw.set(QuickMath.radToDeg(camera.getYaw()));
-      pitch.set(QuickMath.radToDeg(camera.getPitch()));
-      roll.set(QuickMath.radToDeg(camera.getRoll()));
+      yawField.valueProperty().set(QuickMath.radToDeg(camera.getYaw()));
+      pitchField.valueProperty().set(QuickMath.radToDeg(camera.getPitch()));
+      rollField.valueProperty().set(QuickMath.radToDeg(camera.getRoll()));
     }
     cameraViewListener.cameraViewUpdated();
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/EntitiesTab.java
@@ -61,6 +61,7 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.ui.AngleAdjuster;
 import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.IntegerAdjuster;
+import se.llbit.chunky.ui.IntegerTextField;
 import se.llbit.chunky.ui.RenderControlsFxController;
 import se.llbit.chunky.world.material.BeaconBeamMaterial;
 import se.llbit.fx.LuxColorPicker;
@@ -360,15 +361,13 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
             scene.rebuildActorBvh();
           }
         });
-        IntegerProperty layerHeightProp = new SimpleIntegerProperty();
-        TextField layerInput = new TextField();
+        IntegerTextField layerInput = new IntegerTextField();
         layerInput.setMaxWidth(50);
-        layerInput.textProperty().bindBidirectional(layerHeightProp, new NumberStringConverter());
         Button addButton = new Button("Add");
         addButton.setOnAction(e -> {
-          if (!beam.getMaterials().containsKey(layerHeightProp.get())) { //Don't allow duplicate indices
-            beam.getMaterials().put(layerHeightProp.get(), new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR));
-            colorHeightList.getItems().add(layerHeightProp.get());
+          if (!beam.getMaterials().containsKey(layerInput.valueProperty().get())) { //Don't allow duplicate indices
+            beam.getMaterials().put(layerInput.valueProperty().get(), new BeaconBeamMaterial(BeaconBeamMaterial.DEFAULT_COLOR));
+            colorHeightList.getItems().add(layerInput.valueProperty().get());
             scene.rebuildActorBvh();
           }
         });

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -32,7 +32,6 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextInputDialog;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
-import javafx.util.converter.NumberStringConverter;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.renderer.RenderController;
@@ -41,6 +40,7 @@ import se.llbit.chunky.ui.ChunkyFxController;
 import se.llbit.chunky.ui.IntegerAdjuster;
 import se.llbit.chunky.ui.RenderCanvasFx;
 import se.llbit.chunky.ui.RenderControlsFxController;
+import se.llbit.chunky.ui.SilentNumberStringConverter;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Icon;
 import se.llbit.chunky.world.World;
@@ -177,7 +177,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     biomeColors.selectedProperty().addListener((observable, oldValue, newValue) -> {
       scene.setBiomeColorsEnabled(newValue);
     });
-    dumpFrequency.setConverter(new NumberStringConverter());
+    dumpFrequency.setConverter(new SilentNumberStringConverter());
     dumpFrequency.getItems().addAll(50, 100, 500, 1000, 2500, 5000);
     dumpFrequency.setValue(Scene.DEFAULT_DUMP_FREQUENCY);
     dumpFrequency.setEditable(true);

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -24,6 +24,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import se.llbit.chunky.ui.IntegerAdjuster?>
+<?import se.llbit.chunky.ui.DoubleTextField?>
 <?import se.llbit.fx.ToolPane?>
 <?import javafx.scene.layout.FlowPane?>
 <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
@@ -103,9 +104,9 @@
           <Label text="Coordinates"/>
           <HBox alignment="CENTER_LEFT" spacing="10.0">
             <Label text="X="/>
-            <TextField prefWidth="80.0" fx:id="xPosition"/>
+            <DoubleTextField prefWidth="80.0" fx:id="xPosition"/>
             <Label text="Z="/>
-            <TextField fx:id="zPosition" prefWidth="80.0"/>
+            <DoubleTextField fx:id="zPosition" prefWidth="80.0"/>
           </HBox>
           <HBox spacing="10.0">
             <ToggleButton fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">

--- a/chunky/src/res/se/llbit/chunky/ui/render/CameraTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/CameraTab.fxml
@@ -7,7 +7,6 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.MenuButton?>
 <?import javafx.scene.control.Separator?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
@@ -16,6 +15,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
+<?import se.llbit.chunky.ui.DoubleTextField?>
 
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
     <VBox spacing="10.0">
@@ -49,16 +49,16 @@
               </rowConstraints>
               <children>
                 <Label text="Orientation:" GridPane.rowIndex="1" />
-                <TextField fx:id="yawField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                <TextField fx:id="pitchField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="1" />
-                <TextField fx:id="rollField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" GridPane.rowIndex="1" />
+                <DoubleTextField fx:id="yawField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                <DoubleTextField fx:id="pitchField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="1" />
+                <DoubleTextField fx:id="rollField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" GridPane.rowIndex="1" />
                 <Label text="Position:" />
-                <TextField fx:id="posX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" />
-                <TextField fx:id="posY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" />
-                <TextField fx:id="posZ" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" />
+                <DoubleTextField fx:id="posX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" />
+                <DoubleTextField fx:id="posY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" />
+                <DoubleTextField fx:id="posZ" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" />
                 <Label text="Lens shift:" GridPane.rowIndex="2" />
-                <TextField fx:id="shiftX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                <TextField fx:id="shiftY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+                <DoubleTextField fx:id="shiftX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                <DoubleTextField fx:id="shiftY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
               </children>
             </GridPane>
           </content>

--- a/chunky/src/res/style.css
+++ b/chunky/src/res/style.css
@@ -48,3 +48,9 @@ Hyperlink:hover {
     -fx-text-fill: #faebd7;
     -fx-underline: true;
 }
+
+.text-field.invalid {
+    -fx-text-fill: #FF434A;
+    -fx-text-box-border: #FF434A;
+    -fx-focus-color: #FF434A;
+}

--- a/lib/src/se/llbit/chunky/ui/Adjuster.java
+++ b/lib/src/se/llbit/chunky/ui/Adjuster.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.ui;
 
+import java.util.function.Consumer;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleStringProperty;
@@ -23,30 +24,27 @@ import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
-import javafx.util.converter.NumberStringConverter;
-
-import java.util.function.Consumer;
 
 /**
  * A control for editing numeric values with a text field.
  */
 public abstract class Adjuster<T extends Number> extends HBox {
+
   private final StringProperty name = new SimpleStringProperty("Name");
   protected final Label nameLbl = new Label();
-  protected final TextField valueField = new TextField();
+  protected final NumericTextField<Property<Number>> valueField;
   protected final Property<Number> value;
   private ChangeListener<Number> listener;
 
   protected Adjuster(Property<Number> value) {
     this.value = value;
+    valueField = new NumericTextField<>(value);
     nameLbl.textProperty().bind(Bindings.concat(name, ":"));
     setAlignment(Pos.CENTER_LEFT);
     setSpacing(10);
     valueField.setPrefWidth(103);
-    valueField.textProperty().bindBidirectional(value, new NumberStringConverter());
     getChildren().addAll(nameLbl, valueField);
   }
 

--- a/lib/src/se/llbit/chunky/ui/DoubleTextField.java
+++ b/lib/src/se/llbit/chunky/ui/DoubleTextField.java
@@ -1,0 +1,11 @@
+package se.llbit.chunky.ui;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+
+public class DoubleTextField extends NumericTextField<DoubleProperty> {
+
+  public DoubleTextField() {
+    super(new SimpleDoubleProperty());
+  }
+}

--- a/lib/src/se/llbit/chunky/ui/IntegerTextField.java
+++ b/lib/src/se/llbit/chunky/ui/IntegerTextField.java
@@ -1,0 +1,11 @@
+package se.llbit.chunky.ui;
+
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+
+public class IntegerTextField extends NumericTextField<IntegerProperty> {
+
+  public IntegerTextField() {
+    super(new SimpleIntegerProperty());
+  }
+}

--- a/lib/src/se/llbit/chunky/ui/NumericTextField.java
+++ b/lib/src/se/llbit/chunky/ui/NumericTextField.java
@@ -1,0 +1,45 @@
+package se.llbit.chunky.ui;
+
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.Property;
+import javafx.scene.control.TextField;
+
+/**
+ * A {@link TextField} that automatically converts the value to a number.
+ * <p>
+ * If the text content is not a number, the <code>invalid</code> style class is added to this
+ * field.
+ */
+public class NumericTextField<T extends Property<Number>> extends TextField {
+
+  private final T value;
+  private final SilentNumberStringConverter converter;
+
+  public NumericTextField(T value) {
+    this.value = value;
+    getStyleClass().add("numeric-text-field");
+    converter = new SilentNumberStringConverter(
+        (observable, oldValue, newVaue) -> {
+          if (!newVaue) {
+            getStyleClass().add("invalid");
+          } else {
+            getStyleClass().remove("invalid");
+          }
+        });
+    textProperty().bindBidirectional(value, converter);
+  }
+
+  /**
+   * @return The numeric content of this text field.
+   */
+  public T valueProperty() {
+    return value;
+  }
+
+  /**
+   * @return A property that indicates whether the value is a correct number
+   */
+  public BooleanProperty validProperty() {
+    return converter.validProperty();
+  }
+}

--- a/lib/src/se/llbit/chunky/ui/SilentNumberStringConverter.java
+++ b/lib/src/se/llbit/chunky/ui/SilentNumberStringConverter.java
@@ -1,0 +1,49 @@
+package se.llbit.chunky.ui;
+
+import java.text.ParseException;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.util.converter.NumberStringConverter;
+
+/**
+ * A {@link NumberStringConverter} that does not throw a RuntimeException if parsing fails but just
+ * treats invalid input as empty input.
+ */
+public class SilentNumberStringConverter extends NumberStringConverter {
+
+  private final BooleanProperty isValid = new SimpleBooleanProperty(true);
+
+  public SilentNumberStringConverter() {
+  }
+
+  public SilentNumberStringConverter(ChangeListener<Boolean> listener) {
+    isValid.addListener(listener);
+  }
+
+  @Override
+  public Number fromString(String value) {
+    try {
+      Number number = super.fromString(value);
+      isValid.setValue(number != null);
+      return number;
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof ParseException) {
+        isValid.setValue(false);
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public String toString(Number value) {
+    isValid.setValue(value != null);
+    return super.toString(value);
+  }
+
+  public BooleanProperty validProperty() {
+    return this.isValid;
+  }
+}


### PR DESCRIPTION
Currently all numeric inputs throw `RuntimeException`s if the input can't be converted to a number. While this error can safely be ignored it produces a lot of noise and frequently makes people think that it's a bug.

This PR fixes that and introduces new convenient `TextField`s for numeric input that get a red border if the input is invalid.

![image](https://user-images.githubusercontent.com/5544859/116793923-f4f86500-aac9-11eb-9079-ae52b9a3d81f.png)
