### PR TITLE
Remove deprecated/unused octree methods

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -188,10 +188,9 @@ public class OctreeFinalizer {
 
   private static int waterLevelAt(Octree worldTree, Octree waterTree,
       BlockPalette palette, int x, int cy, int z, int baseLevel) {
-    Octree.Node node = waterTree.get(x, cy, z);
-    Material corner = palette.get(node.type);
+    Material corner = waterTree.getMaterial(x, cy, z, palette);
     if (corner instanceof Water) {
-      Material above = palette.get(waterTree.get(x, cy + 1, z).type);
+      Material above = waterTree.getMaterial(x, cy + 1, z, palette);
       boolean isFullBlock = above.isWaterFilled();
       return isFullBlock ? 8 : 8 - ((Water) corner).level;
     } else if (corner.waterlogged) {
@@ -204,10 +203,9 @@ public class OctreeFinalizer {
 
   private static int lavaLevelAt(Octree octree, BlockPalette palette,
       int x, int cy, int z, int baseLevel) {
-    Octree.Node node = octree.get(x, cy, z);
-    Material corner = palette.get(node.type);
+    Material corner = octree.getMaterial(x, cy, z, palette);
     if (corner instanceof Lava) {
-      Material above = palette.get(octree.get(x, cy + 1, z).type);
+      Material above = octree.getMaterial(x, cy + 1, z, palette);
       boolean isFullBlock = above instanceof Lava;
       return isFullBlock ? 8 : 8 - ((Lava) corner).level;
     } else if (!corner.solid) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2479,8 +2479,7 @@ public class Scene implements JsonSerializable, Refreshable {
       int x = (int) QuickMath.floor(ray.o.x);
       int y = (int) QuickMath.floor(ray.o.y);
       int z = (int) QuickMath.floor(ray.o.z);
-      Octree.Node node = waterOctree.get(x, y, z);
-      Material block = palette.get(node.type);
+      Material block = waterOctree.getMaterial(x, y, z, palette);
       return block.isWater()
           && ((ray.o.y - y) < 0.875 || ((Water) block).isFullBlock());
     }

--- a/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
+++ b/chunky/src/java/se/llbit/chunky/resources/OctreeFileFormat.java
@@ -16,16 +16,12 @@
  */
 package se.llbit.chunky.resources;
 
-import static se.llbit.math.Octree.DATA_FLAG;
-
+import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-
-import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
-import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.Lava;
 import se.llbit.chunky.block.Water;
@@ -38,6 +34,12 @@ public class OctreeFileFormat {
 
   private static final int MIN_OCTREE_VERSION = 3;
   private static final int OCTREE_VERSION = 6;
+
+  /**
+   * In octree v3-v4, the top bit of the type field in a serialized octree node is reserved for
+   * indicating if the node is a data node.
+   */
+  private static final int DATA_FLAG = 0x80000000;
 
   /**
    * Load octrees and grass/foliage textures from a file.

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -292,11 +292,6 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
   @Override
   public void set(int type, int x, int y, int z) {
-    set(new Octree.Node(type), x, y, z);
-  }
-
-  @Override
-  public void set(Octree.Node data, int x, int y, int z) {
     long[] parents = new long[depth]; // better to put as a field to preventallocation at each invocation?
     long nodeIndex = 0;
     int parentLevel = depth - 1;
@@ -304,7 +299,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
     for (int i = depth - 1; i >= 0; --i) {
       parents[i] = nodeIndex;
 
-      if (nodeEquals(nodeIndex, data)) {
+      if (typeFromValue(getAt(nodeIndex)) == type) {
         return;
       } else if (getAt(nodeIndex) <= 0) { // It's a leaf node
         subdivideNode(nodeIndex);
@@ -319,7 +314,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
 
     }
     long finalNodeIndex = getAt(parents[0]) + position;
-    setAt(finalNodeIndex, valueFromType(data.type));
+    setAt(finalNodeIndex, valueFromType(type));
 
     // Merge nodes where all children have been set to the same type.
     for (int i = 0; i <= parentLevel; ++i) {
@@ -400,12 +395,7 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
         loadNode(in, childrenIndex + i);
       }
     } else {
-      if ((type & DATA_FLAG) == 0) {
-        setAt(nodeIndex, valueFromType(type));
-      } else {
-        int data = in.readInt();
-        setAt(nodeIndex, valueFromType(type ^ DATA_FLAG));
-      }
+      setAt(nodeIndex, valueFromType(type));
     }
   }
 

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -107,11 +107,6 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
     return typeFromValue(getAt(((NodeId)node).nodeIndex));
   }
 
-  @Override
-  public int getData(Octree.NodeId node) {
-    return 0;
-  }
-
   /**
    * Constructor building a tree with capacity for some nodes
    * @param depth The depth of the tree

--- a/chunky/src/java/se/llbit/math/BigPackedOctree.java
+++ b/chunky/src/java/se/llbit/math/BigPackedOctree.java
@@ -356,16 +356,6 @@ public class BigPackedOctree implements Octree.OctreeImplementation {
   }
 
   @Override
-  public Octree.Node get(int x, int y, int z) {
-    long nodeIndex = getNodeIndex(x, y, z);
-    long value = getAt(nodeIndex);
-    Octree.Node node = new Octree.Node(value > 0 ? BRANCH_NODE : typeFromValue(value));
-
-    // Return dummy Node, will work if only type and data are used, breaks if children are needed
-    return node;
-  }
-
-  @Override
   public Material getMaterial(int x, int y, int z, BlockPalette palette) {
     // Building the dummy node is useless here
     long nodeIndex = getNodeIndex(x, y, z);

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -76,7 +76,6 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     set(new Octree.Node(type), x, y, z);
   }
 
-  @Override
   public void set(Octree.Node data, int x, int y, int z) {
     Octree.Node node = root;
     int parentLevel = depth - 1;

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -61,11 +61,6 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     return ((NodeId)node).node.type;
   }
 
-  @Override
-  public int getData(Octree.NodeId node) {
-    return ((NodeId)node).node.getData();
-  }
-
   public NodeBasedOctree(int octreeDepth, Octree.Node node) {
     depth = octreeDepth;
     root = node;
@@ -119,21 +114,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
       }
 
       if (allSame) {
-        // The parent node needs to be replaced by a DataNode if children have data
-        if(data.getData() != 0) {
-          if(i < parentLevel) {
-            // We need to find the grand parent and find which child of the grand parent
-            // the parent is to replace it
-            Octree.Node grandparent = parents[i+1];
-            int parentPosition = positions[i+1];
-            grandparent.children[parentPosition] = new Octree.DataNode(data.type, data.getData());
-          } else {
-            // The parent is the root
-            root = new Octree.DataNode(data.type, data.getData());
-          }
-        } else {
-          parent.merge(data.type);
-        }
+        parent.merge(data.type);
         cacheLevel = FastMath.max(i, cacheLevel);
       } else {
         break;
@@ -212,7 +193,6 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
   private void finalizationNode(Octree.Node node, Octree.Node parent, int childNo) {
     boolean canMerge = true;
     int mergedType = ANY_TYPE;
-    int mergedData = 0;
     for(int i = 0; i < 8; ++i) {
       Octree.Node child = node.children[i];
       if(child.type == BRANCH_NODE) {
@@ -225,25 +205,13 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
       if(canMerge) {
         if(mergedType == ANY_TYPE) {
           mergedType = child.type;
-          mergedData = child.getData();
-        } else if(!(child.type == ANY_TYPE || (child.type == mergedType && child.getData() == mergedData))) {
+        } else if(!(child.type == ANY_TYPE || child.type == mergedType)) {
           canMerge = false;
         }
       }
     }
     if(canMerge) {
-      if(mergedData == 0) {
-        // No need to use a DataNode
-        node.merge(mergedType);
-      } else {
-        // We need to replace the node by a new node in its parent
-        if(parent == null) {
-          // node is the root
-          root = new Octree.DataNode(mergedType, mergedData);
-        } else {
-          parent.children[childNo] = new Octree.DataNode(mergedType, mergedData);
-        }
-      }
+      node.merge(mergedType);
     }
   }
 

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -122,7 +122,6 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
     }
   }
 
-  @Override
   public Octree.Node get(int x, int y, int z) {
     while (cacheLevel < depth && ((x >>> cacheLevel) != cx ||
             (y >>> cacheLevel) != cy || (z >>> cacheLevel) != cz))

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -55,8 +55,6 @@ public class Octree {
 
   public interface OctreeImplementation {
     void set(int type, int x, int y, int z);
-    @Deprecated
-    void set(Node data, int x, int y, int z);
     Material getMaterial(int x, int y, int z, BlockPalette palette);
     void store(DataOutputStream output) throws IOException;
     int getDepth();
@@ -135,12 +133,6 @@ public class Octree {
    * and so that when serialized with data, it is not confused for a branch node)
    */
   public static final int ANY_TYPE = 0x7FFFFFFE;
-
-  /**
-   * The top bit of the type field in a serialized octree node is reserved for indicating
-   * if the node is a data node.
-   */
-  public static final int DATA_FLAG = 0x80000000;
 
   /** An Octree node. */
   public static class Node {

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -57,8 +57,6 @@ public class Octree {
     void set(int type, int x, int y, int z);
     @Deprecated
     void set(Node data, int x, int y, int z);
-    @Deprecated
-    Node get(int x, int y, int z);
     Material getMaterial(int x, int y, int z, BlockPalette palette);
     void store(DataOutputStream output) throws IOException;
     int getDepth();

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -290,37 +290,12 @@ public class PackedOctree implements Octree.OctreeImplementation {
   }
 
   /**
-   * Compare two nodes.
-   *
-   * True if none branching, and same type.
-   *
-   * @param firstNodeIndex The index of the first node
-   * @param secondNode     The second node (most likely outside of tree)
-   * @return true id the nodes compare equals, false otherwise
-   */
-  private boolean nodeEquals(int firstNodeIndex, Octree.Node secondNode) {
-    boolean firstIsBranch = treeData[firstNodeIndex] > 0;
-    boolean secondIsBranch = (secondNode.type == BRANCH_NODE);
-    return (!firstIsBranch && !secondIsBranch && -treeData[firstNodeIndex] == secondNode.type); // compare types (don't forget that in the tree the negation of the type is stored)
-  }
-
-  /**
    * Sets a specified block within the octree to a specific palette value, subdividing and merging as needed.
    *
    * x, y, z are in octree coordinates, NOT world coordinates.
    */
   @Override
   public void set(int type, int x, int y, int z) {
-    set(new Octree.Node(type), x, y, z);
-  }
-
-  /**
-   * Sets a specified block within the octree to a specific palette value, subdividing and merging as needed.
-   *
-   * x, y, z are in octree coordinates, NOT world coordinates.
-   */
-  @Override
-  public void set(Octree.Node data, int x, int y, int z) {
     int[] parents = new int[depth]; // better to put as a field to prevent allocation at each invocation?
     int nodeIndex = 0; // start at root
     int position;
@@ -329,7 +304,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
     for(int i = depth - 1; i >= 0; --i) {
       parents[i] = nodeIndex;
 
-      if(nodeEquals(nodeIndex, data)) { // Everything in this region is already of this blocktype.
+      if(treeData[nodeIndex] == -type) { // Everything in this region is already of this blocktype.
         return;
       }
 
@@ -346,7 +321,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
 
     }
     // store type into final node (this specific block coordinate's node)
-    treeData[nodeIndex] = -data.type; // Negation of BlockPalette type stored
+    treeData[nodeIndex] = -type; // Negation of BlockPalette type stored
 
     // Merge nodes where all children have been set to the same type, starting from the bottom.
     for(int i = 0; i < depth; ++i) {
@@ -636,12 +611,7 @@ public class PackedOctree implements Octree.OctreeImplementation {
         loadNode(in, childrenIndex + i);
       }
     } else {
-      if((type & DATA_FLAG) == 0) {
-        treeData[nodeIndex] = -type; // negation of type
-      } else {
-        int data = in.readInt();
-        treeData[nodeIndex] = -(type ^ DATA_FLAG);
-      }
+      treeData[nodeIndex] = -type; // negation of type
     }
   }
 

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -149,11 +149,6 @@ public class PackedOctree implements Octree.OctreeImplementation {
     return -treeData[nodeIndex];
   }
 
-  @Override
-  public int getData(Octree.NodeId node) {
-    return 0;
-  }
-
   /**
    * Constructor building a tree with capacity for some nodes
    *

--- a/chunky/src/java/se/llbit/math/PackedOctree.java
+++ b/chunky/src/java/se/llbit/math/PackedOctree.java
@@ -566,26 +566,6 @@ public class PackedOctree implements Octree.OctreeImplementation {
   }
 
   /**
-   * Creates an octree node which represents the PackedOctree node which is (or contains) the
-   * block specified.
-   *
-   * This node is not actually used within this PackedOctree, as it is stored inline in the
-   * array here. This is just a Node object which wraps the values that the PackedOctree node
-   * would have.
-   *
-   * x, y, z are in octree coordinates, NOT world coordinates.
-   */
-  @Override
-  public Octree.Node get(int x, int y, int z) {
-    int nodeIndex = getNodeIndex(x, y, z);
-
-    Octree.Node node = new Octree.Node(treeData[nodeIndex] > 0 ? BRANCH_NODE : -treeData[nodeIndex]);
-
-    // Return dummy Node, will work if only type and data are used, breaks if children are needed
-    return node;
-  }
-
-  /**
    * Gets the block material type from the BlockPalette of the node which is (or contains) the block specified.
    *
    * x, y, z are in octree coordinates, NOT world coordinates.

--- a/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
@@ -58,6 +58,7 @@ public class PluginApiTest {
     Chunky chunky = new Chunky(ChunkyOptions.getDefaults());
     RayTracer tracer = (scene, state) -> state.ray.color.set(0, 0, 0, 1);
     RayTracerFactory myFactory = () -> tracer;
+    //noinspection deprecation
     chunky.setPreviewRayTracerFactory(myFactory);
 
     // Get ray tracer through reflection
@@ -71,6 +72,7 @@ public class PluginApiTest {
     Chunky chunky = new Chunky(ChunkyOptions.getDefaults());
     RayTracer tracer = (scene, state) -> state.ray.color.set(0, 0, 0, 1);
     RayTracerFactory myFactory = () -> tracer;
+    //noinspection deprecation
     chunky.setRayTracerFactory(myFactory);
 
     // Get ray tracer through reflection


### PR DESCRIPTION
Now that we know that even <1.13 world support won't require data, we can drop all related code.

To improve memory efficiency, `Node get(int,int,int)` and `set(Node,int,int,int)` should be removed, too (but I don't know how to replace their implementations).