### PR TITLE
Texture image compression

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -759,6 +759,7 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
         }
       }
     }
+    texture.compress();
     TextureCache.put(item, texture);
     return texture;
   }

--- a/chunky/src/java/se/llbit/chunky/resources/AnimatedTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/AnimatedTexture.java
@@ -42,7 +42,7 @@ public class AnimatedTexture extends Texture {
         (int) ((1 - v) * frameHeight - Ray.EPSILON + i * frameHeight));
   }
 
-  @Override public void setTexture(BitmapImage newImage) {
+  @Override public void setTexture(Image newImage) {
     super.setTexture(newImage);
     updateNumFrames();
   }

--- a/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
@@ -40,6 +40,12 @@ public class BitmapImage implements Image {
     data = new int[width * height];
   }
 
+  public BitmapImage(int width, int height, int[] data) {
+    this.width = width;
+    this.height = height;
+    this.data = data;
+  }
+
   /**
    * Create a copy of another image.
    */

--- a/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/BitmapImage.java
@@ -26,7 +26,7 @@ import org.apache.commons.math3.util.FastMath;
  * raw pixel data is mutable. External synchronization is needed
  * if concurrent modification of pixels needs to be done.
  */
-public class BitmapImage {
+public class BitmapImage implements Image {
   public final int[] data;
   public final int width;
   public final int height;
@@ -48,6 +48,21 @@ public class BitmapImage {
     this.height = image.height;
     data = new int[width * height];
     System.arraycopy(image.data, 0, data, 0, width * height);
+  }
+
+  @Override
+  public int getWidth() {
+    return width;
+  }
+
+  @Override
+  public int getHeight() {
+    return height;
+  }
+
+  @Override
+  public int getPixel(int index) {
+    return data[index];
   }
 
   /** @return the ARGB value of the pixel (x, y). */
@@ -173,5 +188,9 @@ public class BitmapImage {
     img.blit(a, 0, 0);
     img.blit(b, 0, a.height, 0, 0, b.width, b.height);
     return img;
+  }
+
+  public BitmapImage asBitmap() {
+    return this;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/CompressedImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/CompressedImage.java
@@ -5,6 +5,11 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import se.llbit.math.QuickMath;
 
+/**
+ * Image using a palette compression to reduce memory usage.
+ * The size of the palette/number of bit each pixel takes
+ * is computed based on the number of colors used in the image to compress
+ */
 public class CompressedImage implements Image {
   private int width;
   private int height;
@@ -51,6 +56,12 @@ public class CompressedImage implements Image {
     return new BitmapImage(width, height, uncompressedData);
   }
 
+  /**
+   * Do the compression.
+   * The input image is first analyzed to count the number of color and determine
+   * the bit depth of the image.
+   * Then the image is compressed by storing the palette indexes
+   */
   private void compressFrom(Image source) {
     IntArrayList paletteBuilder = new IntArrayList();
     Int2IntOpenHashMap colorToIndex = new Int2IntOpenHashMap();
@@ -78,6 +89,7 @@ public class CompressedImage implements Image {
     pixelPerLong = 64 / bitDepth;
     mask = ((1L << bitDepth) - 1); // bitDepth 1s
 
+    // build the image
     LongArrayList compressedDataBuilder = new LongArrayList();
 
     int pixelIndex = 0;

--- a/chunky/src/java/se/llbit/chunky/resources/CompressedImage.java
+++ b/chunky/src/java/se/llbit/chunky/resources/CompressedImage.java
@@ -1,0 +1,96 @@
+package se.llbit.chunky.resources;
+
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import se.llbit.math.QuickMath;
+
+public class CompressedImage implements Image {
+  private int width;
+  private int height;
+  private int[] palette;
+  private int bitDepth;
+  private int pixelPerLong;
+  private long[] compressedData;
+  private long mask;
+
+  CompressedImage(Image source) {
+    compressFrom(source);
+  }
+
+  @Override
+  public int getWidth() {
+    return width;
+  }
+
+  @Override
+  public int getHeight() {
+    return height;
+  }
+
+  @Override
+  public int getPixel(int x, int y) {
+    return getPixel(y * width + x);
+  }
+
+  @Override
+  public int getPixel(int index) {
+    int longIndex = index / pixelPerLong;
+    int indexInLong = index % pixelPerLong * bitDepth;
+    int paletteIndex = (int) ((compressedData[longIndex] >>> indexInLong) & mask);
+    return palette[paletteIndex];
+  }
+
+  @Override
+  public BitmapImage asBitmap() {
+    int pixelCount = width * height;
+    int[] uncompressedData = new int[pixelCount];
+    for(int i = 0; i < pixelCount; ++i) {
+      uncompressedData[i] = getPixel(i);
+    }
+    return new BitmapImage(width, height, uncompressedData);
+  }
+
+  private void compressFrom(Image source) {
+    IntArrayList paletteBuilder = new IntArrayList();
+    Int2IntOpenHashMap colorToIndex = new Int2IntOpenHashMap();
+
+    width = source.getWidth();
+    height = source.getHeight();
+    int pixelCount = width * height;
+
+    // Build the palette
+    for(int i = 0; i < pixelCount; ++i) {
+      int color = source.getPixel(i);
+      if(!colorToIndex.containsKey(color)) {
+        int colorIndex = paletteBuilder.size();
+        paletteBuilder.add(color);
+        colorToIndex.put(color, colorIndex);
+      }
+    }
+
+    int colorCount = paletteBuilder.size();
+    palette = paletteBuilder.toIntArray();
+    paletteBuilder = null;
+    bitDepth = QuickMath.log2(QuickMath.nextPow2(colorCount));
+    if(bitDepth == 0)
+      bitDepth = 1;
+    pixelPerLong = 64 / bitDepth;
+    mask = ((1L << bitDepth) - 1); // bitDepth 1s
+
+    LongArrayList compressedDataBuilder = new LongArrayList();
+
+    int pixelIndex = 0;
+    while(pixelIndex < pixelCount) {
+      long current = 0L;
+      for(int i = 0; i < pixelPerLong && pixelIndex < pixelCount; ++i) {
+        int color = source.getPixel(pixelIndex);
+        long colorIndex = colorToIndex.get(color);
+        current |= colorIndex  << (i * bitDepth);
+        ++pixelIndex;
+      }
+      compressedDataBuilder.add(current);
+    }
+    compressedData = compressedDataBuilder.toLongArray();
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/resources/Image.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Image.java
@@ -1,9 +1,31 @@
 package se.llbit.chunky.resources;
 
+/**
+ * Generic image giving read only access
+ */
 public interface Image {
+  /**
+   * Get the width of the image
+   */
   int getWidth();
+
+  /**
+   * Get the height of the image
+   */
   int getHeight();
+
+  /**
+   * Get the pixel at position (x, y)
+   */
   int getPixel(int x, int y);
+
+  /**
+   * Get the pixel at the given index. Index is computed as y * width + x
+   */
   int getPixel(int index);
+
+  /**
+   * Convert the image to a BitmapImage
+   */
   BitmapImage asBitmap();
 }

--- a/chunky/src/java/se/llbit/chunky/resources/Image.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Image.java
@@ -1,0 +1,9 @@
+package se.llbit.chunky.resources;
+
+public interface Image {
+  int getWidth();
+  int getHeight();
+  int getPixel(int x, int y);
+  int getPixel(int index);
+  BitmapImage asBitmap();
+}

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -16,7 +16,6 @@
  */
 package se.llbit.chunky.resources;
 
-import javafx.scene.image.Image;
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.scene.Scene;
@@ -1032,7 +1031,7 @@ public class Texture {
       lightGrayClay, cyanClay, purpleClay, blueClay, brownClay, greenClay, redClay, blackClay
   };
 
-  @NotNull protected BitmapImage image;
+  @NotNull protected Image image;
   protected int width;
   protected int height;
   protected int avgColor;
@@ -1040,7 +1039,7 @@ public class Texture {
   private boolean useAverageColor = false;
   private float[] avgColorFlat;
 
-  private Image fxImage = null;
+  private javafx.scene.image.Image fxImage = null;
 
   public Texture() {
     this(ImageLoader.missingImage);
@@ -1050,7 +1049,7 @@ public class Texture {
     this(ImageLoader.readNonNull("textures/" + resourceName + ".png"));
   }
 
-  public Texture(BitmapImage img) {
+  public Texture(Image img) {
     setTexture(img);
   }
 
@@ -1058,20 +1057,19 @@ public class Texture {
     setTexture(texture.image);
   }
 
-  public void setTexture(BitmapImage newImage) {
+  public void setTexture(Image newImage) {
     image = newImage;
 
     // Gamma correct the texture.
     avgColorLinear = new float[] {0, 0, 0, 0};
 
-    int[] data = image.data;
-    width = image.width;
-    height = image.height;
+    width = image.getWidth();
+    height = image.getHeight();
     float[] pixelBuffer = new float[4];
     for (int y = 0; y < height; ++y) {
       for (int x = 0; x < width; ++x) {
         int index = width * y + x;
-        ColorUtil.getRGBAComponentsGammaCorrected(data[index], pixelBuffer);
+        ColorUtil.getRGBAComponentsGammaCorrected(image.getPixel(index), pixelBuffer);
         avgColorLinear[0] += pixelBuffer[3] * pixelBuffer[0];
         avgColorLinear[1] += pixelBuffer[3] * pixelBuffer[1];
         avgColorLinear[2] += pixelBuffer[3] * pixelBuffer[2];
@@ -1134,7 +1132,7 @@ public class Texture {
     if(useAverageColor)
       return avgColorFlat;
     float[] result = new float[4];
-    ColorUtil.getRGBAComponentsGammaCorrected(image.data[width*y + x], result);
+    ColorUtil.getRGBAComponentsGammaCorrected(image.getPixel(width*y + x), result);
     return result;
   }
 
@@ -1213,19 +1211,14 @@ public class Texture {
     return false;
   }
 
-  public Image fxImage() {
+  public javafx.scene.image.Image fxImage() {
     if (fxImage == null) {
-      fxImage = FxImageUtil.toFxImage(image);
+      fxImage = FxImageUtil.toFxImage(image.asBitmap());
     }
     return fxImage;
   }
 
-  /** Access the raw image data for this texture. */
-  public int[] getData() {
-    return image.data;
-  }
-
   public BitmapImage getBitmap() {
-    return image;
+    return image.asBitmap();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1222,6 +1222,9 @@ public class Texture {
     return image.asBitmap();
   }
 
+  /**
+   * Replace the current image by a compressed version of the image
+   */
   public void compress() {
     if(!(image instanceof CompressedImage))
       image = new CompressedImage(image);

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1221,4 +1221,9 @@ public class Texture {
   public BitmapImage getBitmap() {
     return image.asBitmap();
   }
+
+  public void compress() {
+    if(!(image instanceof CompressedImage))
+      image = new CompressedImage(image);
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/EntityTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/EntityTextureLoader.java
@@ -47,6 +47,7 @@ public class EntityTextureLoader extends TextureLoader {
     }
 
     texture.setTexture(image);
+    texture.compress();
 
     boolean extended = image.height == image.width;
     double height = extended ? 64 : 32;

--- a/chunky/src/java/se/llbit/chunky/world/SkymapTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/SkymapTexture.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.world;
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.Image;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.log.Log;
 import se.llbit.math.ColorUtil;
@@ -55,16 +56,17 @@ public class SkymapTexture extends Texture {
       for (int y = y0; y <= y1; ++y) {
         for (int x = x0; x <= x1; ++x) {
           int index = width * y + x;
-          ColorUtil.getRGBAComponents(image.data[index], c);
           ColorUtil.getRGBAComponents(image.getPixel(x, y), c);
           c[0] = (float) FastMath.pow(c[0], Scene.DEFAULT_GAMMA);
           c[1] = (float) FastMath.pow(c[1], Scene.DEFAULT_GAMMA);
           c[2] = (float) FastMath.pow(c[2], Scene.DEFAULT_GAMMA);
-          image.data[index] = ColorUtil.getRGB(c);
+          bitmapImage.data[index] = ColorUtil.getRGB(c);
         }
       }
     }
   }
+
+  private BitmapImage bitmapImage;
 
   /**
    * Create new skymap.
@@ -73,12 +75,17 @@ public class SkymapTexture extends Texture {
     super(image);
   }
 
-  @Override public void setTexture(BitmapImage newImage) {
-    image = newImage;
+  @Override public void setTexture(Image newImage) {
+    setTexture(newImage.asBitmap());
+  }
 
-    width = image.width;
-    height = image.height;
-    avgColor = ImageTools.calcAvgColor(image);
+  public void setTexture(BitmapImage newImage) {
+    image = newImage;
+    bitmapImage = newImage;
+
+    width = bitmapImage.width;
+    height = bitmapImage.height;
+    avgColor = ImageTools.calcAvgColor(bitmapImage);
 
     Log.info("Preprocessing skymap texture");
     long start = System.currentTimeMillis();


### PR DESCRIPTION
Another memory usage reduction PR.
This time I changed Texture to use a generic `Image` interface instead of directly `BitmapImage` and I made a another implementation of this interface that is compressed with a palette.
Of course the compressed implementation is slower to access pixel so the idea is to only use it for rarely accessed texture. What I've done is to use it for texture that are mainly related to player/armor stand like equipment and player head.
With this the majority of texture access are still fast but some memory is saved.
When loading 4 region of Greenfield I have:
before: retained size of `BitmapImage` is 108MB
after: retained size of `BitmapImage`+`CompressedImage` is 69MB (63MB + 6MB).
That's around a 10MB reduction per region for Greenfield. (of course, a map without entities wouldn't see improvements).
I have not measured any performance drop (but small scale test as well while the camera is far away from the ground to get a bird eye view so not a lot of rays must have intersected with entities).