### PR TITLE
Fix preview not updating under certain plugin circumstances.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -198,7 +198,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         listener.setSpp(0);
       });
 
-      if (getRenderer().autoPostProcess())
+      if (getPreviewRenderer().autoPostProcess())
         this.finalizeFrame(true);
 
       frameStart = System.currentTimeMillis();


### PR DESCRIPTION
The preview callback was checking the wrong `Renderer`'s `auotPostProcess()` method.