### PR TITLE
Small RenderManager bug fixes.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -396,7 +396,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
   protected void finalizeFrame(boolean force) {
     if (force || snapshotControl.saveSnapshot(bufferedScene, bufferedScene.spp)) {
       PostProcessingFilter filter = bufferedScene.getPostProcessingFilter();
-      if (mode == RenderMode.RENDERING) filter = PreviewFilter.INSTANCE;
+      if (mode == RenderMode.PREVIEW) filter = PreviewFilter.INSTANCE;
 
       if (filter instanceof PixelPostProcessingFilter) {
         PixelPostProcessingFilter pixelFilter = (PixelPostProcessingFilter) filter;
@@ -407,8 +407,9 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         double exposure = bufferedScene.getExposure();
 
         // Split up to 10 tasks per thread
-        int pixelsPerTask = (bufferedScene.width * bufferedScene.height) / (pool.threads * 10 - 1);
-        ArrayList<RenderWorkerPool.RenderJobFuture> jobs = new ArrayList<>(pool.threads * 10);
+        int tasksPerThread = 10;
+        int pixelsPerTask = (bufferedScene.width * bufferedScene.height) / (pool.threads * tasksPerThread - 1);
+        ArrayList<RenderWorkerPool.RenderJobFuture> jobs = new ArrayList<>(pool.threads * tasksPerThread);
 
         for (int i = 0; i < bufferedScene.width * bufferedScene.height; i += pixelsPerTask) {
           int start = i;

--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -98,9 +98,9 @@ public class DefaultRenderManager extends Thread implements RenderManager {
   public final Scene bufferedScene;
 
   /**
-   * This stores the modification count of the bufferedScene. It is incremented whenever a reset occurs.
+   * This stores the reset count of the bufferedScene. It is incremented whenever a reset occurs.
    */
-  private int modCount = 1;
+  private int resetCount = 1;
 
   /**
    * This is the render worker pool {@code Renderer}s should use.
@@ -273,9 +273,9 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         setPreviewRenderer(bufferedScene.getPreviewRenderer());
 
         // Notify renderers
-        modCount += 1;
-        getRenderer().sceneReset(this, reason, modCount);
-        getPreviewRenderer().sceneReset(this, reason, modCount);
+        resetCount += 1;
+        getRenderer().sceneReset(this, reason, resetCount);
+        getPreviewRenderer().sceneReset(this, reason, resetCount);
 
         // Select the correct renderer
         Renderer render = mode == RenderMode.PREVIEW ? getPreviewRenderer() : getRenderer();

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -72,13 +72,14 @@ public class RenderWorkerPool {
 
     /**
      * Reset the sleep interval. Call this if the worker has spent a long time waiting.
-     * For example: {@code
+     * For example:
+     * <pre>
      *    worker.workSleep()
      *    synchronized(monitor) {
      *      monitor.wait();
      *    }
      *    worker.resetSleep();
-     * }
+     * </pre>
      */
     public void resetSleep() {
       lastSleep = System.currentTimeMillis();
@@ -116,7 +117,7 @@ public class RenderWorkerPool {
     }
   }
 
-  private void work(RenderWorker worker) throws InterruptedException {
+  private void work(RenderWorker worker) throws Throwable {
     synchronized (workQueue) {
       while (workQueue.isEmpty()) {
         workQueue.wait();
@@ -201,14 +202,11 @@ public class RenderWorkerPool {
   }
 
   /**
-   * A render job. It is essentially a {@code Consumer<RenderWorker>} but with
-   * the ability to throw an {@code InterruptedException}.
+   * A render job. Thrown exceptions are handled by the worker.
+   * Note: {@code InterruptedException}s are ignored. All other {@code Throwable}s will be logged as an error.
    */
   @FunctionalInterface
   interface RenderJob {
-    /**
-     * @throws InterruptedException when the Thread is interrupted while waiting.
-     */
-    void accept(RenderWorker worker) throws InterruptedException;
+    void accept(RenderWorker worker) throws Throwable;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -25,8 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Performs rendering work.
- *
- * @author Jesper Öqvist <jesper@llbit.se>
  */
 public class RenderWorkerPool {
 
@@ -202,10 +200,14 @@ public class RenderWorkerPool {
   }
 
   /**
-   * A render job. This may throw an {@code InterruptedException}.
+   * A render job. It is essentially a {@code Consumer<RenderWorker>} but with
+   * the ability to throw an {@code InterruptedException}.
    */
   @FunctionalInterface
   interface RenderJob {
+    /**
+     * @throws InterruptedException when the Thread is interrupted while waiting.
+     */
     void accept(RenderWorker worker) throws InterruptedException;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -206,8 +206,6 @@ public class RenderWorkerPool {
     /**
      * @param worker      The render worker running this job.
      * @throws Throwable  Any unchecked exception.
-     *                    Note: {@code InterruptedException}s are ignored. All other {@code Throwable}s will be logged
-     *                    as an error.
      */
     void accept(RenderWorker worker) throws Throwable;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -201,12 +201,14 @@ public class RenderWorkerPool {
     }
   }
 
-  /**
-   * A render job. Thrown exceptions are handled by the worker.
-   * Note: {@code InterruptedException}s are ignored. All other {@code Throwable}s will be logged as an error.
-   */
   @FunctionalInterface
   interface RenderJob {
+    /**
+     * @param worker      The render worker running this job.
+     * @throws Throwable  Any unchecked exception.
+     *                    Note: {@code InterruptedException}s are ignored. All other {@code Throwable}s will be logged
+     *                    as an error.
+     */
     void accept(RenderWorker worker) throws Throwable;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -146,6 +146,7 @@ public class RenderWorkerPool {
 
   /**
    * Set the cpu load. The pools will attempt (not guaranteed) to limit cpu usage to this value.
+   * @param cpuLoad percentage of cpu usage, will be clamped to [1..100]
    */
   public void setCpuLoad(int cpuLoad) {
     // Clamp to 1-100

--- a/chunky/src/java/se/llbit/chunky/renderer/Renderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/Renderer.java
@@ -70,10 +70,15 @@ public interface Renderer extends Registerable {
   void render(DefaultRenderManager manager) throws InterruptedException;
 
   /**
-   * This is called when the scene is reset. The default implementation does nothing.
+   * This is called when the scene is reset and this {@code Renderer} is selected as either the preview or render.
    * This is for {@code Renderer}s which need to export the scene data in some way.
+   *
+   * The default implementation does nothing.
+   *
+   * @param modCount This is the reset count. Any reset will increment this variable. Implementations may keep track
+   *                 of this count to see if it missed a reset. The starting value will be >= 1.
    */
-  default void sceneReset(DefaultRenderManager manager, ResetReason reason) {}
+  default void sceneReset(DefaultRenderManager manager, ResetReason reason, int modCount) {}
 
   /**
    * This should return if this renderer will postprocess on its own.

--- a/chunky/src/java/se/llbit/chunky/renderer/Renderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/Renderer.java
@@ -75,10 +75,11 @@ public interface Renderer extends Registerable {
    *
    * The default implementation does nothing.
    *
-   * @param modCount This is the reset count. Any reset will increment this variable. Implementations may keep track
-   *                 of this count to see if it missed a reset. The starting value will be >= 1.
+   * @param resetCount This is the reset count. Any reset will increment this variable. Implementations may keep track
+   *                   of this count to see if it missed a reset (and should potentially re-export the scene).
+   *                   The starting value will be >= 1.
    */
-  default void sceneReset(DefaultRenderManager manager, ResetReason reason, int modCount) {}
+  default void sceneReset(DefaultRenderManager manager, ResetReason reason, int resetCount) {}
 
   /**
    * This should return if this renderer will postprocess on its own.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3298,7 +3298,7 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   public void setPreviewRenderer(String previewRenderer) {
-    this.previewRenderer = renderer;
+    this.previewRenderer = previewRenderer;
     refresh();
   }
 

--- a/chunky/src/test/se/llbit/chunky/renderer/TestDeadlock.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/TestDeadlock.java
@@ -37,7 +37,11 @@ public class TestDeadlock {
       super(1, 0);
       Arrays.stream(workers).forEach(Thread::interrupt);
     }
-    @Override public void submit(Consumer<RenderWorker> task) {}
+    @Override public RenderJobFuture submit(RenderJob task) {
+      RenderJobFuture future = new RenderJobFuture(worker -> {});
+      future.finished();
+      return future;
+    }
     @Override public void awaitEmpty() {}
     @Override public void interrupt() {}
   }


### PR DESCRIPTION
Fixed an issue where finalization occurred twice.
Public'ed `RenderWorker.resetSleep()`.
Fixed an issue where you couldn't change the PreviewRenderer.
Allowed render jobs to throw `InterruptedException`.

Refactored `RenderWorkerPool` to return wait-able Futures.