### PR TITLE
Stop render control buttons from causing Chunky to freeze while loading a scene.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -28,6 +28,7 @@ import se.llbit.util.TaskTracker;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * This scene manager is used for asynchronous loading and saving of scenes.
@@ -39,12 +40,13 @@ import java.util.Collection;
 public class AsynchronousSceneManager extends Thread implements SceneManager {
 
   private final SynchronousSceneManager sceneManager;
-  private Runnable currentTask = null;
+  private final ConcurrentLinkedQueue<Runnable> taskQueue;
 
   public AsynchronousSceneManager(RenderContext context, RenderManager renderManager) {
     super("Scene Manager");
 
     sceneManager = new SynchronousSceneManager(context, renderManager);
+    taskQueue = new ConcurrentLinkedQueue<>();
   }
 
   public SceneProvider getSceneProvider() {
@@ -74,15 +76,13 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
   @Override public void run() {
     try {
       while (!isInterrupted()) {
-        synchronized (this) {
-          while (currentTask == null) {
-            wait();
-          }
+        synchronized (taskQueue) {
+          while (taskQueue.isEmpty())
+            taskQueue.wait();
         }
-        currentTask.run();
-        synchronized (this) {
-          currentTask = null;
-        }
+        Runnable task = taskQueue.poll();
+        if (task != null)
+          task.run();
       }
     } catch (InterruptedException ignored) {
       // Interrupted.
@@ -103,87 +103,69 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
    *
    * @param name the name of the scene to load.
    */
-  @Override public synchronized void loadScene(String name) {
-    if (currentTask != null) {
-      Log.warn("Can't load scene right now.");
-    } else {
-      currentTask = () -> {
-        try {
-          sceneManager.loadScene(name);
-        } catch (IOException e) {
-          Log.warn("Could not load scene.\nReason: " + e.getMessage());
-        } catch (InterruptedException e) {
-          Log.warn("Scene loading was interrupted.");
-        }
-      };
-      notifyAll();
-    }
+  @Override public void loadScene(String name) {
+    enqueueTask(() -> {
+      try {
+        sceneManager.loadScene(name);
+      } catch (IOException e) {
+        Log.warn("Could not load scene.\nReason: " + e.getMessage());
+      } catch (InterruptedException e) {
+        Log.warn("Scene loading was interrupted.");
+      }
+    });
   }
 
   /**
    * Save the current scene.
    */
-  @Override public synchronized void saveScene() {
-    if (currentTask != null) {
-      Log.warn("Can't save the scene right now.");
-    } else {
-      currentTask = () -> {
-        try {
-          sceneManager.saveScene();
-        } catch (InterruptedException e) {
-          Log.warn("Scene saving was interrupted.");
-        }
-      };
-      notifyAll();
-    }
+  @Override public void saveScene() {
+    enqueueTask(() -> {
+      try {
+        sceneManager.saveScene();
+      } catch (InterruptedException e) {
+        Log.warn("Scene saving was interrupted.");
+      }
+    });
   }
 
   /**
    * Load chunks and reset camera.
    */
   @Override
-  public synchronized void loadFreshChunks(World world, Collection<ChunkPosition> chunks) {
-    if (currentTask != null) {
-      Log.warn("Can't load chunks right now.");
-    } else {
-      currentTask = () -> sceneManager.loadFreshChunks(world, chunks);
-      notifyAll();
-    }
+  public void loadFreshChunks(World world, Collection<ChunkPosition> chunks) {
+    enqueueTask(() -> sceneManager.loadFreshChunks(world, chunks));
   }
 
   /**
    * Load chunks without moving the camera.
    */
-  @Override public synchronized void loadChunks(World world, Collection<ChunkPosition> chunks) {
-    if (currentTask != null) {
-      Log.warn("Can't load chunks right now.");
-    } else {
-      currentTask = () -> sceneManager.loadChunks(world, chunks);
-      notifyAll();
-    }
+  @Override
+  public void loadChunks(World world, Collection<ChunkPosition> chunks) {
+    enqueueTask(() -> sceneManager.loadChunks(world, chunks));
   }
 
   /**
    * Reload all chunks
    */
-  @Override public synchronized void reloadChunks() {
-    if (currentTask != null) {
-      Log.warn("Can't load chunks right now.");
-    } else {
-      currentTask = sceneManager::reloadChunks;
-      notifyAll();
-    }
+  @Override
+  public void reloadChunks() {
+    enqueueTask(sceneManager::reloadChunks);
   }
 
   /**
    * Merge a render dump into the current render.
    */
-  public synchronized void mergeRenderDump(File renderDump) {
-    if (currentTask != null) {
-      Log.warn("Can't merge render dump right now.");
-    } else {
-      currentTask = () -> sceneManager.mergeDump(renderDump);
-      notifyAll();
+  public void mergeRenderDump(File renderDump) {
+    enqueueTask(() -> sceneManager.mergeDump(renderDump));
+  }
+
+  /**
+   * Schedule a task to be run soon.
+   */
+  public void enqueueTask(Runnable task) {
+    taskQueue.add(task);
+    synchronized (taskQueue) {
+      taskQueue.notifyAll();
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -368,6 +368,8 @@ public class Scene implements JsonSerializable, Refreshable {
   private String renderer = DefaultRenderManager.ChunkyPathTracerID;
   private String previewRenderer = DefaultRenderManager.ChunkyPreviewID;
 
+  protected volatile boolean isLoading = false;
+
   /**
    * Creates a scene with all default settings.
    *
@@ -558,6 +560,8 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public synchronized void loadScene(RenderContext context, String sceneName, TaskTracker taskTracker)
       throws IOException {
+    isLoading = true;
+
     try {
       loadDescription(context.getSceneDescriptionInputStream(sceneName));
     } catch (FileNotFoundException e) {
@@ -607,6 +611,7 @@ public class Scene implements JsonSerializable, Refreshable {
     }
 
     notifyAll();
+    isLoading = false;
   }
 
   /**
@@ -842,6 +847,8 @@ public class Scene implements JsonSerializable, Refreshable {
   public synchronized void loadChunks(TaskTracker taskTracker, World world, Collection<ChunkPosition> chunksToLoad) {
     if (world == null)
       return;
+
+    isLoading = true;
 
     boolean isTallWorld = world.getVersionId() >= World.VERSION_21W06A;
     if (isTallWorld) {
@@ -1416,6 +1423,8 @@ public class Scene implements JsonSerializable, Refreshable {
       buildActorBvh(task);
     }
     Log.info(String.format("Loaded %d chunks", numChunks));
+
+    isLoading = false;
   }
 
   private void buildBvh(TaskTracker.Task task) {
@@ -3310,6 +3319,10 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public String getPreviewRenderer() {
     return previewRenderer;
+  }
+
+  public boolean getIsLoading() {
+    return isLoading;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -561,57 +561,59 @@ public class Scene implements JsonSerializable, Refreshable {
   public synchronized void loadScene(RenderContext context, String sceneName, TaskTracker taskTracker)
       throws IOException {
     isLoading = true;
-
     try {
-      loadDescription(context.getSceneDescriptionInputStream(sceneName));
-    } catch (FileNotFoundException e) {
-      // scene.json not found, try loading the backup file
-      Log.info("Scene description file not found, trying to load the backup file instead", e);
-      loadDescription(context.getSceneFileInputStream(sceneName + Scene.EXTENSION + ".backup"));
-    }
-
-    if (sdfVersion < SDF_VERSION) {
-      Log.warn("Old scene version detected! The scene may not have been loaded correctly.");
-    } else if (sdfVersion > SDF_VERSION) {
-      Log.warn("This scene was created with a newer version of Chunky! The scene may not have been loaded correctly.");
-    }
-
-    // Load the configured skymap file.
-    sky.loadSkymap();
-
-    if (!worldPath.isEmpty()) {
-      File worldDirectory = new File(worldPath);
-      if (World.isWorldDir(worldDirectory)) {
-        loadedWorld = World.loadWorld(worldDirectory, worldDimension, World.LoggedWarnings.NORMAL);
-      } else {
-        Log.info("Could not load world: " + worldPath);
+      try {
+        loadDescription(context.getSceneDescriptionInputStream(sceneName));
+      } catch (FileNotFoundException e) {
+        // scene.json not found, try loading the backup file
+        Log.info("Scene description file not found, trying to load the backup file instead", e);
+        loadDescription(context.getSceneFileInputStream(sceneName + Scene.EXTENSION + ".backup"));
       }
-    }
 
-    loadDump(context, taskTracker);
-
-    if (spp == 0) {
-      mode = RenderMode.PREVIEW;
-    } else if (mode == RenderMode.RENDERING) {
-      mode = RenderMode.PAUSED;
-    }
-
-    boolean emitterGridNeedChunkReload = false;
-    if (emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
-      emitterGridNeedChunkReload = !loadEmitterGrid(context, taskTracker);
-    boolean octreeLoaded = loadOctree(context, taskTracker);
-    if (emitterGridNeedChunkReload || !octreeLoaded) {
-      // Could not load stored octree or emitter grid.
-      // Load the chunks from the world.
-      if (loadedWorld == EmptyWorld.INSTANCE) {
-        Log.warn("Could not load chunks (no world found for scene)");
-      } else {
-        loadChunks(taskTracker, loadedWorld, chunks);
+      if (sdfVersion < SDF_VERSION) {
+        Log.warn("Old scene version detected! The scene may not have been loaded correctly.");
+      } else if (sdfVersion > SDF_VERSION) {
+        Log.warn("This scene was created with a newer version of Chunky! The scene may not have been loaded correctly.");
       }
-    }
 
-    notifyAll();
-    isLoading = false;
+      // Load the configured skymap file.
+      sky.loadSkymap();
+
+      if (!worldPath.isEmpty()) {
+        File worldDirectory = new File(worldPath);
+        if (World.isWorldDir(worldDirectory)) {
+          loadedWorld = World.loadWorld(worldDirectory, worldDimension, World.LoggedWarnings.NORMAL);
+        } else {
+          Log.info("Could not load world: " + worldPath);
+        }
+      }
+
+      loadDump(context, taskTracker);
+
+      if (spp == 0) {
+        mode = RenderMode.PREVIEW;
+      } else if (mode == RenderMode.RENDERING) {
+        mode = RenderMode.PAUSED;
+      }
+
+      boolean emitterGridNeedChunkReload = false;
+      if (emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
+        emitterGridNeedChunkReload = !loadEmitterGrid(context, taskTracker);
+      boolean octreeLoaded = loadOctree(context, taskTracker);
+      if (emitterGridNeedChunkReload || !octreeLoaded) {
+        // Could not load stored octree or emitter grid.
+        // Load the chunks from the world.
+        if (loadedWorld == EmptyWorld.INSTANCE) {
+          Log.warn("Could not load chunks (no world found for scene)");
+        } else {
+          loadChunks(taskTracker, loadedWorld, chunks);
+        }
+      }
+
+      notifyAll();
+    } finally {
+      isLoading = false;
+    }
   }
 
   /**
@@ -3321,7 +3323,7 @@ public class Scene implements JsonSerializable, Refreshable {
     return previewRenderer;
   }
 
-  public boolean getIsLoading() {
+  public boolean isLoading() {
     return isLoading;
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -69,7 +69,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
-import javafx.util.converter.NumberStringConverter;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.launcher.LauncherSettings;
 import se.llbit.chunky.main.Chunky;
@@ -90,7 +89,6 @@ import se.llbit.chunky.world.ChunkView;
 import se.llbit.chunky.world.DeleteChunksJob;
 import se.llbit.chunky.world.Icon;
 import se.llbit.chunky.world.World;
-import se.llbit.chunky.world.listeners.ChunkUpdateListener;
 import se.llbit.fx.ToolPane;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.fxutil.GroupedChangeListener;
@@ -690,19 +688,19 @@ public class ChunkyFxController
     start.setGraphic(new ImageView(Icon.play.fxImage()));
     start.setTooltip(new Tooltip("Start rendering."));
     start.setOnAction(e -> {
-      if (!scene.getIsLoading())
+      if (!scene.isLoading())
         asyncSceneManager.enqueueTask(() -> scene.startRender());
     });
     pause.setGraphic(new ImageView(Icon.pause.fxImage()));
     pause.setTooltip(new Tooltip("Pause the render."));
     pause.setOnAction(e -> {
-      if (!scene.getIsLoading())
+      if (!scene.isLoading())
         asyncSceneManager.enqueueTask(() -> scene.pauseRender());
     });
     reset.setGraphic(new ImageView(Icon.stop.fxImage()));
     reset.setTooltip(new Tooltip("Resets the current render. Discards render progress."));
     reset.setOnAction(e -> {
-      if (!scene.getIsLoading())
+      if (!scene.isLoading())
         asyncSceneManager.enqueueTask(() -> scene.haltRender());
     });
     sppLbl.setTooltip(new Tooltip("SPP = Samples Per Pixel, SPS = Samples Per Second"));

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -689,13 +689,22 @@ public class ChunkyFxController
     copyFrameBtn.setOnAction(this::copyCurrentFrame);
     start.setGraphic(new ImageView(Icon.play.fxImage()));
     start.setTooltip(new Tooltip("Start rendering."));
-    start.setOnAction(e -> scene.startRender());
+    start.setOnAction(e -> {
+      if (!scene.getIsLoading())
+        asyncSceneManager.enqueueTask(() -> scene.startRender());
+    });
     pause.setGraphic(new ImageView(Icon.pause.fxImage()));
     pause.setTooltip(new Tooltip("Pause the render."));
-    pause.setOnAction(e -> scene.pauseRender());
+    pause.setOnAction(e -> {
+      if (!scene.getIsLoading())
+        asyncSceneManager.enqueueTask(() -> scene.pauseRender());
+    });
     reset.setGraphic(new ImageView(Icon.stop.fxImage()));
     reset.setTooltip(new Tooltip("Resets the current render. Discards render progress."));
-    reset.setOnAction(e -> scene.haltRender());
+    reset.setOnAction(e -> {
+      if (!scene.getIsLoading())
+        asyncSceneManager.enqueueTask(() -> scene.haltRender());
+    });
     sppLbl.setTooltip(new Tooltip("SPP = Samples Per Pixel, SPS = Samples Per Second"));
     targetSpp.setName("Target SPP");
     targetSpp.setTooltip("Rendering is stopped after reaching the target Samples Per Pixel (SPP).");


### PR DESCRIPTION
* Added an `enqueueTask` api to AsynchronousSceneManager which allows for synchronized scene modifications to happen off the JavaFx thread.
* Add a query to to Scene to check if it is currently loading a scene.
* Adjust render control buttons to use the `enqueueTask` api and ignore clicks while the Scene is loading.

This closes #832 (Pausing loading should probably be separate since it would be quite complex)