### PR TITLE
Prevent map view from attempting to render as fast as possible

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -350,7 +350,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
         mapBuffer.updateView(view);
         mapBuffer.redrawView(mapLoader, chunkSelection);
         repaintDeferred();
-      }, (1000000000/VIEW_MAX_UPDATES) - (System.nanoTime() - lastUpdate), TimeUnit.NANOSECONDS);
+      }, (1_000_000_000 / VIEW_MAX_UPDATES) - (System.nanoTime() - lastUpdate), TimeUnit.NANOSECONDS);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -107,7 +107,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
 
   private static final int VIEW_MAX_UPDATES = Math.max(Integer.parseInt(System.getProperty("chunky.mapviewfps", "30")), 1);
 
-  private volatile long lastUpdate = System.nanoTime();
+  private volatile long lastUpdate = System.currentTimeMillis();
   private volatile boolean viewUpdateScheduled = false;
   private volatile boolean repaintQueued = false;
   private volatile boolean scheduledUpdate = false;
@@ -343,14 +343,14 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     if (!viewUpdateScheduled) {
       viewUpdateScheduled = true;
       executor.schedule(() -> {
-        lastUpdate = System.nanoTime();
+        lastUpdate = System.currentTimeMillis();
         viewUpdateScheduled = false;
 
         this.view = view;
         mapBuffer.updateView(view);
         mapBuffer.redrawView(mapLoader, chunkSelection);
         repaintDeferred();
-      }, (1_000_000_000 / VIEW_MAX_UPDATES) - (System.nanoTime() - lastUpdate), TimeUnit.NANOSECONDS);
+      }, (1000/VIEW_MAX_UPDATES) - (System.currentTimeMillis() - lastUpdate), TimeUnit.MILLISECONDS);
     }
   }
 


### PR DESCRIPTION
locked to 24fps, can make it configurable if requested
Here is greenfield 2021 example:
before
https://user-images.githubusercontent.com/16853282/119767438-b5495100-beae-11eb-9728-1285352979f7.mp4
after
https://user-images.githubusercontent.com/16853282/119767456-bed2b900-beae-11eb-932a-7ec4af3b73ea.mp4






