### PR TITLE
Deduplicate WorldTextures to save a lot of memory.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1393,9 +1393,9 @@ public class Scene implements JsonSerializable, Refreshable {
       worldOctree.endFinalization();
       waterOctree.endFinalization();
 
-      grassTexture.endFinalization();
-      foliageTexture.endFinalization();
-      waterTexture.endFinalization();
+      grassTexture.compact();
+      foliageTexture.compact();
+      waterTexture.compact();
     }
 
     for (Entity entity : actors) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1392,6 +1392,10 @@ public class Scene implements JsonSerializable, Refreshable {
 
       worldOctree.endFinalization();
       waterOctree.endFinalization();
+
+      grassTexture.endFinalization();
+      foliageTexture.endFinalization();
+      waterTexture.endFinalization();
     }
 
     for (Entity entity : actors) {

--- a/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
@@ -30,12 +30,19 @@ import java.util.Arrays;
  */
 public class ChunkTexture {
 
-  byte[] data = new byte[Chunk.X_MAX * Chunk.Z_MAX * 3];
+  protected final byte[] data = new byte[Chunk.X_MAX * Chunk.Z_MAX * 3];
 
   /**
    * Create new texture
    */
   public ChunkTexture() {
+  }
+
+  /**
+   * Copy an existing chunk texture
+   */
+  public ChunkTexture(ChunkTexture ct) {
+    System.arraycopy(ct.data, 0, data, 0, data.length);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTexture.java
@@ -21,6 +21,7 @@ import se.llbit.math.ColorUtil;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Chunk texture
@@ -90,4 +91,16 @@ public class ChunkTexture {
     return texture;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    ChunkTexture that = (ChunkTexture) o;
+    return Arrays.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(data);
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/WorldTexture.java
@@ -22,7 +22,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Map;
+import java.util.HashMap;
 
 /**
  * World texture.
@@ -33,6 +33,8 @@ public class WorldTexture {
 
   private final Long2ObjectOpenHashMap<ChunkTexture> map = new Long2ObjectOpenHashMap<>();
 
+  private boolean endFinalized = false;
+
   /**
    * Timestamp of last serialization.
    */
@@ -42,8 +44,11 @@ public class WorldTexture {
    * Set color at (x, z)
    *
    * @param frgb RGB color components
+   * @throws IllegalStateException if this WorldTexture has already been finalized.
    */
   public void set(int x, int z, float[] frgb) {
+    if (endFinalized) throw new IllegalStateException("Attempted to modify a finalized WorldTexture.");
+
     long cp = ((long) x >> 4) << 32 | ((z >> 4) & 0xffffffffL);
     ChunkTexture ct = map.get(cp);
     if (ct == null) {
@@ -98,14 +103,41 @@ public class WorldTexture {
    */
   public static WorldTexture load(DataInputStream in) throws IOException {
     WorldTexture texture = new WorldTexture();
+    HashMap<ChunkTexture, ChunkTexture> textureCache = new HashMap<>();
     int numTiles = in.readInt();
     for (int i = 0; i < numTiles; ++i) {
       int x = in.readInt();
       int z = in.readInt();
       ChunkTexture tile = ChunkTexture.load(in);
+
+      if (textureCache.containsKey(tile)) {
+        tile = textureCache.get(tile);
+      } else {
+        textureCache.put(tile, tile);
+      }
+
       texture.map.put(((long) x) << 32 | (z & 0xffffffffL), tile);
     }
     return texture;
+  }
+
+  /**
+   * Deduplicate this {@code WorldTexture} to save memory. This also makes this read-only.
+   */
+  public void endFinalization() {
+    if (endFinalized) return;
+    endFinalized = true;
+
+    HashMap<ChunkTexture, ChunkTexture> textureCache = new HashMap<>();
+    for (Long2ObjectMap.Entry<ChunkTexture> entry : map.long2ObjectEntrySet()) {
+      ChunkTexture tile = entry.getValue();
+
+      if (textureCache.containsKey(tile)) {
+        entry.setValue(textureCache.get(tile));
+      } else {
+        textureCache.put(tile, tile);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Some benchmarks:
Greenfield:
|    | Heap used |
|---|-----------|
| master | 4,718,981,222 bytes |
| deduped | 4,369,123,080 bytes |

4 regions of a real world:
|   | `WorldTexture` size | Number of `ChunkTexture`s |
|---|-------------------|----------------------------|
| master | 27,787,634 bytes |  36,864 textures |
| deduped | 2,271,314 bytes  | 1,786 textures|