### PR TITLE
Mark ladders as non-solid

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Ladder.java
+++ b/chunky/src/java/se/llbit/chunky/block/Ladder.java
@@ -13,6 +13,7 @@ public class Ladder extends MinecraftBlockTranslucent {
     super("ladder", Texture.ladder);
     this.description = "facing=" + facing;
     localIntersect = true;
+    solid = false;
     switch (facing) {
       default:
       case "north":


### PR DESCRIPTION
Fix water height below ladders and legacy world block connections to ladders.

Once #901 ist done, we should go through the translucent blocks and check if they actually are solid.