### PR TITLE
Handle unsupported post-processors more gracefully when exporting a tiff

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/GammaCorrectionFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/GammaCorrectionFilter.java
@@ -4,8 +4,6 @@ import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
 
 public class GammaCorrectionFilter extends SimplePixelPostProcessingFilter {
-  public static final String ID = "GAMMA";
-
   @Override
   public void processPixel(double[] pixel) {
     for(int i = 0; i < 3; ++i) {
@@ -20,6 +18,6 @@ public class GammaCorrectionFilter extends SimplePixelPostProcessingFilter {
 
   @Override
   public String getId() {
-    return ID;
+    return "GAMMA";
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/GammaCorrectionFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/GammaCorrectionFilter.java
@@ -4,6 +4,8 @@ import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
 
 public class GammaCorrectionFilter extends SimplePixelPostProcessingFilter {
+  public static final String ID = "GAMMA";
+
   @Override
   public void processPixel(double[] pixel) {
     for(int i = 0; i < 3; ++i) {
@@ -18,6 +20,6 @@ public class GammaCorrectionFilter extends SimplePixelPostProcessingFilter {
 
   @Override
   public String getId() {
-    return "GAMMA";
+    return ID;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PixelPostProcessingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PixelPostProcessingFilter.java
@@ -3,7 +3,7 @@ package se.llbit.chunky.renderer.postprocessing;
 import se.llbit.chunky.plugin.PluginApi;
 
 /**
- * Post processing filter that support querying one pixel at a time
+ * Post processing filter that supports processing one pixel at a time.
  */
 @PluginApi
 public interface PixelPostProcessingFilter extends PostProcessingFilter {

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilter.java
@@ -4,6 +4,15 @@ import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.util.TaskTracker;
 
+/**
+ * A post processing filter.
+ * <p>
+ * These filters are used to convert the HDR sample buffer into an SDR image that can be displayed.
+ * Exposure is also applied by the filter.
+ * <p>
+ * Filters that support processing a single pixel at a time should implement {@link
+ * PixelPostProcessingFilter} instead.
+ */
 @PluginApi
 public interface PostProcessingFilter {
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilters.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilters.java
@@ -6,20 +6,20 @@ import java.util.*;
 
 public abstract class PostProcessingFilters {
 
+  public static final PixelPostProcessingFilter NONE = new NoneFilter();
+
   private static final Map<String, PostProcessingFilter> filters = new HashMap<>();
   // using tree map for the added benefit of sorting by name
   private static final Map<String, PostProcessingFilter> filtersByName = new TreeMap<>();
-  private static final PostProcessingFilter defaultFilter;
-  
+
   static {
-    defaultFilter = new GammaCorrectionFilter();
-    addPostProcessingFilter(defaultFilter);
-    addPostProcessingFilter(new NoneFilter());
+    addPostProcessingFilter(NONE);
+    addPostProcessingFilter(new GammaCorrectionFilter());
     addPostProcessingFilter(new Tonemap1Filter());
     addPostProcessingFilter(new ACESFilmicFilter());
     addPostProcessingFilter(new HableToneMappingFilter());
   }
-  
+
   public static Optional<PostProcessingFilter> getPostProcessingFilterFromId(String id) {
     return Optional.ofNullable(filters.get(id));
   }
@@ -33,10 +33,6 @@ public abstract class PostProcessingFilters {
 
   public static Collection<PostProcessingFilter> getFilters() {
     return filtersByName.values();
-  }
-
-  public static PostProcessingFilter getDefault() {
-    return defaultFilter;
   }
 
   @PluginApi

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -71,7 +71,6 @@ import se.llbit.chunky.renderer.ResetReason;
 import se.llbit.chunky.renderer.WorkerState;
 import se.llbit.chunky.renderer.export.PictureExportFormat;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
-import se.llbit.chunky.renderer.postprocessing.PixelPostProcessingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
 import se.llbit.chunky.renderer.postprocessing.PreviewFilter;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -178,6 +178,12 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public static final double DEFAULT_FOG_DENSITY = 0.0;
 
+  /**
+   * Default post processing filter.
+   */
+  public static final PostProcessingFilter DEFAULT_POSTPROCESSING_FILTER = PostProcessingFilters
+      .getPostProcessingFilterFromId("GAMMA").orElse(PostProcessingFilters.NONE);
+
   protected final Sky sky = new Sky(this);
   protected final Camera camera = new Camera(this);
   protected final Sun sun = new Sun(this);
@@ -200,7 +206,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public int height;
 
-  public PostProcessingFilter postProcessingFilter = PostProcessingFilters.getDefault();
+  public PostProcessingFilter postProcessingFilter = DEFAULT_POSTPROCESSING_FILTER;
   public PictureExportFormat outputMode = PictureExportFormats.PNG;
   public long renderTime;
   /**
@@ -2831,7 +2837,7 @@ public class Scene implements JsonSerializable, Refreshable {
                 Log.warn("The post processing filter " + json +
                         " is unknown. Maybe you're missing a plugin that was used to create this scene?");
               }
-              return PostProcessingFilters.getDefault();
+              return DEFAULT_POSTPROCESSING_FILTER;
             });
     outputMode = PictureExportFormats
       .getFormat(json.get("outputMode").stringValue(outputMode.getName()))

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2239,17 +2239,6 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * Postprocess a pixel. This applies gamma correction and clamps the color value to [0,1].
-   *
-   * @param result the resulting color values are written to this array
-   */
-  public void postProcessPixel(int x, int y, double[] result) throws ClassCastException {
-    PostProcessingFilter filter = mode == RenderMode.PREVIEW ? PreviewFilter.INSTANCE : postProcessingFilter;
-
-    ((PixelPostProcessingFilter)filter).processPixel(width, height, samples, x, y, exposure, result);
-  }
-
-  /**
    * Compute the alpha channel based on sky visibility.
    */
   public void computeAlpha(int x, int y, WorkerState state) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
@@ -84,7 +84,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
 
       @Override
       public PostProcessingFilter fromString(String string) {
-        return PostProcessingFilters.getPostProcessingFilterFromName(string).orElse(PostProcessingFilters.NONE);
+        return PostProcessingFilters.getPostProcessingFilterFromName(string).orElse(Scene.DEFAULT_POSTPROCESSING_FILTER);
       }
     });
     exposure.setName("Exposure");

--- a/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
@@ -69,7 +69,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
 
   @Override public void initialize(URL location, ResourceBundle resources) {
     postprocessingFilter.getItems().addAll(PostProcessingFilters.getFilters());
-    postprocessingFilter.getSelectionModel().select(PostProcessingFilters.getDefault());
+    postprocessingFilter.getSelectionModel().select(Scene.DEFAULT_POSTPROCESSING_FILTER);
     postprocessingFilter.getSelectionModel().selectedItemProperty().addListener(
         (observable, oldValue, newValue) -> {
           scene.setPostprocess(newValue);
@@ -84,7 +84,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
 
       @Override
       public PostProcessingFilter fromString(String string) {
-        return PostProcessingFilters.getPostProcessingFilterFromName(string).orElse(PostProcessingFilters.getDefault());
+        return PostProcessingFilters.getPostProcessingFilterFromName(string).orElse(PostProcessingFilters.NONE);
       }
     });
     exposure.setName("Exposure");

--- a/chunky/src/java/se/llbit/tiff/TiffFileWriter.java
+++ b/chunky/src/java/se/llbit/tiff/TiffFileWriter.java
@@ -16,17 +16,17 @@
  */
 package se.llbit.tiff;
 
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-
+import java.io.IOException;
+import java.io.OutputStream;
 import se.llbit.chunky.renderer.postprocessing.PixelPostProcessingFilter;
+import se.llbit.chunky.renderer.postprocessing.PostProcessingFilter;
+import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.log.Log;
 import se.llbit.util.TaskTracker;
-
-import java.io.DataOutputStream;
-import java.io.OutputStream;
-import java.io.IOException;
 
 /**
  * TIFF image output. This supports 32-bit floating point channel output.
@@ -62,7 +62,8 @@ public class TiffFileWriter implements AutoCloseable {
   /**
    * @throws IOException
    */
-  @Override public void close() throws IOException {
+  @Override
+  public void close() throws IOException {
     out.close();
   }
 
@@ -220,9 +221,12 @@ public class TiffFileWriter implements AutoCloseable {
    * Write an image as a 32-bit per channel TIFF file.
    */
   public void write32(Scene scene, TaskTracker.Task task) throws IOException {
-    if(!(scene.getPostProcessingFilter() instanceof PixelPostProcessingFilter)) {
-      Log.error("Can't write TIFF file because post processing filter doesn't support pixel based processing");
-      return;
+    PostProcessingFilter filter = scene.getPostProcessingFilter();
+    if (!(filter instanceof PixelPostProcessingFilter)) {
+      Log.warn("The selected post processing filter (" + filter.getName()
+          + ") doesn't support pixel based processing and can't be used to export TIFF files. "+
+          "The TIFF will be exported without post-processing instead.");
+      filter = PostProcessingFilters.NONE;
     }
 
     int width = scene.canvasWidth();
@@ -233,7 +237,8 @@ public class TiffFileWriter implements AutoCloseable {
       task.update(height, y);
       for (int x = 0; x < width; ++x) {
         double[] pixel = new double[3];
-        scene.postProcessPixel(x, y, pixel);
+        ((PixelPostProcessingFilter) filter)
+            .processPixel(width, height, scene.getSampleBuffer(), x, y, scene.getExposure(), pixel);
         out.writeFloat((float) pixel[0]);
         out.writeFloat((float) pixel[1]);
         out.writeFloat((float) pixel[2]);


### PR DESCRIPTION
This logs a warning and saves without post-processing.

I also moved the default post-processor into the scene because it's more of a default value for a scene than something related to the post-processing itself.