### PR TITLE
Fix bug where opening the `Advanced Tab` with certain plugins installed would cause a crash.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -302,7 +302,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         } else {
           // Bail early if render is already done
           if (bufferedScene.spp >= bufferedScene.getTargetSpp()) {
-            sceneProvider.withSceneProtected(scene -> {
+            sceneProvider.withEditSceneProtected(scene -> {
               scene.pauseRender();
               updateRenderState(scene);
             });


### PR DESCRIPTION
Replaced `withSceneProtected()` to `withEditSceneProtected()` when setting render-mode to `PAUSED`