### PR TITLE
Fix redstone wire north and south up states.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/RedstoneWire.java
+++ b/chunky/src/java/se/llbit/chunky/block/RedstoneWire.java
@@ -33,13 +33,13 @@ public class RedstoneWire extends MinecraftBlock {
     }
     if (!north.equals("none")) {
       state |= 1 << BlockData.RSW_NORTH_CONNECTION;
-      if (south.equals("up")) {
+      if (north.equals("up")) {
         state |= 1 << BlockData.RSW_NORTH_UP;
       }
     }
     if (!south.equals("none")) {
       state |= 1 << BlockData.RSW_SOUTH_CONNECTION;
-      if (north.equals("up")) {
+      if (south.equals("up")) {
         state |= 1 << BlockData.RSW_SOUTH_UP;
       }
     }


### PR DESCRIPTION
Previously the "up" wire would be missing sometimes for north and south.
![image](https://user-images.githubusercontent.com/5544859/117890083-cf7f0e80-b2b4-11eb-82c1-12deb24bb298.png)

This is part of #888 
This needs to be added to #901 
