### PR TITLE
Fix lags and dropped repaints in the map view.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -105,7 +105,6 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
   private final Canvas canvas;
   private final Canvas mapOverlay;
 
-  private volatile long lastUpdate = System.currentTimeMillis();
   private volatile boolean viewUpdateScheduled = false;
   private volatile boolean repaintQueued = false;
   private volatile boolean scheduledUpdate = false;


### PR DESCRIPTION
This fixes the regressions from #979 that I described in #985.

View updates and repainting are now a bit more deferred:

- The view is _always_ updated (position and size) and a deferred repaint is scheduled
- On deferred repaint, the mapBuffer is updated if it needs to be updated (this is the part that needed to be deferred to fix freezes e.g. for @NotStirred)

This ensures that `repaintDeferred` always uses the _latest_ position and size (i.e. `view`) but still doesn't repaint on every `viewUpdated` call. Not too many repaints (= no freezing) yet still always rendering the _latest_ position/size (= no lagging behind the cursor or missing updates e.g. after launching or resize)