### PR TITLE
Add strategy interfaces for perfomring emitter sampling and fog rendering. Decouple logic from PathTracer and PreviewTracer

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/WorkerState.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/WorkerState.java
@@ -16,16 +16,13 @@
  */
 package se.llbit.chunky.renderer;
 
-import se.llbit.math.Ray;
-import se.llbit.math.Vector4;
-
 import java.util.Random;
+import se.llbit.math.Ray;
 
 /**
  * State for a render worker.
  */
 public class WorkerState {
   public Ray ray;
-  public Vector4 attenuation = new Vector4();
   public Random random;
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/EmitterSamplerFactory.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/EmitterSamplerFactory.java
@@ -1,0 +1,117 @@
+package se.llbit.chunky.renderer.scene;
+
+import java.util.Random;
+import se.llbit.chunky.renderer.EmitterSamplingStrategy;
+import se.llbit.chunky.world.Material;
+import se.llbit.math.Grid;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+public class EmitterSamplerFactory {
+
+  public EmitterSampler create(EmitterSamplingStrategy strategy) {
+    switch (strategy) {
+      case ALL:
+        return new AllEmittersSampler();
+      case ONE:
+        return new SingleEmitterSampler();
+      case NONE:
+      default:
+        return (scene, ray, random) -> new Vector4(0, 0, 0, 0);
+    }
+  }
+
+
+  interface EmitterSampler {
+
+    /**
+     * Sample emitters for the current ray and return the indirect emitter color.
+     */
+    Vector4 sample(Scene scene, Ray ray, Random random);
+  }
+
+  private static class SingleEmitterSampler implements EmitterSampler {
+
+    @Override
+    public Vector4 sample(Scene scene, Ray ray, Random random) {
+      Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
+
+      Grid.EmitterPosition pos = scene.getEmitterGrid()
+          .sampleEmitterPosition((int) ray.o.x, (int) ray.o.y, (int) ray.o.z, random);
+      if (pos != null) {
+        indirectEmitterColor = sampleEmitter(scene, ray, pos, random);
+      }
+
+      return indirectEmitterColor;
+    }
+  }
+
+  private static class AllEmittersSampler implements EmitterSampler {
+
+    @Override
+    public Vector4 sample(Scene scene, Ray ray, Random random) {
+      Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
+
+      for (Grid.EmitterPosition pos : scene.getEmitterGrid()
+          .getEmitterPositions((int) ray.o.x, (int) ray.o.y, (int) ray.o.z)) {
+        indirectEmitterColor.scaleAdd(1, sampleEmitter(scene, ray, pos, random));
+      }
+
+      return indirectEmitterColor;
+    }
+  }
+
+  /**
+   * Cast a shadow ray from the intersection point (given by ray) to the emitter at position pos.
+   * Returns the contribution of this emitter (0 if the emitter is occluded)
+   *
+   * @param scene  The scene being rendered
+   * @param ray    The ray that generated the intersection
+   * @param pos    The position of the emitter to sample
+   * @param random RNG
+   * @return The contribution of the emitter
+   */
+  static Vector4 sampleEmitter(Scene scene, Ray ray, Grid.EmitterPosition pos,
+      Random random) {
+    Vector4 indirectEmitterColor = new Vector4();
+    Ray emitterRay = new Ray();
+    emitterRay.set(ray);
+    // TODO Sampling a random point on the model would be better than using a random point in the middle of the cube
+    Vector3 target = new Vector3(pos.x + (random.nextDouble() - 0.5) * pos.radius,
+        pos.y + (random.nextDouble() - 0.5) * pos.radius,
+        pos.z + (random.nextDouble() - 0.5) * pos.radius);
+    emitterRay.d.set(target);
+    emitterRay.d.sub(emitterRay.o);
+    double distance = emitterRay.d.length();
+    emitterRay.d.normalize();
+    double indirectEmitterCoef = emitterRay.d.dot(emitterRay.n);
+    if (indirectEmitterCoef > 0) {
+      // Here We need to invert the material.
+      // The fact that the dot product is > 0 guarantees that the ray is going away from the surface
+      // it just met. This means the ray is going from the block just hit to the previous material (usually air or water)
+      // TODO If/when normal mapping is implemented, indirectEmitterCoef will be computed with the mapped normal
+      //      but the dot product with the original geometry normal will still need to be computed
+      //      to ensure the emitterRay isn't going through the geometry
+      Material prev = emitterRay.getPrevMaterial();
+      int prevData = emitterRay.getPrevData();
+      emitterRay.setPrevMaterial(emitterRay.getCurrentMaterial(), emitterRay.getCurrentData());
+      emitterRay.setCurrentMaterial(prev, prevData);
+      emitterRay.emittance.set(0, 0, 0);
+      emitterRay.o.scaleAdd(Ray.EPSILON, emitterRay.d);
+      RayTracers.nextIntersection(scene, emitterRay);
+      if (emitterRay.getCurrentMaterial().emittance > Ray.EPSILON) {
+        indirectEmitterColor.set(emitterRay.color);
+        indirectEmitterColor.scale(emitterRay.getCurrentMaterial().emittance);
+        // TODO Take fog into account
+        indirectEmitterCoef *= scene.emitterIntensity;
+        // Dont know if really realistic but offer better convergence and is better artistically
+        indirectEmitterCoef /= Math.max(distance * distance, 1);
+      }
+    } else {
+      indirectEmitterCoef = 0;
+    }
+    indirectEmitterColor.scale(indirectEmitterCoef);
+    return indirectEmitterColor;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/EmitterSamplerFactory.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/EmitterSamplerFactory.java
@@ -1,24 +1,26 @@
 package se.llbit.chunky.renderer.scene;
 
 import java.util.Random;
-import se.llbit.chunky.renderer.EmitterSamplingStrategy;
 import se.llbit.chunky.world.Material;
 import se.llbit.math.Grid;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 
+/**
+ * Factory for creating {@link EmitterSampler}s.
+ */
 public class EmitterSamplerFactory {
 
-  public EmitterSampler create(EmitterSamplingStrategy strategy) {
-    switch (strategy) {
+  public EmitterSampler create(Scene scene) {
+    switch (scene.getEmitterSamplingStrategy()) {
       case ALL:
         return new AllEmittersSampler();
       case ONE:
         return new SingleEmitterSampler();
       case NONE:
       default:
-        return (scene, ray, random) -> new Vector4(0, 0, 0, 0);
+        return (s, ray, random) -> new Vector4(0, 0, 0, 0);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategy.java
@@ -1,0 +1,8 @@
+package se.llbit.chunky.renderer.scene;
+
+import se.llbit.math.Ray;
+
+public interface FogStrategy {
+
+  void fogalize(Scene scene, Ray ray);
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategy.java
@@ -1,8 +1,0 @@
-package se.llbit.chunky.renderer.scene;
-
-import se.llbit.math.Ray;
-
-public interface FogStrategy {
-
-  void fogalize(Scene scene, Ray ray);
-}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategyFactory.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogStrategyFactory.java
@@ -1,0 +1,119 @@
+package se.llbit.chunky.renderer.scene;
+
+import java.util.Random;
+import se.llbit.chunky.block.Air;
+import se.llbit.math.QuickMath;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+/**
+ * Factory for creating {@link FogStrategy}s.
+ */
+public class FogStrategyFactory {
+
+  public FogStrategy create(Scene scene) {
+    if (scene.fogEnabled()) {
+      if (scene.fastFog) {
+        return new FastFogStrategy();
+      } else {
+        return new FancyFogStrategy();
+      }
+    }
+
+    // Fog disabled, fog rendering is a no-op.
+    return (scene1, ray, random, airDistance) -> {
+    };
+  }
+
+
+  public interface FogStrategy {
+
+    /**
+     * Calculates effects of fog and apply to the {@code ray}.
+     *
+     * @param scene       The scene being rendered.
+     * @param ray         The ray to apply fog to.
+     * @param random      instance for generating random values.
+     * @param airDistance TODO
+     */
+    void fog(Scene scene, Ray ray, Random random, double airDistance);
+  }
+
+  private static class FastFogStrategy extends BaseFogStrategy {
+
+    @Override
+    double calculateInscatter(double extinction, double airDistance, double offset,
+        double fogDensity) {
+      return 1 - extinction;
+    }
+  }
+
+  private static class FancyFogStrategy extends BaseFogStrategy {
+
+    @Override
+    double calculateInscatter(double extinction, double airDistance, double offset,
+        double fogDensity) {
+      return airDistance * fogDensity * Math.exp(-offset * fogDensity);
+    }
+  }
+
+  /**
+   * Base class for default fast/fancy fog rendering methods.
+   */
+  private abstract static class BaseFogStrategy implements FogStrategy {
+
+    /**
+     * Extinction factor for fog rendering.
+     */
+    private static final double EXTINCTION_FACTOR = 0.04;
+
+    abstract double calculateInscatter(double extinction, double airDistance, double offset,
+        double fogDensity);
+
+    @Override
+    public void fog(Scene scene, Ray ray, Random random, double airDistance) {
+      Vector3 ox = new Vector3(ray.o);
+      Vector3 od = new Vector3(ray.d);
+      // This is a simplistic fog model which gives greater artistic freedom but
+      // less realism. The user can select fog color and density; in a more
+      // realistic model color would depend on viewing angle and sun color/position.
+      if (airDistance > 0) {
+        Sun sun = scene.sun;
+
+        // Pick point between ray origin and intersected object.
+        // The chosen point is used to test if the sun is lighting the
+        // fog between the camera and the first diffuse ray target.
+        // The sun contribution will be proportional to the amount of
+        // sunlit fog areas in the ray path, thus giving an approximation
+        // of the sun inscatter leading to effects like god rays.
+        // The way the sun contribution point is chosen is not
+        // entirely correct because the original ray may have
+        // travelled through glass or other materials between air gaps.
+        // However, the results are probably close enough to not be distracting,
+        // so this seems like a reasonable approximation.
+        Ray atmos = new Ray();
+        double offset = QuickMath.clamp(airDistance * random.nextFloat(),
+            Ray.EPSILON, airDistance - Ray.EPSILON);
+        atmos.o.scaleAdd(offset, od, ox);
+        sun.getRandomSunDirection(atmos, random);
+        atmos.setCurrentMaterial(Air.INSTANCE);
+
+        double fogDensity = scene.getFogDensity() * EXTINCTION_FACTOR;
+        double extinction = Math.exp(-airDistance * fogDensity);
+        ray.color.scale(extinction);
+
+        // Check sun visibility at random point to determine inscatter brightness.
+        Vector4 attenuation = PathTracer.getDirectLightAttenuation(scene, atmos);
+        if (attenuation.w > Ray.EPSILON) {
+          Vector3 fogColor = scene.getFogColor();
+          double inscatter;
+          inscatter = calculateInscatter(extinction, airDistance, offset, fogDensity);
+          ray.color.x += attenuation.x * attenuation.w * fogColor.x * inscatter;
+          ray.color.y += attenuation.y * attenuation.w * fogColor.y * inscatter;
+          ray.color.z += attenuation.z * attenuation.w * fogColor.z * inscatter;
+        }
+      }
+    }
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -24,10 +24,10 @@ import se.llbit.chunky.model.WaterModel;
 import se.llbit.chunky.renderer.EmitterSamplingStrategy;
 import se.llbit.chunky.renderer.WorkerState;
 import se.llbit.chunky.renderer.scene.EmitterSamplerFactory.EmitterSampler;
+import se.llbit.chunky.renderer.scene.FogStrategyFactory.FogStrategy;
 import se.llbit.chunky.world.Material;
 import se.llbit.math.QuickMath;
 import se.llbit.math.Ray;
-import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 
 /**
@@ -37,10 +37,13 @@ import se.llbit.math.Vector4;
  */
 public class PathTracer implements RayTracer {
 
-  /**
-   * Extinction factor for fog rendering.
-   */
-  private static final double EXTINCTION_FACTOR = 0.04;
+  private final EmitterSamplerFactory emitterSamplerFactory;
+  private final FogStrategyFactory fogStrategyFactory;
+
+  public PathTracer() {
+    this.emitterSamplerFactory = new EmitterSamplerFactory();
+    this.fogStrategyFactory = new FogStrategyFactory();
+  }
 
   /**
    * Path trace the ray.
@@ -53,7 +56,8 @@ public class PathTracer implements RayTracer {
     } else {
       ray.setCurrentMaterial(Air.INSTANCE);
     }
-    pathTrace(scene, ray, state, 1, true, scene.getEmitterSampler());
+    pathTrace(scene, ray, state, 1, true,
+        emitterSamplerFactory.create(scene), fogStrategyFactory.create(scene));
   }
 
   /**
@@ -61,18 +65,16 @@ public class PathTracer implements RayTracer {
    *
    * @param firstReflection {@code true} if the ray has not yet hit the first diffuse or specular
    *                        reflection
+   * @param fogStrategy
    */
   private static boolean pathTrace(Scene scene, Ray ray, WorkerState state, int addEmitted,
-      boolean firstReflection, EmitterSampler emitterSampler) {
+      boolean firstReflection, EmitterSampler emitterSampler, FogStrategy fogStrategy) {
 
     boolean hit = false;
     Random random = state.random;
-    Vector3 ox = new Vector3(ray.o);
-    Vector3 od = new Vector3(ray.d);
     double airDistance = 0;
 
     while (true) {
-
       if (!RayTracers.nextIntersection(scene, ray)) {
         if (ray.getPrevMaterial().isWater()) {
           ray.color.set(0, 0, 0, 1);
@@ -143,7 +145,7 @@ public class PathTracer implements RayTracer {
           Ray reflected = new Ray();
           reflected.specularReflection(ray, random);
 
-          if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
+          if (pathTrace(scene, reflected, state, 1, false, emitterSampler, fogStrategy)) {
             if (doMetal) {
               // use the albedo color as specular color
               ray.color.x *= reflected.color.x;
@@ -210,9 +212,8 @@ public class PathTracer implements RayTracer {
 
                 reflected.setCurrentMaterial(reflected.getPrevMaterial(), reflected.getPrevData());
 
-                getDirectLightAttenuation(scene, reflected, state);
+                Vector4 attenuation = getDirectLightAttenuation(scene, reflected);
 
-                Vector4 attenuation = state.attenuation;
                 if (attenuation.w > 0) {
                   double mult = QuickMath.abs(reflected.d.dot(ray.n));
                   directLightR = attenuation.x * attenuation.w * mult;
@@ -223,7 +224,8 @@ public class PathTracer implements RayTracer {
               }
 
               reflected.diffuseReflection(ray, random);
-              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler) || hit;
+              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler,
+                  fogStrategy) || hit;
               if (hit) {
                 ray.color.x = ray.color.x * (emittance + directLightR * scene.sun.emittance.x + (
                     reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
@@ -242,7 +244,8 @@ public class PathTracer implements RayTracer {
             } else {
               reflected.diffuseReflection(ray, random);
 
-              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler) || hit;
+              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler,
+                  fogStrategy) || hit;
               if (hit) {
                 ray.color.x =
                     ray.color.x * (emittance + (reflected.color.x + reflected.emittance.x)
@@ -278,7 +281,8 @@ public class PathTracer implements RayTracer {
             if (!scene.kill(ray.depth + 1, random)) {
               Ray reflected = new Ray();
               reflected.specularReflection(ray, random);
-              if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
+              if (pathTrace(scene, reflected, state, 1, false, emitterSampler,
+                  fogStrategy)) {
 
                 ray.color.x = reflected.color.x;
                 ray.color.y = reflected.color.y;
@@ -303,7 +307,8 @@ public class PathTracer implements RayTracer {
               if (random.nextFloat() < Rtheta) {
                 Ray reflected = new Ray();
                 reflected.specularReflection(ray, random);
-                if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
+                if (pathTrace(scene, reflected, state, 1, false, emitterSampler,
+                    fogStrategy)) {
                   ray.color.x = reflected.color.x;
                   ray.color.y = reflected.color.y;
                   ray.color.z = reflected.color.z;
@@ -328,7 +333,8 @@ public class PathTracer implements RayTracer {
                   refracted.o.scaleAdd(Ray.OFFSET, refracted.d);
                 }
 
-                if (pathTrace(scene, refracted, state, 1, false, emitterSampler)) {
+                if (pathTrace(scene, refracted, state, 1, false, emitterSampler,
+                    fogStrategy)) {
                   ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
                   ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
                   ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
@@ -347,7 +353,8 @@ public class PathTracer implements RayTracer {
           transmitted.set(ray);
           transmitted.o.scaleAdd(Ray.OFFSET, transmitted.d);
 
-          if (pathTrace(scene, transmitted, state, 1, false, emitterSampler)) {
+          if (pathTrace(scene, transmitted, state, 1, false, emitterSampler,
+              fogStrategy)) {
             ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
             ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
             ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
@@ -379,50 +386,7 @@ public class PathTracer implements RayTracer {
       }
     }
 
-    // This is a simplistic fog model which gives greater artistic freedom but
-    // less realism. The user can select fog color and density; in a more
-    // realistic model color would depend on viewing angle and sun color/position.
-    if (airDistance > 0 && scene.fogEnabled()) {
-      Sun sun = scene.sun;
-
-      // Pick point between ray origin and intersected object.
-      // The chosen point is used to test if the sun is lighting the
-      // fog between the camera and the first diffuse ray target.
-      // The sun contribution will be proportional to the amount of
-      // sunlit fog areas in the ray path, thus giving an approximation
-      // of the sun inscatter leading to effects like god rays.
-      // The way the sun contribution point is chosen is not
-      // entirely correct because the original ray may have
-      // travelled through glass or other materials between air gaps.
-      // However, the results are probably close enough to not be distracting,
-      // so this seems like a reasonable approximation.
-      Ray atmos = new Ray();
-      double offset = QuickMath.clamp(airDistance * random.nextFloat(),
-          Ray.EPSILON, airDistance - Ray.EPSILON);
-      atmos.o.scaleAdd(offset, od, ox);
-      sun.getRandomSunDirection(atmos, random);
-      atmos.setCurrentMaterial(Air.INSTANCE);
-
-      double fogDensity = scene.getFogDensity() * EXTINCTION_FACTOR;
-      double extinction = Math.exp(-airDistance * fogDensity);
-      ray.color.scale(extinction);
-
-      // Check sun visibility at random point to determine inscatter brightness.
-      getDirectLightAttenuation(scene, atmos, state);
-      Vector4 attenuation = state.attenuation;
-      if (attenuation.w > Ray.EPSILON) {
-        Vector3 fogColor = scene.getFogColor();
-        double inscatter;
-        if (scene.fastFog()) {
-          inscatter = (1 - extinction);
-        } else {
-          inscatter = airDistance * fogDensity * Math.exp(-offset * fogDensity);
-        }
-        ray.color.x += attenuation.x * attenuation.w * fogColor.x * inscatter;
-        ray.color.y += attenuation.y * attenuation.w * fogColor.y * inscatter;
-        ray.color.z += attenuation.z * attenuation.w * fogColor.z * inscatter;
-      }
-    }
+    fogStrategy.fog(scene, ray, random, airDistance);
 
     return hit;
   }
@@ -430,13 +394,8 @@ public class PathTracer implements RayTracer {
   /**
    * Calculate direct lighting attenuation.
    */
-  private static void getDirectLightAttenuation(Scene scene, Ray ray, WorkerState state) {
-
-    Vector4 attenuation = state.attenuation;
-    attenuation.x = 1;
-    attenuation.y = 1;
-    attenuation.z = 1;
-    attenuation.w = 1;
+  public static Vector4 getDirectLightAttenuation(Scene scene, Ray ray) {
+    Vector4 attenuation = new Vector4(1, 1, 1, 1);
     while (attenuation.w > 0) {
       ray.o.scaleAdd(Ray.OFFSET, ray.d);
       if (!RayTracers.nextIntersection(scene, ray)) {
@@ -456,6 +415,7 @@ public class PathTracer implements RayTracer {
         }
       }
     }
-  }
 
+    return attenuation;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -143,7 +143,7 @@ public class PathTracer implements RayTracer {
           Ray reflected = new Ray();
           reflected.specularReflection(ray, random);
 
-          if (pathTrace(scene, reflected, state, 1, false)) {
+          if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
             if (doMetal) {
               // use the albedo color as specular color
               ray.color.x *= reflected.color.x;
@@ -223,7 +223,7 @@ public class PathTracer implements RayTracer {
               }
 
               reflected.diffuseReflection(ray, random);
-              hit = pathTrace(scene, reflected, state, 0, false) || hit;
+              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler) || hit;
               if (hit) {
                 ray.color.x = ray.color.x * (emittance + directLightR * scene.sun.emittance.x + (
                     reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
@@ -242,7 +242,7 @@ public class PathTracer implements RayTracer {
             } else {
               reflected.diffuseReflection(ray, random);
 
-              hit = pathTrace(scene, reflected, state, 0, false) || hit;
+              hit = pathTrace(scene, reflected, state, 0, false, emitterSampler) || hit;
               if (hit) {
                 ray.color.x =
                     ray.color.x * (emittance + (reflected.color.x + reflected.emittance.x)
@@ -278,7 +278,7 @@ public class PathTracer implements RayTracer {
             if (!scene.kill(ray.depth + 1, random)) {
               Ray reflected = new Ray();
               reflected.specularReflection(ray, random);
-              if (pathTrace(scene, reflected, state, 1, false)) {
+              if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
 
                 ray.color.x = reflected.color.x;
                 ray.color.y = reflected.color.y;
@@ -303,7 +303,7 @@ public class PathTracer implements RayTracer {
               if (random.nextFloat() < Rtheta) {
                 Ray reflected = new Ray();
                 reflected.specularReflection(ray, random);
-                if (pathTrace(scene, reflected, state, 1, false)) {
+                if (pathTrace(scene, reflected, state, 1, false, emitterSampler)) {
                   ray.color.x = reflected.color.x;
                   ray.color.y = reflected.color.y;
                   ray.color.z = reflected.color.z;
@@ -328,7 +328,7 @@ public class PathTracer implements RayTracer {
                   refracted.o.scaleAdd(Ray.OFFSET, refracted.d);
                 }
 
-                if (pathTrace(scene, refracted, state, 1, false)) {
+                if (pathTrace(scene, refracted, state, 1, false, emitterSampler)) {
                   ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
                   ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
                   ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
@@ -347,7 +347,7 @@ public class PathTracer implements RayTracer {
           transmitted.set(ray);
           transmitted.o.scaleAdd(Ray.OFFSET, transmitted.d);
 
-          if (pathTrace(scene, transmitted, state, 1, false)) {
+          if (pathTrace(scene, transmitted, state, 1, false, emitterSampler)) {
             ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
             ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
             ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -41,7 +41,7 @@ public class PreviewRayTracer implements RayTracer {
       ray.setCurrentMaterial(Air.INSTANCE);
     }
     while (true) {
-      if (!nextIntersection(scene, ray)) {
+      if (!RayTracers.nextIntersection(scene, ray)) {
         if (mapIntersection(scene, ray)) {
           break;
         }
@@ -58,85 +58,6 @@ public class PreviewRayTracer implements RayTracer {
     } else {
       scene.sun.flatShading(ray);
     }
-  }
-
-  /**
-   * Calculate sky occlusion.
-   * @return occlusion value
-   */
-  public static double skyOcclusion(Scene scene, WorkerState state) {
-    Ray ray = state.ray;
-    double occlusion = 1.0;
-    while (true) {
-      if (!nextIntersection(scene, ray)) {
-        break;
-      } else {
-        occlusion *= (1 - ray.color.w);
-        if (occlusion == 0) {
-          return 1; // occlusion can't become > 0 anymore
-        }
-        ray.o.scaleAdd(Ray.OFFSET, ray.d);
-      }
-    }
-    return 1 - occlusion;
-  }
-
-  /**
-   * Find next ray intersection.
-   * @return Next intersection
-   */
-  public static boolean nextIntersection(Scene scene, Ray ray) {
-    ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());
-    ray.t = Double.POSITIVE_INFINITY;
-    boolean hit = false;
-    if (scene.sky().cloudsEnabled()) {
-      hit = scene.sky().cloudIntersection(scene, ray);
-    }
-    if (scene.isWaterPlaneEnabled()) {
-      hit = waterPlaneIntersection(scene, ray) || hit;
-    }
-    if (scene.intersect(ray)) {
-      // Octree tracer handles updating distance.
-      return true;
-    }
-    if (hit) {
-      ray.distance += ray.t;
-      ray.o.scaleAdd(ray.t, ray.d);
-      scene.updateOpacity(ray);
-      return true;
-    } else {
-      ray.setCurrentMaterial(Air.INSTANCE);
-      return false;
-    }
-  }
-
-  private static boolean waterPlaneIntersection(Scene scene, Ray ray) {
-    double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
-    if (scene.getWaterPlaneChunkClip()) {
-      Vector3 pos = new Vector3(ray.o);
-      pos.scaleAdd(t, ray.d);
-      if (scene.isChunkLoaded((int)Math.floor(pos.x), (int)Math.floor(pos.z)))
-        return false;
-    }
-    if (ray.d.y < 0) {
-      if (t > 0 && t < ray.t) {
-        ray.t = t;
-        Water.INSTANCE.getColor(ray);
-        ray.n.set(0, 1, 0);
-        ray.setCurrentMaterial(scene.getPalette().water);
-        return true;
-      }
-    }
-    if (ray.d.y > 0) {
-      if (t > 0 && t < ray.t) {
-        ray.t = t;
-        Water.INSTANCE.getColor(ray);
-        ray.n.set(0, -1, 0);
-        ray.setCurrentMaterial(Air.INSTANCE);
-        return true;
-      }
-    }
-    return false;
   }
 
   // Chunk pattern config

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/RayTracers.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/RayTracers.java
@@ -1,0 +1,102 @@
+package se.llbit.chunky.renderer.scene;
+
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Water;
+import se.llbit.chunky.renderer.WorkerState;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+
+/**
+ * Static utility methods pertaining to RayTracer instances.
+ */
+public final class RayTracers {
+
+  /**
+   * Private no argument constructor to prevent initialization.
+   */
+  private RayTracers() {
+  }
+
+
+  /**
+   * Calculate sky occlusion.
+   *
+   * @return occlusion value
+   */
+  public static double skyOcclusion(Scene scene, WorkerState state) {
+    Ray ray = state.ray;
+    double occlusion = 1.0;
+    while (true) {
+      if (!nextIntersection(scene, ray)) {
+        break;
+      } else {
+        occlusion *= (1 - ray.color.w);
+        if (occlusion == 0) {
+          return 1; // occlusion can't become > 0 anymore
+        }
+        ray.o.scaleAdd(Ray.OFFSET, ray.d);
+      }
+    }
+    return 1 - occlusion;
+  }
+
+  /**
+   * Find next ray intersection. The ray is displaced to the target position if it hits something.
+   *
+   * @return {@code true} if an intersection is found.
+   */
+  public static boolean nextIntersection(Scene scene, Ray ray) {
+    ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());
+    ray.t = Double.POSITIVE_INFINITY;
+    boolean hit = false;
+    if (scene.sky().cloudsEnabled()) {
+      hit = scene.sky().cloudIntersection(scene, ray);
+    }
+    if (scene.isWaterPlaneEnabled()) {
+      hit = waterPlaneIntersection(scene, ray) || hit;
+    }
+    if (scene.intersect(ray)) {
+      // Octree tracer handles updating distance.
+      return true;
+    }
+    if (hit) {
+      ray.distance += ray.t;
+      ray.o.scaleAdd(ray.t, ray.d);
+      scene.updateOpacity(ray);
+      return true;
+    } else {
+      ray.setCurrentMaterial(Air.INSTANCE);
+      return false;
+    }
+  }
+
+  private static boolean waterPlaneIntersection(Scene scene, Ray ray) {
+    double t = (scene.getEffectiveWaterPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
+    if (scene.getWaterPlaneChunkClip()) {
+      Vector3 pos = new Vector3(ray.o);
+      pos.scaleAdd(t, ray.d);
+      if (scene.isChunkLoaded((int) Math.floor(pos.x), (int) Math.floor(pos.z))) {
+        return false;
+      }
+    }
+    if (ray.d.y < 0) {
+      if (t > 0 && t < ray.t) {
+        ray.t = t;
+        Water.INSTANCE.getColor(ray);
+        ray.n.set(0, 1, 0);
+        ray.setCurrentMaterial(scene.getPalette().water);
+        return true;
+      }
+    }
+    if (ray.d.y > 0) {
+      if (t > 0 && t < ray.t) {
+        ray.t = t;
+        Water.INSTANCE.getColor(ray);
+        ray.n.set(0, -1, 0);
+        ray.setCurrentMaterial(Air.INSTANCE);
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -83,7 +83,6 @@ import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
 import se.llbit.chunky.renderer.postprocessing.PreviewFilter;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
 import se.llbit.chunky.renderer.renderdump.RenderDump;
-import se.llbit.chunky.renderer.scene.EmitterSamplerFactory.EmitterSampler;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.resources.OctreeFileFormat;
 import se.llbit.chunky.world.Biomes;
@@ -382,7 +381,6 @@ public class Scene implements JsonSerializable, Refreshable {
    * Additional data that is associated with a scene, this can be used by plugins
    */
   private JsonObject additionalData = new JsonObject();
-  private EmitterSampler emitterSampler = new EmitterSamplerFactory().create(emitterSamplingStrategy);
 
   /**
    * Creates a scene with all default settings.
@@ -3293,9 +3291,5 @@ public class Scene implements JsonSerializable, Refreshable {
   @PluginApi
   public JsonValue getAdditionalData(String name) {
     return additionalData.get(name);
-  }
-
-  public EmitterSampler getEmitterSampler() {
-    return emitterSampler;
   }
 }


### PR DESCRIPTION
This PR modifies how the PathTracer handles emitter sampling and fog. Instead of directly implementing fog/sampling within a ray tracer, delegate to a Sampler or FogStrategy.

Additionally I have moved static methods defined in PreviewRayTracer to a utility `RayTracers` class to untangle tracer types.

TODO

- [ ] Verify that the minor increase in method calls does not hurt rayTrace performance. JIT should handle this just fine, but have to be sure.
- [ ] Allow plugins to provide custom fog handling strategies
- [ ] Better differentiate between skyFog and er not sky fog? settings in UI and allow choosing a fog strategy