### PR TITLE
Make `RenderJob` public.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -202,7 +202,7 @@ public class RenderWorkerPool {
   }
 
   @FunctionalInterface
-  interface RenderJob {
+  public interface RenderJob {
     /**
      * @param worker      The render worker running this job.
      * @throws Throwable  Any unchecked exception.


### PR DESCRIPTION
This allows plugins to actually use the `RenderWorkerPool`