### PR TITLE
Fix overwriting snapshot control having no effect on saving snapshots.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -131,12 +131,12 @@ public class Chunky {
     sceneManager.setTaskTracker(taskTracker);
     renderManager.setSnapshotControl(SnapshotControl.DEFAULT);
     renderManager.setOnFrameCompleted((scene, spp) -> {
-      if (SnapshotControl.DEFAULT.saveSnapshot(scene, spp)) {
+      if (renderManager.getSnapshotControl().saveSnapshot(scene, spp)) {
         scene.saveSnapshot(new File(getRenderContext().getSceneDirectory(), "snapshots"),
             taskTracker, getRenderContext().numRenderThreads());
       }
 
-      if (SnapshotControl.DEFAULT.saveRenderDump(scene, spp)) {
+      if (renderManager.getSnapshotControl().saveRenderDump(scene, spp)) {
         // Save the scene description and current render dump.
         try {
           sceneManager.saveScene();

--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -496,6 +496,11 @@ public class DefaultRenderManager extends Thread implements RenderManager {
   }
 
   @Override
+  public SnapshotControl getSnapshotControl() {
+    return this.snapshotControl;
+  }
+
+  @Override
   public void setSnapshotControl(SnapshotControl callback) {
     this.snapshotControl = callback;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
@@ -68,7 +68,12 @@ public interface RenderManager {
   void setOnFrameCompleted(BiConsumer<Scene, Integer> listener);
 
   /**
-   * Set the snapshot control mode.
+   * Get the snapshot controller.
+   */
+  SnapshotControl getSnapshotControl();
+
+  /**
+   * Set the snapshot controller.
    * Postprocessing should always occur if {@code SnapshotControl.saveSnapshot(...)} is true.
    */
   void setSnapshotControl(SnapshotControl callback);

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -351,12 +351,11 @@ public class ChunkyFxController
     });
     renderManager.setSnapshotControl(SnapshotControl.DEFAULT);
     renderManager.setOnFrameCompleted((scene1, spp) -> {
-      if (SnapshotControl.DEFAULT.saveSnapshot(scene1, spp)) {
-
+      if (renderManager.getSnapshotControl().saveSnapshot(scene1, spp)) {
         scene1.saveSnapshot(new File(renderController.getContext().getSceneDirectory(), "snapshots"), taskTracker, renderController.getContext().numRenderThreads());
       }
 
-      if (SnapshotControl.DEFAULT.saveRenderDump(scene1, spp)) {
+      if (renderManager.getSnapshotControl().saveRenderDump(scene1, spp)) {
         // Save the scene description and current render dump.
         asyncSceneManager.saveScene();
       }


### PR DESCRIPTION
In the denoiser plugin I don't want to save snapshots for albedo or normal maps and add my own snapshot control for that reason. Turns out it had no effect.