### PR TITLE
Prevent normal being (0, 0, 0) which leads to lock in the renderer

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/TileBasedRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/TileBasedRenderer.java
@@ -74,6 +74,7 @@ public abstract class TileBasedRenderer implements Renderer {
         manager.pool.submit(worker -> {
           WorkerState state = new WorkerState();
           state.ray = new Ray();
+          state.ray.n.set(0, 0, -1);
           state.random = worker.random;
 
           IntIntMutablePair pair = new IntIntMutablePair(0, 0);


### PR DESCRIPTION
cf discussion on discord.
I set a value to the normal after the ray is created. The actual value doesn't matter, the only case where it isn't replaced is when the camera is inside a block and the screen will be black.
Fix #963 