### PR TITLE
Fix broken water world

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2525,7 +2525,7 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   public boolean isInWater(Ray ray) {
-    if (isWaterPlaneEnabled() && ray.o.y < getEffectiveWaterPlaneHeight()) {
+    if (isWaterPlaneEnabled() && ray.o.y + origin.y < getEffectiveWaterPlaneHeight()) {
       if (getWaterPlaneChunkClip()) {
         if (!isChunkLoaded((int)Math.floor(ray.o.x), (int)Math.floor(ray.o.z))) {
           return true;


### PR DESCRIPTION
Fix #934

The bug was because the origin was not taken into account when doing the height comparison of the water plane with the y of the ray origin.
The bug does not manifest itself when yMin is 0 which is probably the reason you couldn't reproduce it.