### PR TITLE
Fix worlds being loaded twice

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -74,6 +74,9 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
    */
   public void loadWorld(File worldDir) {
     if (World.isWorldDir(worldDir)) {
+      if (world != null) {
+        world.removeChunkTopographyListener(this);
+      }
       World newWorld = World.loadWorld(worldDir, currentDimension, World.LoggedWarnings.NORMAL);
       newWorld.addChunkTopographyListener(this);
       synchronized (this) {
@@ -134,6 +137,8 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
    * for the current world.
    */
   public void reloadWorld() {
+    topographyUpdater.clearQueue();
+    world.removeChunkTopographyListener(this);
     World newWorld = World.loadWorld(world.getWorldDirectory(), currentDimension,
         World.LoggedWarnings.NORMAL);
     newWorld.addChunkTopographyListener(this);

--- a/chunky/src/java/se/llbit/chunky/world/ChunkTopographyUpdater.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTopographyUpdater.java
@@ -70,6 +70,13 @@ public class ChunkTopographyUpdater extends Thread {
   }
 
   /**
+   * Remove all chunks from the parse queue.
+   */
+  public synchronized void clearQueue() {
+    queue.clear();
+  }
+
+  /**
    * @return <code>true</code> if the work queue is not empty
    */
   public synchronized boolean isWorking() {

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -552,6 +552,13 @@ public class World implements Comparable<World> {
     }
   }
 
+  /** Remove a chunk discovery listener */
+  public void removeChunkTopographyListener(ChunkTopographyListener listener) {
+    synchronized (chunkTopographyListeners) {
+      chunkTopographyListeners.remove(listener);
+    }
+  }
+
   /**
    * Notifies listeners that the height gradient of a chunk may have changed.
    *


### PR DESCRIPTION
Fixes #926 and removes listeners and clears queues so that the map view updates faster after reloading a world.