### PR TITLE
Fix parsing skull textures that are not valid json (again)

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -20,7 +20,7 @@ public class Head extends MinecraftBlockTranslucent {
   // the decoded string might not be valid json (sometimes keys are not quoted)
   // so we use a regex to extract the skin url
   private static final Pattern SKIN_URL_FROM_OBJECT = Pattern
-      .compile("\"?SKIN\"?\\s*:\\s*\\{.+?\"?url\"?\\s*:\\s*\"(.+?)\"", Pattern.DOTALL);
+      .compile("\"?SKIN\"?\\s*:\\s*\\{(.*)\"?url\"?\\s*:\\s*\"(.*)\"", Pattern.DOTALL);
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;
@@ -82,7 +82,7 @@ public class Head extends MinecraftBlockTranslucent {
         String decoded = new String(Base64.getDecoder().decode(fixBase64Padding(textureBase64)));
         Matcher matcher = SKIN_URL_FROM_OBJECT.matcher(decoded);
         if (matcher.find()) {
-          return matcher.group(1);
+          return matcher.group(2);
         } else {
           Log.warn("Could not get skull texture from json: " + decoded);
         }

--- a/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
+++ b/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
@@ -1,16 +1,19 @@
 package se.llbit.chunky.block;
 
+import static org.junit.Assert.assertEquals;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
-import junit.framework.TestCase;
+import org.junit.Test;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ListTag;
 import se.llbit.nbt.StringTag;
 import se.llbit.nbt.Tag;
 
-public class SkullTextureTest extends TestCase {
+public class SkullTextureTest {
 
+  @Test
   public void testValidJson() {
     CompoundTag validOwnerTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
         "{ \"textures\": { \"SKIN\": { \"url\": \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
@@ -20,6 +23,7 @@ public class SkullTextureTest extends TestCase {
         Head.getTextureUrl(validOwnerTag));
   }
 
+  @Test
   public void testSkullOwner() {
     // player heads use SkullOwner, which should work too
     CompoundTag validOwnerTag = createSkullTag("SkullOwner", Base64.getEncoder().encodeToString(
@@ -30,6 +34,7 @@ public class SkullTextureTest extends TestCase {
         Head.getTextureUrl(validOwnerTag));
   }
 
+  @Test
   public void testInvalidJson() { // test for #680, #681
     CompoundTag validOwnerTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
         "{textures:{SKIN:{url:\"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\"}}}"
@@ -39,6 +44,7 @@ public class SkullTextureTest extends TestCase {
         Head.getTextureUrl(validOwnerTag));
   }
 
+  @Test
   public void testAlexSkull() { // test for #749
     CompoundTag validJsonAlexTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
         "{ \"textures\": { \"SKIN\": {\"metadata\": {\"model\": \"slim\"}, \"url\": \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
@@ -55,6 +61,7 @@ public class SkullTextureTest extends TestCase {
         Head.getTextureUrl(invalidJsonAlexTag));
   }
 
+  @Test
   public void testBadBase64Padding() { // test for #900
     CompoundTag validOwnerTag = createSkullTag("Owner",
         // the following base64 string has intentional wrong padding
@@ -64,8 +71,9 @@ public class SkullTextureTest extends TestCase {
         Head.getTextureUrl(validOwnerTag));
   }
 
+  @Test
   public void testLinebreaks() { // test for #764
-    CompoundTag validOwnerTag = createSkullTag("Owner",Base64.getEncoder().encodeToString(
+    CompoundTag validOwnerTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
         "{ \"textures\":\n{ \"SKIN\": {\n  \"metadata\": {\n\"model\": \"slim\"},\n \"url\":\n \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
             .getBytes(StandardCharsets.UTF_8)));
     assertEquals(

--- a/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
+++ b/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
@@ -1,0 +1,89 @@
+package se.llbit.chunky.block;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import junit.framework.TestCase;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.ListTag;
+import se.llbit.nbt.StringTag;
+import se.llbit.nbt.Tag;
+
+public class SkullTextureTest extends TestCase {
+
+  public void testValidJson() {
+    CompoundTag validOwnerTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
+        "{ \"textures\": { \"SKIN\": { \"url\": \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validOwnerTag));
+  }
+
+  public void testSkullOwner() {
+    // player heads use SkullOwner, which should work too
+    CompoundTag validOwnerTag = createSkullTag("SkullOwner", Base64.getEncoder().encodeToString(
+        "{ \"textures\": { \"SKIN\": { \"url\": \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validOwnerTag));
+  }
+
+  public void testInvalidJson() { // test for #680, #681
+    CompoundTag validOwnerTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
+        "{textures:{SKIN:{url:\"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\"}}}"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validOwnerTag));
+  }
+
+  public void testAlexSkull() { // test for #749
+    CompoundTag validJsonAlexTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
+        "{ \"textures\": { \"SKIN\": {\"metadata\": {\"model\": \"slim\"}, \"url\": \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validJsonAlexTag));
+
+    CompoundTag invalidJsonAlexTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
+        "{textures:{SKIN:{metadata:{model:\"slim\"},url:\"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\"}}}"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(invalidJsonAlexTag));
+  }
+
+  public void testBadBase64Padding() { // test for #900
+    CompoundTag validOwnerTag = createSkullTag("Owner",
+        // the following base64 string has intentional wrong padding
+        "eyAidGV4dHVyZXMiOiB7ICJTS0lOIjogeyJtZXRhZGF0YSI6IHsibW9kZWwiOiAic2xpbSJ9LCAidXJsIjogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWFjZGU5NTRkYjMyNzY4NTIwMWY3ODVhNmIyNDhiNzNmZGM4OTgyYzJhZWQ0MzBmNjk3Y2RlYmVjOWI3ZTE0IiB9IH0gfQ=");
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validOwnerTag));
+  }
+
+  public void testLinebreaks() { // test for #764
+    CompoundTag validOwnerTag = createSkullTag("Owner",Base64.getEncoder().encodeToString(
+        "{ \"textures\":\n{ \"SKIN\": {\n  \"metadata\": {\n\"model\": \"slim\"},\n \"url\":\n \"http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14\" } } }"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/1acde954db327685201f785a6b248b73fdc8982c2aed430f697cdebec9b7e14",
+        Head.getTextureUrl(validOwnerTag));
+  }
+
+  private static CompoundTag createSkullTag(String rootKey, String value) {
+    CompoundTag skull = new CompoundTag();
+    CompoundTag ownerTag = new CompoundTag();
+    CompoundTag properties = new CompoundTag();
+    CompoundTag valueTag = new CompoundTag();
+    valueTag.add("Value", new StringTag(value));
+    properties.add("textures", new ListTag(Tag.TAG_COMPOUND, Collections.singletonList(
+        valueTag
+    )));
+    ownerTag.add("Properties", properties);
+    skull.add(rootKey, ownerTag);
+    return skull;
+  }
+}


### PR DESCRIPTION
…also add tests so that this doesn't break again, hopefully (they test all known bugs with this feature, testing it manually is very tedious).

Fixes #680 again