### PR TITLE
Make ChunkPosition#get much faster

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -44,25 +44,12 @@ public class ChunkPosition {
     return get(x >> 5, z >> 5);
   }
 
-  private static final Map<Integer, Map<Integer, ChunkPosition>> map = new ConcurrentHashMap<>();
+  //not using synchronized Long2ReferenceOpenHashMap due to using one lock. ConcurrentHashMap locks on buckets
+  private static final Map<Long, ChunkPosition> positions = new ConcurrentHashMap<>();
+  private static final long INT_BIT_MASK = (1L << 32) - 1;
 
   public static ChunkPosition get(int x, int z) {
-    Map<Integer, ChunkPosition> submap = map.get(x);
-    if (submap == null) {
-      submap = new ConcurrentHashMap<>();
-      map.put(x, submap);
-      ChunkPosition chunkPosition = new ChunkPosition(x, z);
-      submap.put(z, chunkPosition);
-      return chunkPosition;
-    }
-
-    ChunkPosition chunkPosition = submap.get(z);
-    if (chunkPosition == null) {
-      chunkPosition = new ChunkPosition(x, z);
-      submap.put(z, chunkPosition);
-    }
-
-    return chunkPosition;
+    return positions.computeIfAbsent((x & INT_BIT_MASK) | (z & INT_BIT_MASK) << 32, (position) -> new ChunkPosition(x, z));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -46,10 +46,9 @@ public class ChunkPosition {
 
   //not using synchronized Long2ReferenceOpenHashMap due to using one lock. ConcurrentHashMap locks on buckets
   private static final Map<Long, ChunkPosition> positions = new ConcurrentHashMap<>();
-  private static final long INT_BIT_MASK = (1L << 32) - 1;
 
   public static ChunkPosition get(int x, int z) {
-    return positions.computeIfAbsent((x & INT_BIT_MASK) | (z & INT_BIT_MASK) << 32, (position) -> new ChunkPosition(x, z));
+    return positions.computeIfAbsent((z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32, (position) -> new ChunkPosition(x, z));
   }
 
   /**


### PR DESCRIPTION
eliminates one hashmap get
also uses `computeIfAbsent` insead of `get` nullcheck `put` which is also faster