### PR TITLE
Fix another skull json regex error.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -20,7 +20,7 @@ public class Head extends MinecraftBlockTranslucent {
   // the decoded string might not be valid json (sometimes keys are not quoted)
   // so we use a regex to extract the skin url
   private static final Pattern SKIN_URL_FROM_OBJECT = Pattern
-      .compile("\"?SKIN\"?\\s*:\\s*\\{(.*)\"?url\"?\\s*:\\s*\"(.+?)\"", Pattern.DOTALL);
+      .compile("\"?SKIN\"?\\s*:\\s*\\{(.*)\"?url\"?\\s*:\\s*\"([^\"]*)\"", Pattern.DOTALL);
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;

--- a/chunky/src/java/se/llbit/chunky/block/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/Head.java
@@ -20,7 +20,7 @@ public class Head extends MinecraftBlockTranslucent {
   // the decoded string might not be valid json (sometimes keys are not quoted)
   // so we use a regex to extract the skin url
   private static final Pattern SKIN_URL_FROM_OBJECT = Pattern
-      .compile("\"?SKIN\"?\\s*:\\s*\\{(.*)\"?url\"?\\s*:\\s*\"(.*)\"", Pattern.DOTALL);
+      .compile("\"?SKIN\"?\\s*:\\s*\\{(.*)\"?url\"?\\s*:\\s*\"(.+?)\"", Pattern.DOTALL);
   private final String description;
   private final int rotation;
   private final SkullEntity.Kind type;

--- a/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
+++ b/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
@@ -62,6 +62,16 @@ public class SkullTextureTest {
   }
 
   @Test
+  public void testMetadataAfterUrl() { // test for #969
+    CompoundTag validJsonAlexTag = createSkullTag("Owner", Base64.getEncoder().encodeToString(
+        "{\"timestamp\":1425828978186,\"profileId\":\"00000000000000000000000000000000\",\"profileName\":\"chunky\",\"isPublic\":true,\"textures\":{\"SKIN\":{\"url\":\"http://textures.minecraft.net/texture/8e9fa6f8f2a1141524ff37c4df642dc2da29a6c05a35c38f43fe4919b84b34f\",\"metadata\":{\"model\":\"slim\"}}}}"
+            .getBytes(StandardCharsets.UTF_8)));
+    assertEquals(
+        "http://textures.minecraft.net/texture/8e9fa6f8f2a1141524ff37c4df642dc2da29a6c05a35c38f43fe4919b84b34f",
+        Head.getTextureUrl(validJsonAlexTag));
+  }
+
+  @Test
   public void testBadBase64Padding() { // test for #900
     CompoundTag validOwnerTag = createSkullTag("Owner",
         // the following base64 string has intentional wrong padding


### PR DESCRIPTION
Fixes #969 

Unfortunately, llbit's json parser doesn't have an option to ignore missing `""`. That would help a lot because we could then remove the regex and parse the JSON properly.

For future readers (probably me): My first commit fixed the issue because .* is greedy, unlike .+?, so it matches everything until the very last " in the string, not only until the first " (which is what we need). The second commit (fix suggested by @Stenodyon) makes this more clear.