### PR TITLE
Fix bug where the blocks were wrong with small octree

### DIFF
--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -365,6 +365,9 @@ public class Octree {
   }
 
   public Material getMaterial(int x, int y, int z, BlockPalette palette) {
+    int size = (1 << implementation.getDepth());
+    if(x < 0 || y < 0 || z < 0 || x >= size || y >= size || z >= size)
+      return Air.INSTANCE;
     return implementation.getMaterial(x, y, z, palette);
   }
 

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -364,6 +364,14 @@ public class Octree {
     return implementation.get(x, y, z);
   }
 
+  /**
+   * Get the material at the given position (relative to the octree origin).
+   * @param x x position
+   * @param y y position
+   * @param z z position
+   * @param palette Block palette
+   * @return Material at the given position or {@link Air#INSTANCE} if the position is outside of this octree
+   */
   public Material getMaterial(int x, int y, int z, BlockPalette palette) {
     int size = (1 << implementation.getDepth());
     if(x < 0 || y < 0 || z < 0 || x >= size || y >= size || z >= size)


### PR DESCRIPTION
Fix the bug where we had this
![image](https://user-images.githubusercontent.com/23342398/118107941-ac9d4900-b3df-11eb-8f1c-89c95458b5b2.png)
instead of this
![image](https://user-images.githubusercontent.com/23342398/118107977-b7f07480-b3df-11eb-943d-ce92e138bada.png)
when loading a single chunk with yMin-yMax to 0-16.

The cause of the bug is that, during finalization we checked blocks out of bounds of the octree when trying to do the replacement by ANY, those out of bounds access wrapped around and where accessing the blocks at the other end of the octree. When the blocks at the other end of the octree are solid, the block at the edge of the octree is thought to be hidden when it is not.

See how this is bug is also reproduced with a 32\*32\*32 octree
![image](https://user-images.githubusercontent.com/23342398/118107854-92636b00-b3df-11eb-8382-5cfa7837274c.png)

Or even by a situation a bit more complex:
![image](https://user-images.githubusercontent.com/23342398/118108842-c723f200-b3e0-11eb-87d9-00fcd53a94c8.png)
The front face is wrong because the adjacent blocks are thought to be the one on the back of the chunk in the background.

Anyway the fix is to check for out of bound access and return Air in this case