### PR TITLE
Save the window position/size on close and restore that on startup

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -24,6 +24,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.main.Chunky;
@@ -81,12 +82,18 @@ public class ChunkyFx extends Application {
       JsonValue windowHeight = PersistentSettings.settings.get("window.height");
       JsonValue windowMaximized = PersistentSettings.settings.get("window.maximized");
 
-      if(!windowX.isUnknown() && !windowY.isUnknown() && !windowWidth.isUnknown()
-              && !windowHeight.isUnknown() && !windowMaximized.isUnknown()) {
-        stage.setX(windowX.asDouble(0));
-        stage.setY(windowY.asDouble(0));
-        stage.setWidth(windowWidth.asDouble(1800));
-        stage.setHeight(windowHeight.asDouble(1000));
+      if (!windowX.isUnknown() && !windowY.isUnknown() && !windowWidth.isUnknown()
+          && !windowHeight.isUnknown() && !windowMaximized.isUnknown()) {
+        double x = windowX.asDouble(0);
+        double y = windowY.asDouble(0);
+        double width = Math.max(300, windowWidth.asDouble(1800));
+        double height = Math.max(300, windowHeight.asDouble(1000));
+        if (!Screen.getScreensForRectangle(x, y, width, height).isEmpty()) {
+          stage.setX(x);
+          stage.setY(y);
+          stage.setWidth(width);
+          stage.setHeight(height);
+        }
         stage.setMaximized(windowMaximized.asBoolean(true));
       } else {
         stage.setWidth(1800);

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -25,9 +25,11 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.resources.SettingsDirectory;
+import se.llbit.json.JsonValue;
 import se.llbit.log.Log;
 
 import java.io.File;
@@ -57,6 +59,12 @@ public class ChunkyFx extends Application {
       controller.setApplication(this);
       stage.getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
       stage.setOnCloseRequest(event -> {
+        PersistentSettings.settings.setDouble("window.x", stage.getX());
+        PersistentSettings.settings.setDouble("window.y", stage.getY());
+        PersistentSettings.settings.setDouble("window.width", stage.getWidth());
+        PersistentSettings.settings.setDouble("window.height", stage.getHeight());
+        PersistentSettings.settings.setBool("window.maximized", stage.isMaximized());
+        PersistentSettings.save();
         Platform.exit();
         System.exit(0);
       });
@@ -66,8 +74,24 @@ public class ChunkyFx extends Application {
       } else {
         scene.getStylesheets().add("style.css");
       }
-      stage.setWidth(1800);
-      stage.setMaximized(true);
+
+      JsonValue windowX = PersistentSettings.settings.get("window.x");
+      JsonValue windowY = PersistentSettings.settings.get("window.y");
+      JsonValue windowWidth = PersistentSettings.settings.get("window.width");
+      JsonValue windowHeight = PersistentSettings.settings.get("window.height");
+      JsonValue windowMaximized = PersistentSettings.settings.get("window.maximized");
+
+      if(!windowX.isUnknown() && !windowY.isUnknown() && !windowWidth.isUnknown()
+              && !windowHeight.isUnknown() && !windowMaximized.isUnknown()) {
+        stage.setX(windowX.asDouble(0));
+        stage.setY(windowY.asDouble(0));
+        stage.setWidth(windowWidth.asDouble(1800));
+        stage.setHeight(windowHeight.asDouble(1000));
+        stage.setMaximized(windowMaximized.asBoolean(true));
+      } else {
+        stage.setWidth(1800);
+        stage.setMaximized(true);
+      }
       stage.show();
     } catch (Exception e) {
       e.printStackTrace(System.err);

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -30,6 +30,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.resources.SettingsDirectory;
+import se.llbit.fxutil.WindowPosition;
 import se.llbit.json.JsonValue;
 import se.llbit.log.Log;
 
@@ -60,12 +61,7 @@ public class ChunkyFx extends Application {
       controller.setApplication(this);
       stage.getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
       stage.setOnCloseRequest(event -> {
-        PersistentSettings.settings.setDouble("window.x", stage.getX());
-        PersistentSettings.settings.setDouble("window.y", stage.getY());
-        PersistentSettings.settings.setDouble("window.width", stage.getWidth());
-        PersistentSettings.settings.setDouble("window.height", stage.getHeight());
-        PersistentSettings.settings.setBool("window.maximized", stage.isMaximized());
-        PersistentSettings.save();
+        PersistentSettings.setWindowPosition(new WindowPosition(stage));
         Platform.exit();
         System.exit(0);
       });
@@ -76,25 +72,9 @@ public class ChunkyFx extends Application {
         scene.getStylesheets().add("style.css");
       }
 
-      JsonValue windowX = PersistentSettings.settings.get("window.x");
-      JsonValue windowY = PersistentSettings.settings.get("window.y");
-      JsonValue windowWidth = PersistentSettings.settings.get("window.width");
-      JsonValue windowHeight = PersistentSettings.settings.get("window.height");
-      JsonValue windowMaximized = PersistentSettings.settings.get("window.maximized");
-
-      if (!windowX.isUnknown() && !windowY.isUnknown() && !windowWidth.isUnknown()
-          && !windowHeight.isUnknown() && !windowMaximized.isUnknown()) {
-        double x = windowX.asDouble(0);
-        double y = windowY.asDouble(0);
-        double width = Math.max(300, windowWidth.asDouble(1800));
-        double height = Math.max(300, windowHeight.asDouble(1000));
-        if (!Screen.getScreensForRectangle(x, y, width, height).isEmpty()) {
-          stage.setX(x);
-          stage.setY(y);
-          stage.setWidth(width);
-          stage.setHeight(height);
-        }
-        stage.setMaximized(windowMaximized.asBoolean(true));
+      WindowPosition windowPosition = PersistentSettings.getPreviousWindowPosition();
+      if (windowPosition != null) {
+        windowPosition.apply(stage, 300, 300);
       } else {
         stage.setWidth(1800);
         stage.setMaximized(true);

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 import se.llbit.chunky.renderer.RenderConstants;
 import se.llbit.chunky.resources.SettingsDirectory;
+import se.llbit.fxutil.WindowPosition;
 import se.llbit.json.JsonArray;
 import se.llbit.json.JsonValue;
 
@@ -460,6 +461,34 @@ public final class PersistentSettings {
 
   public static void setCanvasFitToScreen(boolean fitToScreen) {
     settings.setBool("canvasFitToScreen", fitToScreen);
+    save();
+  }
+
+  public static WindowPosition getPreviousWindowPosition() {
+    JsonValue windowX = settings.get("window.x");
+    JsonValue windowY = settings.get("window.y");
+    JsonValue windowWidth = settings.get("window.width");
+    JsonValue windowHeight = settings.get("window.height");
+    JsonValue windowMaximized = settings.get("window.maximized");
+
+    if (!windowX.isUnknown() && !windowY.isUnknown() && !windowWidth.isUnknown()
+        && !windowHeight.isUnknown() && !windowMaximized.isUnknown()) {
+      return new WindowPosition(
+          windowX.doubleValue(0),
+          windowY.doubleValue(0),
+          windowWidth.doubleValue(1800),
+          windowHeight.doubleValue(1000),
+          windowMaximized.boolValue(false));
+    }
+    return null;
+  }
+
+  public static void setWindowPosition(WindowPosition position) {
+    settings.setDouble("window.x", position.getX());
+    settings.setDouble("window.y", position.getY());
+    settings.setDouble("window.width", position.getWidth());
+    settings.setDouble("window.height", position.getHeight());
+    settings.setBool("window.maximized", position.isMaximized());
     save();
   }
 }

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -85,7 +85,7 @@ public final class PersistentSettings {
     changeSettingsDirectory(directory);
   }
 
-  private static void save() {
+  public static void save() {
     settings.save(settingsDir, settingsFile);
   }
 

--- a/lib/src/se/llbit/fxutil/WindowPosition.java
+++ b/lib/src/se/llbit/fxutil/WindowPosition.java
@@ -1,0 +1,64 @@
+package se.llbit.fxutil;
+
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+
+public class WindowPosition {
+
+  private final double x;
+  private final double y;
+  private final double width;
+  private final double height;
+  private final boolean maximized;
+
+  public WindowPosition(double x, double y, double width, double height, boolean maximized) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+    this.maximized = maximized;
+  }
+
+  public WindowPosition(Stage stage) {
+    this(stage.getX(), stage.getY(), stage.getWidth(), stage.getHeight(), stage.isMaximized());
+  }
+
+  public double getX() {
+    return x;
+  }
+
+  public double getY() {
+    return y;
+  }
+
+  public double getWidth() {
+    return width;
+  }
+
+  public double getHeight() {
+    return height;
+  }
+
+  public boolean isMaximized() {
+    return maximized;
+  }
+
+  /**
+   * Move the given stage to this window position if the position is at least on one screen.
+   *
+   * @param stage Stage to reposition
+   * @param minWidth Minimum window width
+   * @param minHeight Minimum window height
+   */
+  public void apply(Stage stage, double minWidth, double minHeight) {
+    double width = Math.max(minWidth, this.width);
+    double height = Math.max(minHeight, this.height);
+    if (!Screen.getScreensForRectangle(x, y, width, height).isEmpty()) {
+      stage.setX(x);
+      stage.setY(y);
+      stage.setWidth(width);
+      stage.setHeight(height);
+    }
+    stage.setMaximized(maximized);
+  }
+}


### PR DESCRIPTION
Small quality of life feature (maybe more for me that for real users).
I was annoyed with chunky starting maximized every time I start it (often while debugging) when I don't want it to cover the whole screen.
I was not able to test this with multiple screen, if someone can try that, I'd appreciate it. I'm especially worried about the situation where the chunky window is put on the second screen, close (saving its position), the second screen is unplugged and chunky reopened, I don't know where chunky would go in this situation