### PR TITLE
Move bulk of chunk loading out of Scene

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkLoader.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkLoader.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.renderer.scene;
 
 import static java.lang.Math.min;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkLoader.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkLoader.java
@@ -1,0 +1,604 @@
+package se.llbit.chunky.renderer.scene;
+
+import static java.lang.Math.min;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import se.llbit.chunky.PersistentSettings;
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.chunk.GenericChunkData;
+import se.llbit.chunky.chunk.SimpleChunkData;
+import se.llbit.chunky.entity.ArmorStand;
+import se.llbit.chunky.entity.Entity;
+import se.llbit.chunky.entity.Lectern;
+import se.llbit.chunky.entity.PaintingEntity;
+import se.llbit.chunky.entity.PlayerEntity;
+import se.llbit.chunky.entity.Poseable;
+import se.llbit.chunky.renderer.EmitterSamplingStrategy;
+import se.llbit.chunky.renderer.scene.Scene.BlockBounds;
+import se.llbit.chunky.world.Biomes;
+import se.llbit.chunky.world.Chunk;
+import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.Heightmap;
+import se.llbit.chunky.world.World;
+import se.llbit.chunky.world.WorldTexture;
+import se.llbit.json.JsonObject;
+import se.llbit.log.Log;
+import se.llbit.math.Grid;
+import se.llbit.math.Grid.EmitterPosition;
+import se.llbit.math.Octree;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector3i;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.ListTag;
+import se.llbit.nbt.Tag;
+import se.llbit.util.MCDownloader;
+import se.llbit.util.TaskTracker;
+import se.llbit.util.TaskTracker.Task;
+
+/**
+ * Loads chunks into octrees and other associated data structures.
+ */
+public class ChunkLoader {
+
+  private final String octreeImplementation;
+  private final int yMin;
+  private final int yMax;
+  private final int yClipMin;
+  private final int yClipMax;
+  private EmitterSamplingStrategy emitterSamplingStrategy;
+  private final int gridSize;
+
+  public ChunkLoader(String octreeImplementation, int yMin, int yMax, int yClipMin, int yClipMax,
+      EmitterSamplingStrategy emitterSamplingStrategy, int gridSize) {
+    this.octreeImplementation = octreeImplementation;
+    this.yMin = yMin;
+    this.yMax = yMax;
+    this.yClipMin = yClipMin;
+    this.yClipMax = yClipMax;
+    this.gridSize = gridSize;
+    this.emitterSamplingStrategy = emitterSamplingStrategy;
+  }
+
+  /**
+   * Result from loading chunks.
+   */
+  public static class ChunkLoadResult {
+
+    final BlockPalette blockPalette;
+    final Octree worldOctree;
+    final Octree waterOctree;
+    Grid emitterGrid;
+    final Collection<Entity> entities;
+    final Collection<Entity> actors;
+    final Map<PlayerEntity, JsonObject> profiles;
+    final Vector3i origin;
+    final WorldTexture foliageTexture;
+    final WorldTexture waterTexture;
+    final WorldTexture grassTexture;
+    final Collection<ChunkPosition> loadedChunks;
+
+    public ChunkLoadResult(String octreeImplementation, int requiredDepth,
+        EmitterSamplingStrategy emitterSamplingStrategy, int gridSize) {
+      blockPalette = new BlockPalette();
+      worldOctree = new Octree(octreeImplementation, requiredDepth);
+      waterOctree = new Octree(octreeImplementation, requiredDepth);
+      emitterGrid =
+          emitterSamplingStrategy.equals(EmitterSamplingStrategy.NONE) ? null : new Grid(gridSize);
+      entities = new LinkedList<>();
+      actors = new LinkedList<>();
+      profiles = new HashMap<>();
+      origin = new Vector3i();
+      foliageTexture = new WorldTexture();
+      waterTexture = new WorldTexture();
+      grassTexture = new WorldTexture();
+      loadedChunks = new HashSet<>();
+    }
+  }
+
+  /**
+   * Loads chunks into octrees and other associated data.
+   *
+   * @param world        world to load
+   * @param chunksToLoad chunks to load
+   * @param taskTracker  tracker for keeping track of progress
+   * @param loadActors   whether or not to load actors from the world
+   */
+  public ChunkLoadResult loadChunks(World world, Collection<ChunkPosition> chunksToLoad,
+      TaskTracker taskTracker, boolean loadActors) {
+    BlockBounds bounds = Scene.calculateBounds(chunksToLoad);
+    int requiredDepth = Scene.calculateOctreeRequiredDepth(bounds, yMax, yMin);
+
+    ChunkLoadResult result = new ChunkLoadResult(octreeImplementation, requiredDepth,
+        emitterSamplingStrategy, gridSize);
+
+    try (Task task = taskTracker.task("(1/6) Loading regions")) {
+      task.update(2, 1);
+      //TODO is this necessary? Are we intentionally mutating origin here?
+      result.origin.set(Scene.calculateOctreeOrigin(yMax, yMin, bounds, false));
+
+      // Parse the regions first - force chunk lists to be populated!
+      Set<ChunkPosition> regions = new HashSet<>();
+      for (ChunkPosition cp : chunksToLoad) {
+        regions.add(cp.getRegionPosition());
+      }
+
+      for (ChunkPosition region : regions) {
+        world.getRegion(region).parse();
+      }
+    }
+
+    try (Task task = taskTracker.task("(2/6) Loading result.entities")) {
+      if (loadActors && PersistentSettings.getLoadPlayers()) {
+        // We don't load actor entities if some already exists. Loading actor entities
+        // risks resetting posed actors when reloading chunks for an existing scene.
+        Collection<PlayerEntity> players = world.playerEntities();
+        int done = 1;
+        int target = players.size();
+        for (PlayerEntity entity : players) {
+          entity.randomPose();
+          task.update(target, done);
+          done += 1;
+          JsonObject profile;
+          try {
+            profile = MCDownloader.fetchProfile(entity.uuid);
+          } catch (IOException e) {
+            Log.error(e);
+            profile = new JsonObject();
+          }
+          result.profiles.put(entity, profile);
+          result.actors.add(entity);
+        }
+      }
+    }
+
+    Set<ChunkPosition> nonEmptyChunks = new HashSet<>();
+    Heightmap biomeIdMap = new Heightmap();
+
+    ChunkReader chunkReader = new ChunkReader(
+        isTallWorld(world) ? GenericChunkData::new : SimpleChunkData::new, world,
+        result.blockPalette,
+        chunksToLoad,
+        Executors.newSingleThreadExecutor());
+
+    try (Task task = taskTracker.task("(3/6) Loading chunks")) {
+      int target = chunksToLoad.size();
+
+      int[] cubeWorldBlocks = new int[16 * 16 * 16];
+      int[] cubeWaterBlocks = new int[16 * 16 * 16];
+
+      chunkReader.forEach((cp, chunkData, progress) -> {
+        task.updateEta(target, progress);
+
+        if (result.loadedChunks.contains(cp)) {
+          return;
+        }
+
+        result.loadedChunks.add(cp);
+
+        int wx0 = cp.x * 16; // Start of this chunk in world coordinates.
+        int wz0 = cp.z * 16;
+        for (int cz = 0; cz < 16; ++cz) {
+          int wz = cz + wz0;
+          for (int cx = 0; cx < 16; ++cx) {
+            int wx = cx + wx0;
+            int biomeId =
+                0xFF & chunkData.getBiomeAt(cx, 0, cz); // TODO add vertical biomes support (1.15+)
+            biomeIdMap.set(biomeId, wx, wz);
+          }
+        }
+
+        // Load result.entities from the chunk:
+        for (CompoundTag tag : chunkData.getEntities()) {
+          Tag posTag = tag.get("Pos");
+          if (posTag.isList()) {
+            ListTag pos = posTag.asList();
+            double x = pos.get(0).doubleValue();
+            double y = pos.get(1).doubleValue();
+            double z = pos.get(2).doubleValue();
+
+            if (y >= yClipMin && y < yClipMax) {
+              String id = tag.get("id").stringValue("");
+              if (id.equals("minecraft:painting") || id.equals("Painting")) {
+                // Before 1.12 paintings had id=Painting.
+                // After 1.12 paintings had id=minecraft:painting.
+                float yaw = tag.get("Rotation").get(0).floatValue();
+                result.entities.add(
+                    new PaintingEntity(new Vector3(x, y, z), tag.get("Motive").stringValue(), yaw));
+              } else if (id.equals("minecraft:armor_stand")) {
+                result.actors.add(new ArmorStand(new Vector3(x, y, z), tag));
+              }
+            }
+          }
+        }
+
+        int yCubeMin = yMin / 16;
+        int yCubeMax = (yMax + 15) / 16;
+        for (int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
+          // Reset the cubes
+          Arrays.fill(cubeWorldBlocks, 0);
+          Arrays.fill(cubeWaterBlocks, 0);
+          for (int cy = 0; cy < 16;
+              ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
+            int y = yCube * 16 + cy;
+            if (y < yMin || y >= yMax) {
+              continue;
+            }
+            for (int cz = 0; cz < 16; ++cz) {
+              int z = cz + cp.z * 16 - result.origin.z;
+              for (int cx = 0; cx < 16; ++cx) {
+                int x = cx + cp.x * 16 - result.origin.x;
+
+                int cubeIndex = (cz * 16 + cy) * 16 + cx;
+
+                // Change the type of hidden blocks to ANY_TYPE
+                boolean onEdge = y <= yMin || y >= yMax - 1 || chunkData.isBlockOnEdge(cx, y, cz);
+                boolean isHidden = !onEdge
+                    && result.blockPalette.get(chunkData.getBlockAt(cx + 1, y, cz)).opaque
+                    && result.blockPalette.get(chunkData.getBlockAt(cx - 1, y, cz)).opaque
+                    && result.blockPalette.get(chunkData.getBlockAt(cx, y + 1, cz)).opaque
+                    && result.blockPalette.get(chunkData.getBlockAt(cx, y - 1, cz)).opaque
+                    && result.blockPalette.get(chunkData.getBlockAt(cx, y, cz + 1)).opaque
+                    && result.blockPalette.get(chunkData.getBlockAt(cx, y, cz - 1)).opaque;
+
+                if (isHidden) {
+                  cubeWorldBlocks[cubeIndex] = Octree.ANY_TYPE;
+                } else {
+                  int currentBlock = chunkData.getBlockAt(cx, y, cz);
+                  int octNode = currentBlock;
+                  Block block = result.blockPalette.get(currentBlock);
+
+                  if (block.isEntity()) {
+                    Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
+                    Entity entity = block.toEntity(position);
+
+                    if (entity instanceof Poseable && !(entity instanceof Lectern
+                        && !((Lectern) entity).hasBook())) {
+                      // don't add the actor again if it was already loaded from json
+                      if (result.actors.stream().noneMatch(actor -> {
+                        if (actor.getClass().equals(entity.getClass())) {
+                          Vector3 distance = new Vector3(actor.position);
+                          distance.sub(entity.position);
+                          return distance.lengthSquared() < Ray.EPSILON;
+                        }
+                        return false;
+                      })) {
+                        result.actors.add(entity);
+                      }
+                    } else {
+                      result.entities.add(entity);
+                      if (result.emitterGrid != null) {
+                        for (EmitterPosition emitterPos : entity.getEmitterPosition()) {
+                          emitterPos.x -= result.origin.x;
+                          emitterPos.y -= result.origin.y;
+                          emitterPos.z -= result.origin.z;
+                          result.emitterGrid.addEmitter(emitterPos);
+                        }
+                      }
+                    }
+
+                    if (!block.isBlockWithEntity()) {
+                      if (block.waterlogged) {
+                        block = result.blockPalette.water;
+                        octNode = result.blockPalette.waterId;
+                      } else {
+                        block = Air.INSTANCE;
+                        octNode = result.blockPalette.airId;
+                      }
+                    }
+                  }
+
+                  if (block.isWaterFilled()) {
+                    int waterNode = result.blockPalette.waterId;
+                    if (y + 1 < yMax) {
+                      if (result.blockPalette.get(chunkData.getBlockAt(cx, y + 1, cz))
+                          .isWaterFilled()) {
+                        waterNode = result.blockPalette.getWaterId(0, 1 << Water.FULL_BLOCK);
+                      }
+                    }
+                    if (block.isWater()) {
+                      // Move plain water blocks to the water octree.
+                      octNode = result.blockPalette.airId;
+
+                      if (!onEdge) {
+                        // Perform water computation now for water blocks that are not on th edge of the chunk
+                        // Test if the block has not already be marked as full
+                        if (((Water) result.blockPalette.get(waterNode)).data == 0) {
+                          int level0 = 8 - ((Water) block).level;
+                          int corner0 = level0;
+                          int corner1 = level0;
+                          int corner2 = level0;
+                          int corner3 = level0;
+
+                          int level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx - 1, y, cz, level0);
+                          corner3 += level;
+                          corner0 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx - 1, y, cz + 1,
+                                  level0);
+                          corner0 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx, y, cz + 1, level0);
+                          corner0 += level;
+                          corner1 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx + 1, y, cz + 1,
+                                  level0);
+                          corner1 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx + 1, y, cz, level0);
+                          corner1 += level;
+                          corner2 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx + 1, y, cz - 1,
+                                  level0);
+                          corner2 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx, y, cz - 1, level0);
+                          corner2 += level;
+                          corner3 += level;
+
+                          level = Chunk
+                              .waterLevelAt(chunkData, result.blockPalette, cx - 1, y, cz - 1,
+                                  level0);
+                          corner3 += level;
+
+                          corner0 = min(7, 8 - (corner0 / 4));
+                          corner1 = min(7, 8 - (corner1 / 4));
+                          corner2 = min(7, 8 - (corner2 / 4));
+                          corner3 = min(7, 8 - (corner3 / 4));
+                          waterNode = result.blockPalette
+                              .getWaterId(((Water) block).level, (corner0 << Water.CORNER_0)
+                                  | (corner1 << Water.CORNER_1)
+                                  | (corner2 << Water.CORNER_2)
+                                  | (corner3 << Water.CORNER_3));
+                        }
+                      } else {
+                        // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
+                        waterNode = result.blockPalette.getWaterId(((Water) block).level, 0);
+                      }
+                    }
+                    cubeWaterBlocks[cubeIndex] = waterNode;
+                  } else if (y + 1 < yMax && block instanceof Lava) {
+                    if (result.blockPalette
+                        .get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
+                      octNode = result.blockPalette.getLavaId(0, 1 << Water.FULL_BLOCK);
+                    } else if (!onEdge) {
+                      // Compute lava level for blocks not on edge
+                      Lava lava = (Lava) block;
+                      int level0 = 8 - lava.level;
+                      int corner0 = level0;
+                      int corner1 = level0;
+                      int corner2 = level0;
+                      int corner3 = level0;
+
+                      int level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx - 1, y, cz, level0);
+                      corner3 += level;
+                      corner0 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx - 1, y, cz + 1, level0);
+                      corner0 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx, y, cz + 1, level0);
+                      corner0 += level;
+                      corner1 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx + 1, y, cz + 1, level0);
+                      corner1 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx + 1, y, cz, level0);
+                      corner1 += level;
+                      corner2 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx + 1, y, cz - 1, level0);
+                      corner2 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx, y, cz - 1, level0);
+                      corner2 += level;
+                      corner3 += level;
+
+                      level = Chunk
+                          .lavaLevelAt(chunkData, result.blockPalette, cx - 1, y, cz - 1, level0);
+                      corner3 += level;
+
+                      corner0 = min(7, 8 - (corner0 / 4));
+                      corner1 = min(7, 8 - (corner1 / 4));
+                      corner2 = min(7, 8 - (corner2 / 4));
+                      corner3 = min(7, 8 - (corner3 / 4));
+                      octNode = result.blockPalette.getLavaId(
+                          lava.level,
+                          (corner0 << Water.CORNER_0)
+                              | (corner1 << Water.CORNER_1)
+                              | (corner2 << Water.CORNER_2)
+                              | (corner3 << Water.CORNER_3)
+                      );
+                    }
+                  }
+                  cubeWorldBlocks[cubeIndex] = octNode;
+
+                  if (result.emitterGrid != null && block.emittance > 1e-4) {
+                    result.emitterGrid.addEmitter(
+                        new EmitterPosition(x + 0.5f, y - result.origin.y + 0.5f, z + 0.5f));
+                  }
+                }
+              }
+            }
+          }
+          result.worldOctree.setCube(4, cubeWorldBlocks, cp.x * 16 - result.origin.x,
+              yCube * 16 - result.origin.y,
+              cp.z * 16 - result.origin.z);
+          result.waterOctree.setCube(4, cubeWaterBlocks, cp.x * 16 - result.origin.x,
+              yCube * 16 - result.origin.y,
+              cp.z * 16 - result.origin.z);
+        }
+
+        // Block result.entities are also called "tile result.entities". These are extra bits of metadata
+        // about certain blocks or result.entities.
+        // Block result.entities are loaded after the base block data so that metadata can be updated.
+        for (CompoundTag entityTag : chunkData.getTileEntities()) {
+          int y = entityTag.get("y").intValue(0);
+          if (y >= yMin && y < yMax) {
+            int x = entityTag.get("x").intValue(0) - wx0; // Chunk-local coordinates.
+            int z = entityTag.get("z").intValue(0) - wz0;
+            if (x < 0 || x > 15 || z < 0 || z > 15) {
+              // Block entity is out of range (bad chunk data?), ignore it
+              continue;
+            }
+            Block block = result.blockPalette.get(chunkData.getBlockAt(x, y, z));
+            // Metadata is the old block data (to be replaced in future Minecraft versions?).
+            Vector3 position = new Vector3(x + wx0, y, z + wz0);
+            if (block.isBlockEntity()) {
+              Entity blockEntity = block.toBlockEntity(position, entityTag);
+              if (blockEntity == null) {
+                continue;
+              }
+              if (blockEntity instanceof Poseable) {
+                // don't add the actor again if it was already loaded from json
+                if (result.actors.stream().noneMatch(actor -> {
+                  if (actor.getClass().equals(blockEntity.getClass())) {
+                    Vector3 distance = new Vector3(actor.position);
+                    distance.sub(blockEntity.position);
+                    return distance.lengthSquared() < Ray.EPSILON;
+                  }
+                  return false;
+                })) {
+                  result.actors.add(blockEntity);
+                }
+              } else {
+                result.entities.add(blockEntity);
+                if (result.emitterGrid != null) {
+                  for (EmitterPosition emitterPos : blockEntity.getEmitterPosition()) {
+                    emitterPos.x -= result.origin.x;
+                    emitterPos.y -= result.origin.y;
+                    emitterPos.z -= result.origin.z;
+                    result.emitterGrid.addEmitter(emitterPos);
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (!chunkData.isEmpty()) {
+          nonEmptyChunks.add(cp);
+        }
+      });
+    }
+
+    result.blockPalette.unsynchronize();
+
+    try (Task task = taskTracker.task("(4/6) Finalizing octree")) {
+
+      result.worldOctree.startFinalization();
+      result.waterOctree.startFinalization();
+
+      int done = 0;
+      int target = nonEmptyChunks.size();
+      for (ChunkPosition cp : nonEmptyChunks) {
+        // Finalize grass and foliage textures.
+        // 3x3 box blur.
+        for (int x = 0; x < 16; ++x) {
+          for (int z = 0; z < 16; ++z) {
+
+            int nsum = 0;
+            float[] grassMix = {0, 0, 0};
+            float[] foliageMix = {0, 0, 0};
+            float[] waterMix = {0, 0, 0};
+            for (int sx = x - 1; sx <= x + 1; ++sx) {
+              int wx = cp.x * 16 + sx;
+              for (int sz = z - 1; sz <= z + 1; ++sz) {
+                int wz = cp.z * 16 + sz;
+
+                ChunkPosition ccp = ChunkPosition.get(wx >> 4, wz >> 4);
+                if (nonEmptyChunks.contains(ccp)) {
+                  nsum += 1;
+                  int biomeId = biomeIdMap.get(wx, wz);
+                  float[] grassColor = Biomes.getGrassColorLinear(biomeId);
+                  grassMix[0] += grassColor[0];
+                  grassMix[1] += grassColor[1];
+                  grassMix[2] += grassColor[2];
+                  float[] foliageColor = Biomes.getFoliageColorLinear(biomeId);
+                  foliageMix[0] += foliageColor[0];
+                  foliageMix[1] += foliageColor[1];
+                  foliageMix[2] += foliageColor[2];
+                  float[] waterColor = Biomes.getWaterColorLinear(biomeId);
+                  waterMix[0] += waterColor[0];
+                  waterMix[1] += waterColor[1];
+                  waterMix[2] += waterColor[2];
+                }
+              }
+            }
+            grassMix[0] /= nsum;
+            grassMix[1] /= nsum;
+            grassMix[2] /= nsum;
+            result.grassTexture
+                .set(cp.x * 16 + x - result.origin.x, cp.z * 16 + z - result.origin.z, grassMix);
+
+            foliageMix[0] /= nsum;
+            foliageMix[1] /= nsum;
+            foliageMix[2] /= nsum;
+            result.foliageTexture
+                .set(cp.x * 16 + x - result.origin.x, cp.z * 16 + z - result.origin.z, foliageMix);
+
+            waterMix[0] /= nsum;
+            waterMix[1] /= nsum;
+            waterMix[2] /= nsum;
+            result.waterTexture
+                .set(cp.x * 16 + x - result.origin.x, cp.z * 16 + z - result.origin.z, waterMix);
+          }
+        }
+        task.updateEta(target, done);
+        done += 1;
+        OctreeFinalizer.finalizeChunk(result.worldOctree, result.waterOctree, result.blockPalette,
+            result.origin, cp, yMin, yMax);
+      }
+
+      result.worldOctree.endFinalization();
+      result.waterOctree.endFinalization();
+    }
+
+    for (Entity entity : result.actors) {
+      entity.loadDataFromOctree(result.worldOctree, result.blockPalette, result.origin);
+    }
+
+    for (Entity entity : result.entities) {
+      entity.loadDataFromOctree(result.worldOctree, result.blockPalette, result.origin);
+    }
+
+    if (result.emitterGrid != null) {
+      result.emitterGrid.prepare();
+    }
+
+    return result;
+  }
+
+  static boolean isTallWorld(World world) {
+    return world.getVersionId() >= World.VERSION_21W06A;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkReader.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkReader.java
@@ -1,0 +1,178 @@
+package se.llbit.chunky.renderer.scene;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.chunk.ChunkData;
+import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.World;
+import se.llbit.log.Log;
+import se.llbit.nbt.CompoundTag;
+
+/**
+ * Reads {@link ChunkData} from a {@link World} and allows them to be consumed.
+ *
+ * <p>
+ * ChunkData is only guaranteed to be correct during the current iteration. Using data from a prior
+ * iteration will result in reading invalid data.
+ */
+public class ChunkReader {
+
+  private final Supplier<ChunkData> chunkDataFactory;
+  private final World world;
+  private final BlockPalette palette;
+  private final Collection<ChunkPosition> chunksToLoad;
+  private final ExecutorService executor;
+
+  public ChunkReader(Supplier<ChunkData> chunkDataFactory, World world, BlockPalette palette,
+      Collection<ChunkPosition> chunksToLoad, ExecutorService executorService) {
+
+    this.chunkDataFactory = chunkDataFactory;
+    this.world = world;
+    this.palette = palette;
+    this.chunksToLoad = chunksToLoad;
+    this.executor = executorService;
+  }
+
+  /**
+   * Consumer for {@link ChunkData}. This consumer additionally provides the {@link ChunkPosition}
+   * as well as the current iteration number.
+   */
+  @FunctionalInterface
+  public interface ChunkDataConsumer {
+
+    void accept(ChunkPosition chunkPosition, ChunkData chunkData, int iteration);
+  }
+
+  /**
+   * Read all {@link ChunkData} and apply the {@code consumer} to the result.
+   */
+  public void forEach(ChunkDataConsumer consumer) {
+    ChunkData readyChunk = chunkDataFactory.get();
+    ChunkData loadingChunk = chunkDataFactory.get();
+
+    ChunkPosition[] chunkPositions = chunksToLoad.toArray(new ChunkPosition[0]);
+
+    ChunkData finalReadyChunk = readyChunk;
+    Future<?> nextChunkDataTask = executor
+        .submit(() -> { //Initialise first chunk data for the for loop
+          world.getChunk(chunkPositions[0]).getChunkData(finalReadyChunk, palette);
+        });
+
+    for (int i = 0; i < chunkPositions.length; i++) {
+      try {
+        nextChunkDataTask.get(50, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException | InterruptedException logged) { // If except, load the chunk synchronously
+        if (logged instanceof TimeoutException) {
+          Log.info("Chunk loading timed out.");
+        } else {
+          Log.warn("Chunky loading interrupted.", logged);
+        }
+        world.getChunk(chunkPositions[i]).getChunkData(readyChunk, palette);
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e.getCause());
+      }
+
+      if (i + 1 < chunkPositions.length) { //if has next request next
+        final int finalI = i;
+        ChunkData finalLoadingChunk = loadingChunk;
+        nextChunkDataTask = executor.submit(() -> { //Initialise next chunk data for the for loop
+          world.getChunk(chunkPositions[finalI + 1]).getChunkData(finalLoadingChunk, palette);
+        });
+      }
+      consumer.accept(chunkPositions[i], new ReadOnlyChunkData(readyChunk), i + 1);
+
+      // Swap chunks for next iteration
+      ChunkData temp = loadingChunk;
+      loadingChunk = readyChunk;
+      readyChunk = temp;
+    }
+
+    executor.shutdown();
+  }
+
+
+  /**
+   * Wrapper around ChunkData that prevents modification of the underlying ChunkData.
+   */
+  public static class ReadOnlyChunkData implements ChunkData {
+
+    final ChunkData chunkData;
+
+    private ReadOnlyChunkData(ChunkData chunkData) {
+      this.chunkData = chunkData;
+    }
+
+    @Override
+    public int minY() {
+      return chunkData.minY();
+    }
+
+    @Override
+    public int maxY() {
+      return 0;
+    }
+
+    @Override
+    public int getBlockAt(int x, int y, int z) {
+      return chunkData.getBlockAt(x, y, z);
+    }
+
+    @Override
+    public boolean isBlockOnEdge(int x, int y, int z) {
+      return chunkData.isBlockOnEdge(x, y, z);
+    }
+
+    @Override
+    public Collection<CompoundTag> getTileEntities() {
+      return chunkData.getTileEntities();
+    }
+
+    @Override
+    public Collection<CompoundTag> getEntities() {
+      return chunkData.getEntities();
+    }
+
+    @Override
+    public byte getBiomeAt(int x, int y, int z) {
+      return chunkData.getBiomeAt(x, y, z);
+    }
+
+
+    @Override
+    public boolean isEmpty() {
+      return chunkData.isEmpty();
+    }
+
+    @Override
+    public void setBlockAt(int x, int y, int z, int block) {
+      throw new UnsupportedOperationException("ChunkData is Read Only.");
+    }
+
+    @Override
+    public void addTileEntity(CompoundTag tileEntity) {
+      throw new UnsupportedOperationException("ChunkData is Read Only.");
+    }
+
+    @Override
+    public void addEntity(CompoundTag entity) {
+      throw new UnsupportedOperationException("ChunkData is Read Only.");
+    }
+
+    @Override
+    public void setBiomeAt(int x, int y, int z, byte biome) {
+      throw new UnsupportedOperationException("ChunkData is Read Only.");
+    }
+
+    @Override
+    public void clear() {
+      throw new UnsupportedOperationException("ChunkData is Read Only.");
+    }
+
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkReader.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/ChunkReader.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.renderer.scene;
 
 import java.util.Collection;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -35,18 +35,14 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -55,17 +51,10 @@ import java.util.zip.GZIPOutputStream;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.Block;
-import se.llbit.chunky.block.Lava;
 import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.chunk.GenericChunkData;
-import se.llbit.chunky.chunk.SimpleChunkData;
-import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.Entity;
-import se.llbit.chunky.entity.Lectern;
-import se.llbit.chunky.entity.PaintingEntity;
 import se.llbit.chunky.entity.PlayerEntity;
-import se.llbit.chunky.entity.Poseable;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.EmitterSamplingStrategy;
@@ -81,14 +70,13 @@ import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
 import se.llbit.chunky.renderer.postprocessing.PreviewFilter;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.renderer.renderdump.RenderDump;
+import se.llbit.chunky.renderer.scene.ChunkLoader.ChunkLoadResult;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.resources.OctreeFileFormat;
 import se.llbit.chunky.world.Biomes;
-import se.llbit.chunky.world.Chunk;
 import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.ExtraMaterials;
-import se.llbit.chunky.world.Heightmap;
 import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.MaterialStore;
 import se.llbit.chunky.world.World;
@@ -108,14 +96,11 @@ import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector3i;
 import se.llbit.math.bvh.BVH;
-import se.llbit.nbt.CompoundTag;
-import se.llbit.nbt.ListTag;
-import se.llbit.nbt.Tag;
 import se.llbit.util.JsonSerializable;
-import se.llbit.util.MCDownloader;
 import se.llbit.util.NotNull;
 import se.llbit.util.PositionalInputStream;
 import se.llbit.util.TaskTracker;
+import se.llbit.util.TaskTracker.Task;
 import se.llbit.util.ZipExport;
 
 /**
@@ -848,12 +833,13 @@ public class Scene implements JsonSerializable, Refreshable {
    * The octree finalizer is then run to compute block properties like fence
    * connectedness.
    */
-  public synchronized void loadChunks(TaskTracker taskTracker, World world, Collection<ChunkPosition> chunksToLoad) {
-    if (world == null)
+  public synchronized void loadChunks(TaskTracker taskTracker, World world,
+      Collection<ChunkPosition> chunksToLoad) {
+    if (world == null || chunksToLoad.isEmpty()) {
       return;
+    }
 
-    boolean isTallWorld = world.getVersionId() >= World.VERSION_21W06A;
-    if (isTallWorld) {
+    if (ChunkLoader.isTallWorld(world)) {
       // snapshot 21w06a or later, don't limit yMin/yMax to allow custom height worlds
       yMin = yClipMin;
       yMax = yClipMax;
@@ -863,483 +849,49 @@ public class Scene implements JsonSerializable, Refreshable {
       yMax = min(256, yClipMax);
     }
 
-    Set<ChunkPosition> loadedChunks = new HashSet<>();
-    int numChunks = 0;
+    loadedWorld = world;
+    worldPath = loadedWorld.getWorldDirectory().getAbsolutePath();
+    worldDimension = world.currentDimension();
 
-    try (TaskTracker.Task task = taskTracker.task("(1/6) Loading regions")) {
-      task.update(2, 1);
+    boolean loadActors = actors.isEmpty();
+    ChunkLoadResult chunkLoadResult = new ChunkLoader(octreeImplementation,
+        yMin,
+        yMax,
+        yClipMin,
+        yClipMax,
+        emitterSamplingStrategy,
+        gridSize)
+        .loadChunks(world, chunksToLoad, taskTracker, loadActors);
 
-      loadedWorld = world;
-      worldPath = loadedWorld.getWorldDirectory().getAbsolutePath();
-      worldDimension = world.currentDimension();
-
-      if (chunksToLoad.isEmpty()) {
-        return;
-      }
-
-      int requiredDepth = calculateOctreeOrigin(chunksToLoad, false);
-
-      // Create new octree to fit all chunks.
-      palette = new BlockPalette();
-      worldOctree = new Octree(octreeImplementation, requiredDepth);
-      waterOctree = new Octree(octreeImplementation, requiredDepth);
-      if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
-        emitterGrid = new Grid(gridSize);
-
-      // Parse the regions first - force chunk lists to be populated!
-      Set<ChunkPosition> regions = new HashSet<>();
-      for (ChunkPosition cp : chunksToLoad) {
-        regions.add(cp.getRegionPosition());
-      }
-
-      for (ChunkPosition region : regions) {
-        world.getRegion(region).parse();
-      }
-    }
-
-    try (TaskTracker.Task task = taskTracker.task("(2/6) Loading entities")) {
-      entities = new LinkedList<>();
-      if (actors.isEmpty() && PersistentSettings.getLoadPlayers()) {
-        // We don't load actor entities if some already exists. Loading actor entities
-        // risks resetting posed actors when reloading chunks for an existing scene.
-        actors = new LinkedList<>();
-        profiles = new HashMap<>();
-        Collection<PlayerEntity> players = world.playerEntities();
-        int done = 1;
-        int target = players.size();
-        for (PlayerEntity entity : players) {
-          entity.randomPose();
-          task.update(target, done);
-          done += 1;
-          JsonObject profile;
-          try {
-            profile = MCDownloader.fetchProfile(entity.uuid);
-          } catch (IOException e) {
-            Log.error(e);
-            profile = new JsonObject();
-          }
-          profiles.put(entity, profile);
-          actors.add(entity);
-        }
-      }
-    }
-
-    Set<ChunkPosition> nonEmptyChunks = new HashSet<>();
-    Heightmap biomeIdMap = new Heightmap();
-
-    ChunkReader chunkReader = new ChunkReader(
-        isTallWorld ? GenericChunkData::new : SimpleChunkData::new, world, palette, chunksToLoad,
-        Executors.newSingleThreadExecutor());
-
-    try (TaskTracker.Task task = taskTracker.task("(3/6) Loading chunks")) {
-      int target = chunksToLoad.size();
-
-      int[] cubeWorldBlocks = new int[16 * 16 * 16];
-      int[] cubeWaterBlocks = new int[16 * 16 * 16];
-
-      chunkReader.forEach((cp, chunkData, progress) -> {
-        task.updateEta(target, progress);
-
-        if (loadedChunks.contains(cp)) {
-          return;
-        }
-
-        loadedChunks.add(cp);
-
-        int wx0 = cp.x * 16; // Start of this chunk in world coordinates.
-        int wz0 = cp.z * 16;
-        for (int cz = 0; cz < 16; ++cz) {
-          int wz = cz + wz0;
-          for (int cx = 0; cx < 16; ++cx) {
-            int wx = cx + wx0;
-            int biomeId = 0xFF & chunkData.getBiomeAt(cx, 0, cz); // TODO add vertical biomes support (1.15+)
-            biomeIdMap.set(biomeId, wx, wz);
-          }
-        }
-
-        // Load entities from the chunk:
-        for (CompoundTag tag : chunkData.getEntities()) {
-          Tag posTag = tag.get("Pos");
-          if (posTag.isList()) {
-            ListTag pos = posTag.asList();
-            double x = pos.get(0).doubleValue();
-            double y = pos.get(1).doubleValue();
-            double z = pos.get(2).doubleValue();
-
-            if (y >= yClipMin && y < yClipMax) {
-              String id = tag.get("id").stringValue("");
-              if (id.equals("minecraft:painting") || id.equals("Painting")) {
-                // Before 1.12 paintings had id=Painting.
-                // After 1.12 paintings had id=minecraft:painting.
-                float yaw = tag.get("Rotation").get(0).floatValue();
-                entities.add(
-                    new PaintingEntity(new Vector3(x, y, z), tag.get("Motive").stringValue(), yaw));
-              } else if (id.equals("minecraft:armor_stand")) {
-                actors.add(new ArmorStand(new Vector3(x, y, z), tag));
-              }
-            }
-          }
-        }
-
-        int yCubeMin = yMin / 16;
-        int yCubeMax = (yMax+15) / 16;
-        for(int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
-          // Reset the cubes
-          Arrays.fill(cubeWorldBlocks, 0);
-          Arrays.fill(cubeWaterBlocks, 0);
-          for(int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
-            int y = yCube * 16 + cy;
-            if(y < yMin || y >= yMax)
-              continue;
-            for(int cz = 0; cz < 16; ++cz) {
-              int z = cz + cp.z * 16 - origin.z;
-              for(int cx = 0; cx < 16; ++cx) {
-                int x = cx + cp.x * 16 - origin.x;
-
-                int cubeIndex = (cz * 16 + cy) * 16 + cx;
-
-                // Change the type of hidden blocks to ANY_TYPE
-                boolean onEdge = y <= yMin || y >= yMax - 1 || chunkData.isBlockOnEdge(cx, y, cz);
-                boolean isHidden = !onEdge
-                        && palette.get(chunkData.getBlockAt(cx + 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx - 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y + 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y - 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz + 1)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz - 1)).opaque;
-
-                if(isHidden) {
-                  cubeWorldBlocks[cubeIndex] = Octree.ANY_TYPE;
-                } else {
-                  int currentBlock = chunkData.getBlockAt(cx, y, cz);
-                  int octNode = currentBlock;
-                  Block block = palette.get(currentBlock);
-
-                  if(block.isEntity()) {
-                    Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
-                    Entity entity = block.toEntity(position);
-
-                    if(entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
-                      // don't add the actor again if it was already loaded from json
-                      if(actors.stream().noneMatch(actor -> {
-                        if(actor.getClass().equals(entity.getClass())) {
-                          Vector3 distance = new Vector3(actor.position);
-                          distance.sub(entity.position);
-                          return distance.lengthSquared() < Ray.EPSILON;
-                        }
-                        return false;
-                      })) {
-                        actors.add(entity);
-                      }
-                    } else {
-                      entities.add(entity);
-                      if(emitterGrid != null) {
-                        for(Grid.EmitterPosition emitterPos : entity.getEmitterPosition()) {
-                          emitterPos.x -= origin.x;
-                          emitterPos.y -= origin.y;
-                          emitterPos.z -= origin.z;
-                          emitterGrid.addEmitter(emitterPos);
-                        }
-                      }
-                    }
-
-                    if(!block.isBlockWithEntity()) {
-                      if(block.waterlogged) {
-                        block = palette.water;
-                        octNode = palette.waterId;
-                      } else {
-                        block = Air.INSTANCE;
-                        octNode = palette.airId;
-                      }
-                    }
-                  }
-
-                  if(block.isWaterFilled()) {
-                    int waterNode = palette.waterId;
-                    if(y + 1 < yMax) {
-                      if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)).isWaterFilled()) {
-                        waterNode = palette.getWaterId(0, 1 << Water.FULL_BLOCK);
-                      }
-                    }
-                    if(block.isWater()) {
-                      // Move plain water blocks to the water octree.
-                      octNode = palette.airId;
-
-                      if(!onEdge) {
-                        // Perform water computation now for water blocks that are not on th edge of the chunk
-                        // Test if the block has not already be marked as full
-                        if(((Water) palette.get(waterNode)).data == 0) {
-                          int level0 = 8 - ((Water) block).level;
-                          int corner0 = level0;
-                          int corner1 = level0;
-                          int corner2 = level0;
-                          int corner3 = level0;
-
-                          int level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                          corner3 += level;
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                          corner0 += level;
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                          corner1 += level;
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                          corner2 += level;
-                          corner3 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                          corner3 += level;
-
-                          corner0 = min(7, 8 - (corner0 / 4));
-                          corner1 = min(7, 8 - (corner1 / 4));
-                          corner2 = min(7, 8 - (corner2 / 4));
-                          corner3 = min(7, 8 - (corner3 / 4));
-                          waterNode = palette.getWaterId(((Water) block).level, (corner0 << Water.CORNER_0)
-                                          | (corner1 << Water.CORNER_1)
-                                          | (corner2 << Water.CORNER_2)
-                                          | (corner3 << Water.CORNER_3));
-                        }
-                      } else {
-                        // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
-                        waterNode = palette.getWaterId(((Water) block).level, 0);
-                      }
-                    }
-                    cubeWaterBlocks[cubeIndex] = waterNode;
-                  } else if(y + 1 < yMax && block instanceof Lava) {
-                    if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
-                      octNode = palette.getLavaId(0, 1 << Water.FULL_BLOCK);
-                    } else if(!onEdge) {
-                      // Compute lava level for blocks not on edge
-                      Lava lava = (Lava) block;
-                      int level0 = 8 - lava.level;
-                      int corner0 = level0;
-                      int corner1 = level0;
-                      int corner2 = level0;
-                      int corner3 = level0;
-
-                      int level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                      corner3 += level;
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                      corner0 += level;
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                      corner1 += level;
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                      corner2 += level;
-                      corner3 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                      corner3 += level;
-
-                      corner0 = min(7, 8 - (corner0 / 4));
-                      corner1 = min(7, 8 - (corner1 / 4));
-                      corner2 = min(7, 8 - (corner2 / 4));
-                      corner3 = min(7, 8 - (corner3 / 4));
-                      octNode = palette.getLavaId(
-                              lava.level,
-                              (corner0 << Water.CORNER_0)
-                                      | (corner1 << Water.CORNER_1)
-                                      | (corner2 << Water.CORNER_2)
-                                      | (corner3 << Water.CORNER_3)
-                      );
-                    }
-                  }
-                  cubeWorldBlocks[cubeIndex] = octNode;
-
-                  if(emitterGrid != null && block.emittance > 1e-4) {
-                    emitterGrid.addEmitter(new Grid.EmitterPosition(x + 0.5f, y - origin.y + 0.5f, z + 0.5f));
-                  }
-                }
-              }
-            }
-          }
-          worldOctree.setCube(4, cubeWorldBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
-          waterOctree.setCube(4, cubeWaterBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
-        }
-
-        // Block entities are also called "tile entities". These are extra bits of metadata
-        // about certain blocks or entities.
-        // Block entities are loaded after the base block data so that metadata can be updated.
-        for (CompoundTag entityTag : chunkData.getTileEntities()) {
-          int y = entityTag.get("y").intValue(0);
-          if (y >= yMin && y < yMax) {
-            int x = entityTag.get("x").intValue(0) - wx0; // Chunk-local coordinates.
-            int z = entityTag.get("z").intValue(0) - wz0;
-            if (x < 0 || x > 15 || z < 0 || z > 15) {
-              // Block entity is out of range (bad chunk data?), ignore it
-              continue;
-            }
-            Block block = palette.get(chunkData.getBlockAt(x, y, z));
-            // Metadata is the old block data (to be replaced in future Minecraft versions?).
-            Vector3 position = new Vector3(x + wx0, y, z + wz0);
-            if (block.isBlockEntity()) {
-              Entity blockEntity = block.toBlockEntity(position, entityTag);
-              if (blockEntity == null) {
-                continue;
-              }
-              if (blockEntity instanceof Poseable) {
-                // don't add the actor again if it was already loaded from json
-                if (actors.stream().noneMatch(actor -> {
-                  if (actor.getClass().equals(blockEntity.getClass())) {
-                    Vector3 distance = new Vector3(actor.position);
-                    distance.sub(blockEntity.position);
-                    return distance.lengthSquared() < Ray.EPSILON;
-                  }
-                  return false;
-                })) {
-                  actors.add(blockEntity);
-                }
-              } else {
-                entities.add(blockEntity);
-                if(emitterGrid != null) {
-                  for(Grid.EmitterPosition emitterPos : blockEntity.getEmitterPosition()) {
-                    emitterPos.x -= origin.x;
-                    emitterPos.y -= origin.y;
-                    emitterPos.z -= origin.z;
-                    emitterGrid.addEmitter(emitterPos);
-                  }
-                }
-              }
-            }
-            /*
-            switch (block) {
-              case Block.HEAD_ID:
-                entities.add(new SkullEntity(position, entityTag, metadata));
-                break;
-              case Block.WALL_BANNER_ID: {
-                entities.add(new WallBanner(position, metadata, entityTag));
-                break;
-              }
-            }
-            */
-          }
-        }
-
-        if (!chunkData.isEmpty()){
-          nonEmptyChunks.add(cp);
-        }
-      });
-    }
-
-    palette.unsynchronize();
-
-    grassTexture = new WorldTexture();
-    foliageTexture = new WorldTexture();
-    waterTexture = new WorldTexture();
-
-    try (TaskTracker.Task task = taskTracker.task("(4/6) Finalizing octree")) {
-
-      worldOctree.startFinalization();
-      waterOctree.startFinalization();
-
-      int done = 0;
-      int target = nonEmptyChunks.size();
-      for (ChunkPosition cp : nonEmptyChunks) {
-        // Finalize grass and foliage textures.
-        // 3x3 box blur.
-        for (int x = 0; x < 16; ++x) {
-          for (int z = 0; z < 16; ++z) {
-
-            int nsum = 0;
-            float[] grassMix = {0, 0, 0};
-            float[] foliageMix = {0, 0, 0};
-            float[] waterMix = {0, 0, 0};
-            for (int sx = x - 1; sx <= x + 1; ++sx) {
-              int wx = cp.x * 16 + sx;
-              for (int sz = z - 1; sz <= z + 1; ++sz) {
-                int wz = cp.z * 16 + sz;
-
-                ChunkPosition ccp = ChunkPosition.get(wx >> 4, wz >> 4);
-                if (nonEmptyChunks.contains(ccp)) {
-                  nsum += 1;
-                  int biomeId = biomeIdMap.get(wx, wz);
-                  float[] grassColor = Biomes.getGrassColorLinear(biomeId);
-                  grassMix[0] += grassColor[0];
-                  grassMix[1] += grassColor[1];
-                  grassMix[2] += grassColor[2];
-                  float[] foliageColor = Biomes.getFoliageColorLinear(biomeId);
-                  foliageMix[0] += foliageColor[0];
-                  foliageMix[1] += foliageColor[1];
-                  foliageMix[2] += foliageColor[2];
-                  float[] waterColor = Biomes.getWaterColorLinear(biomeId);
-                  waterMix[0] += waterColor[0];
-                  waterMix[1] += waterColor[1];
-                  waterMix[2] += waterColor[2];
-                }
-              }
-            }
-            grassMix[0] /= nsum;
-            grassMix[1] /= nsum;
-            grassMix[2] /= nsum;
-            grassTexture.set(cp.x * 16 + x - origin.x, cp.z * 16 + z - origin.z, grassMix);
-
-            foliageMix[0] /= nsum;
-            foliageMix[1] /= nsum;
-            foliageMix[2] /= nsum;
-            foliageTexture.set(cp.x * 16 + x - origin.x, cp.z * 16 + z - origin.z, foliageMix);
-
-            waterMix[0] /= nsum;
-            waterMix[1] /= nsum;
-            waterMix[2] /= nsum;
-            waterTexture.set(cp.x * 16 + x - origin.x, cp.z * 16 + z - origin.z, waterMix);
-          }
-        }
-        task.updateEta(target, done);
-        done += 1;
-        OctreeFinalizer.finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
-      }
-
-      worldOctree.endFinalization();
-      waterOctree.endFinalization();
-    }
-
-    for (Entity entity : actors) {
-      entity.loadDataFromOctree(worldOctree, palette, origin);
-    }
-
-    for (Entity entity : entities) {
-      entity.loadDataFromOctree(worldOctree, palette, origin);
-    }
-
-    if (emitterGrid != null)
-      emitterGrid.prepare();
-
-    chunks = loadedChunks;
-    camera.setWorldSize(1 << worldOctree.getDepth());
-    try (TaskTracker.Task task = taskTracker.task("(5/6) Building world BVH")) {
+    try (Task task = taskTracker.task("(5/6) Building world BVH")) {
       buildBvh(task);
     }
-    try (TaskTracker.Task task = taskTracker.task("(6/6) Building actor BVH")) {
+    try (Task task = taskTracker.task("(6/6) Building actor BVH")) {
       buildActorBvh(task);
     }
-    Log.info(String.format("Loaded %d chunks", numChunks));
+
+    // Set scene values to load results
+    palette = chunkLoadResult.blockPalette;
+    worldOctree = chunkLoadResult.worldOctree;
+    waterOctree = chunkLoadResult.waterOctree;
+    emitterGrid = chunkLoadResult.emitterGrid;
+    entities = chunkLoadResult.entities;
+
+    // We don't load actor entities if some already exists. Loading actor entities
+    // risks resetting posed actors when reloading chunks for an existing scene.
+    if (loadActors) {
+      actors = chunkLoadResult.actors;
+      profiles = chunkLoadResult.profiles;
+    }
+    origin = chunkLoadResult.origin;
+    foliageTexture = chunkLoadResult.foliageTexture;
+    waterTexture = chunkLoadResult.waterTexture;
+    grassTexture = chunkLoadResult.grassTexture;
+    chunks = chunkLoadResult.loadedChunks;
+
+    camera.setWorldSize(1 << chunkLoadResult.worldOctree.getDepth());
+
+    Log.info(String.format("Loaded %d chunks", chunks.size()));
   }
 
   private void buildBvh(TaskTracker.Task task) {
@@ -1372,7 +924,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Find the bounds in blocks for a collection of chunks.
    */
-  private static BlockBounds calculateBounds(Collection<ChunkPosition> chunks) {
+  static BlockBounds calculateBounds(Collection<ChunkPosition> chunks) {
     int xmin = Integer.MAX_VALUE;
     int xmax = Integer.MIN_VALUE;
     int zmin = Integer.MAX_VALUE;
@@ -1393,11 +945,11 @@ public class Scene implements JsonSerializable, Refreshable {
     return new BlockBounds(xmin, xmax, zmin, zmax);
   }
 
-  private static class BlockBounds {
-    private final int xmin;
-    private final int xmax;
-    private final int zmin;
-    private final int zmax;
+  static class BlockBounds {
+    final int xmin;
+    final int xmax;
+    final int zmin;
+    final int zmax;
 
     private BlockBounds(int xmin, int xmax, int zmin, int zmax) {
       this.xmin = xmin;
@@ -1407,23 +959,25 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
-  private int calculateOctreeOrigin(Collection<ChunkPosition> chunksToLoad, boolean centerOctree) {
-    BlockBounds bounds = calculateBounds(chunksToLoad);
-
-    int maxDimension = max(yMax - yMin, max(bounds.xmax - bounds.xmin, bounds.zmax - bounds.zmin));
-    int requiredDepth = QuickMath.log2(QuickMath.nextPow2(maxDimension));
+  static Vector3i calculateOctreeOrigin(int yMax, int yMin, BlockBounds bounds,
+      boolean centerOctree) {
+    int requiredDepth = calculateOctreeRequiredDepth(bounds, yMax, yMin);
 
     if (centerOctree) {
       int xroom = (1 << requiredDepth) - (bounds.xmax - bounds.xmin);
       int yroom = (1 << requiredDepth) - (yMax - yMin);
       int zroom = (1 << requiredDepth) - (bounds.zmax - bounds.zmin);
 
-      origin.set(bounds.xmin - xroom / 2, -yroom / 2, bounds.zmin - zroom / 2);
+      return new Vector3i(bounds.xmin - xroom / 2, -yroom / 2, bounds.zmin - zroom / 2);
     } else {
       // Note: Math.floorDiv rather than integer division for round toward -infinity
-      origin.set(bounds.xmin, Math.floorDiv(yMin, 16) * 16, bounds.zmin);
+      return new Vector3i(bounds.xmin, Math.floorDiv(yMin, 16) * 16, bounds.zmin);
     }
-    return requiredDepth;
+  }
+
+  static int calculateOctreeRequiredDepth(BlockBounds bounds, int yMax, int yMin) {
+    int maxDimension = max(yMax - yMin, max(bounds.xmax - bounds.xmin, bounds.zmax - bounds.zmin));
+    return QuickMath.log2(QuickMath.nextPow2(maxDimension));
   }
 
   /**
@@ -2100,7 +1654,8 @@ public class Scene implements JsonSerializable, Refreshable {
         palette = data.palette;
         palette.applyMaterials();
         Log.info("Octree loaded");
-        calculateOctreeOrigin(chunks, data.version < 6);
+
+        origin = calculateOctreeOrigin(yMax, yMin, calculateBounds(chunks), data.version < 6);
         camera.setWorldSize(1 << worldOctree.getDepth());
 
         try (TaskTracker.Task bvhTask = taskTracker.task("(2/3) Building world BVH")) {

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/ChunkReaderTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/ChunkReaderTest.java
@@ -1,0 +1,170 @@
+package se.llbit.chunky.renderer.scene;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.chunk.ChunkData;
+import se.llbit.chunky.renderer.scene.ChunkReader.ReadOnlyChunkData;
+import se.llbit.chunky.world.Chunk;
+import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.World;
+import se.llbit.nbt.CompoundTag;
+
+public class ChunkReaderTest {
+
+  @Test
+  public void forEach() {
+    List<ChunkPosition> chunksToLoad = Stream
+        .of(ChunkPosition.get(1, 1), ChunkPosition.get(1, 2), ChunkPosition.get(1, 3))
+        .collect(
+            Collectors.toList());
+    ChunkData chunkData1 = new MockChunkData("A");
+    ChunkData chunkData2 = new MockChunkData("B");
+    Iterator<ChunkData> iterator = Arrays.asList(chunkData1, chunkData2).iterator();
+    MockWorld world = new MockWorld();
+    ListeningExecutorService executorService = MoreExecutors.newDirectExecutorService();
+    ChunkReader chunkReader = new ChunkReader(iterator::next, world,
+        new BlockPalette(new HashMap<>(), new ArrayList<>()), chunksToLoad,
+        executorService);
+
+    List<ChunkPosition> consumedPositions = new ArrayList<>();
+    List<ReadOnlyChunkData> consumedChunkData = new ArrayList<>();
+    List<Integer> consumedProgress = new ArrayList<>();
+    chunkReader.forEach((position, chunkData, progress) -> {
+      consumedPositions.add(position);
+      consumedChunkData.add((ReadOnlyChunkData) chunkData);
+      consumedProgress.add(progress);
+    });
+
+    assertThat(consumedPositions)
+        .containsExactly(ChunkPosition.get(1, 1), ChunkPosition.get(1, 2), ChunkPosition.get(1, 3));
+    assertThat(consumedChunkData.stream().map(roc -> roc.chunkData).collect(Collectors.toList()))
+        .containsExactly(chunkData1, chunkData2, chunkData1).inOrder();
+    assertThat(world.mockChunk.chunksCalledWith)
+        .containsExactly(chunkData1, chunkData2, chunkData1).inOrder();
+    assertThat(consumedProgress).containsExactly(1, 2, 3).inOrder();
+    assertThat(executorService.isShutdown()).isTrue();
+  }
+
+  private static final class MockChunk extends Chunk {
+
+    private final List<ChunkData> chunksCalledWith;
+
+    public MockChunk(World world) {
+      super(ChunkPosition.get(0, 0), world);
+      this.chunksCalledWith = new ArrayList<>();
+    }
+
+    @Override
+    public synchronized ChunkData getChunkData(ChunkData reuseChunkData, BlockPalette palette) {
+      chunksCalledWith.add(reuseChunkData);
+      return reuseChunkData;
+    }
+  }
+
+  private static final class MockWorld extends World {
+
+    private final MockChunk mockChunk;
+
+    protected MockWorld() {
+      super("Mock World", null, 1, Collections.emptySet(), false, 0, 0);
+      mockChunk = new MockChunk(this);
+    }
+
+    @Override
+    public synchronized Chunk getChunk(ChunkPosition pos) {
+      return mockChunk;
+    }
+  }
+
+  private static final class MockChunkData implements ChunkData {
+
+    private final String name;
+
+    private MockChunkData(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "MockChunkData: " + name;
+    }
+
+    @Override
+    public int minY() {
+      return 0;
+    }
+
+    @Override
+    public int maxY() {
+      return 0;
+    }
+
+    @Override
+    public int getBlockAt(int x, int y, int z) {
+      return 0;
+    }
+
+    @Override
+    public void setBlockAt(int x, int y, int z, int block) {
+
+    }
+
+    @Override
+    public boolean isBlockOnEdge(int x, int y, int z) {
+      return false;
+    }
+
+    @Override
+    public Collection<CompoundTag> getTileEntities() {
+      return null;
+    }
+
+    @Override
+    public void addTileEntity(CompoundTag tileEntity) {
+
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return false;
+    }
+
+    @Override
+    public Collection<CompoundTag> getEntities() {
+      return null;
+    }
+
+    @Override
+    public void addEntity(CompoundTag entity) {
+
+    }
+
+    @Override
+    public byte getBiomeAt(int x, int y, int z) {
+      return 0;
+    }
+
+    @Override
+    public void setBiomeAt(int x, int y, int z, byte biome) {
+
+    }
+
+    @Override
+    public void clear() {
+
+    }
+  }
+}

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/ChunkReaderTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/ChunkReaderTest.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.renderer.scene;
 
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
Refactor to simplify the responsibilities of the scene class.

* Moved the bulk of the logic within loadChunks to a dedicated ChunkLoader class which performs chunk loading and returns data back in a wrapper object to scene.
* Move chunk reading into dedicated class that abstracts away the async read write.
* Move shared code from `calculateOctreeOrigin` and `calcCenterCamera` to separate method.