### PR TITLE
Prevent empty scene creation

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -137,6 +137,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     MenuItem clearSelection = new MenuItem("Clear selection");
     clearSelection.setGraphic(new ImageView(Icon.clear.fxImage()));
     clearSelection.setOnAction(event -> chunkSelection.clearSelection());
+    clearSelection.setDisable(chunkSelection.size() == 0);
 
     MenuItem newScene = new MenuItem("New scene from selection");
     newScene.setGraphic(new ImageView(Icon.sky.fxImage()));
@@ -144,6 +145,12 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       SceneManager sceneManager = controller.getRenderController().getSceneManager();
       sceneManager
           .loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
+    });
+    newScene.setDisable(chunkSelection.size() == 0);
+    chunkSelection.addSelectionListener(() -> {
+      boolean noChunksSelected = chunkSelection.size() == 0;
+      clearSelection.setDisable(noChunksSelected);
+      newScene.setDisable(noChunksSelected);
     });
 
     moveCameraHere.setOnAction(event -> {

--- a/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/GeneralTab.java
@@ -116,7 +116,18 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     biomeColors.setSelected(scene.biomeColorsEnabled());
     saveSnapshots.setSelected(scene.shouldSaveSnapshots());
     reloadChunks.setDisable(scene.numberOfChunks() == 0);
-    loadSelectedChunks.setDisable(mapLoader.getWorld() instanceof EmptyWorld || mapLoader.getWorld() == null);
+    loadSelectedChunks.setDisable(
+      mapLoader.getWorld() instanceof EmptyWorld ||
+      mapLoader.getWorld() == null ||
+      chunkyFxController.getChunkSelection().size() == 0
+    );
+    chunkyFxController.getChunkSelection().addSelectionListener(() -> {
+      loadSelectedChunks.setDisable(
+        mapLoader.getWorld() instanceof EmptyWorld ||
+        mapLoader.getWorld() == null ||
+        chunkyFxController.getChunkSelection().size() == 0
+      );
+    });
   }
 
   @Override public String getTabTitle() {

--- a/chunky/src/res/style.css
+++ b/chunky/src/res/style.css
@@ -54,3 +54,12 @@ Hyperlink:hover {
     -fx-text-box-border: #FF434A;
     -fx-focus-color: #FF434A;
 }
+
+.menu-item:disabled:focused {
+    -fx-background: unset;
+    -fx-background-color: transparent;
+}
+
+.menu-item:disabled:focused > .label {
+    -fx-text-fill: white;
+}


### PR DESCRIPTION
Related to #945 but doesn't actually fix the bug but only prevents users from creating empty scenes (which is a tiny UX improvement).