### PR TITLE
Fix NPE when loading players that don't have a skin

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -906,11 +906,13 @@ public class Scene implements JsonSerializable, Refreshable {
           try {
             profile = MojangApi.fetchProfile(entity.uuid);
             PlayerSkin skin = MojangApi.getSkinFromProfile(profile);
-            String skinUrl = skin.getUrl();
-            if (skinUrl != null) {
-              entity.skin = MojangApi.downloadSkin(skinUrl).getAbsolutePath();
+            if (skin != null) {
+              String skinUrl = skin.getUrl();
+              if (skinUrl != null) {
+                entity.skin = MojangApi.downloadSkin(skinUrl).getAbsolutePath();
+              }
+              entity.model = skin.getModel();
             }
-            entity.model = skin.getModel();
           } catch (IOException e) {
             Log.error(e);
             profile = new JsonObject();

--- a/chunky/src/java/se/llbit/util/mojangapi/MojangApi.java
+++ b/chunky/src/java/se/llbit/util/mojangapi/MojangApi.java
@@ -151,7 +151,7 @@ public class MojangApi {
    * Get the skin URL from the given profile. To get a profile, use {@link #fetchProfile(String)}.
    *
    * @param profile Player profile
-   * @return Skin URL (null if the player has no skin)
+   * @return Skin (null if the player has no skin)
    */
   public static PlayerSkin getSkinFromProfile(JsonObject profile) {
     JsonArray properties = profile.get("properties").asArray();


### PR DESCRIPTION
This fixes an NPE when loading players without a skin:

```
Exception in thread "Scene Manager" java.lang.NullPointerException: Cannot invoke "se.llbit.util.mojangapi.PlayerSkin.getUrl()" because "skin" is null
	at se.llbit.chunky.renderer.scene.Scene.loadChunks(Scene.java:909)
	at se.llbit.chunky.renderer.scene.SynchronousSceneManager.loadChunks(SynchronousSceneManager.java:178)
	at se.llbit.chunky.renderer.scene.AsynchronousSceneManager.lambda$loadChunks$3(AsynchronousSceneManager.java:152)
	at se.llbit.chunky.renderer.scene.AsynchronousSceneManager.run(AsynchronousSceneManager.java:82)