### PR TITLE
Buffered Dump IO

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
@@ -16,10 +16,10 @@
  */
 package se.llbit.chunky.renderer.renderdump;
 
-import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.TaskTracker;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -60,7 +60,7 @@ public class RenderDump {
       throws IOException, IllegalStateException {
     int magicNumberLength = DUMP_FORMAT_MAGIC_NUMBER.length;
 
-    PushbackInputStream pushbackInputStream = new PushbackInputStream(new FastBufferedInputStream(inputStream), magicNumberLength);
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(new BufferedInputStream(inputStream), magicNumberLength);
     byte[] magicNumber = new byte[magicNumberLength];
 
     // If the file starts with the magic number, it is the new format containing a version number
@@ -88,7 +88,7 @@ public class RenderDump {
       throws IOException, IllegalStateException {
     int magicNumberLength = DUMP_FORMAT_MAGIC_NUMBER.length;
 
-    PushbackInputStream pushbackInputStream = new PushbackInputStream(new FastBufferedInputStream(inputStream), magicNumberLength);
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(new BufferedInputStream(inputStream), magicNumberLength);
     byte[] magicNumber = new byte[magicNumberLength];
 
     // If the file starts with the magic number, it is the new format containing a version number

--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
@@ -60,7 +60,7 @@ public class RenderDump {
       throws IOException, IllegalStateException {
     int magicNumberLength = DUMP_FORMAT_MAGIC_NUMBER.length;
 
-    PushbackInputStream pushbackInputStream = new PushbackInputStream(inputStream, magicNumberLength);
+    PushbackInputStream pushbackInputStream = new PushbackInputStream(new FastBufferedInputStream(inputStream), magicNumberLength);
     byte[] magicNumber = new byte[magicNumberLength];
 
     // If the file starts with the magic number, it is the new format containing a version number
@@ -108,7 +108,7 @@ public class RenderDump {
 
   public static void save(OutputStream outputStream, Scene scene, TaskTracker taskTracker) throws IOException {
     outputStream.write(DUMP_FORMAT_MAGIC_NUMBER);
-    DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
+    DataOutputStream dataOutputStream = new DataOutputStream(new FastBufferedOutputStream(outputStream));
     DumpFormat format = getDumpFormatForVersion(CURRENT_DUMP_VERSION);
     dataOutputStream.writeInt(CURRENT_DUMP_VERSION);
     format.save(dataOutputStream, scene, taskTracker);

--- a/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/renderdump/RenderDump.java
@@ -17,10 +17,10 @@
 package se.llbit.chunky.renderer.renderdump;
 
 import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
-import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.TaskTracker;
 
+import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -108,7 +108,7 @@ public class RenderDump {
 
   public static void save(OutputStream outputStream, Scene scene, TaskTracker taskTracker) throws IOException {
     outputStream.write(DUMP_FORMAT_MAGIC_NUMBER);
-    DataOutputStream dataOutputStream = new DataOutputStream(new FastBufferedOutputStream(outputStream));
+    DataOutputStream dataOutputStream = new DataOutputStream(new BufferedOutputStream(outputStream));
     DumpFormat format = getDumpFormatForVersion(CURRENT_DUMP_VERSION);
     dataOutputStream.writeInt(CURRENT_DUMP_VERSION);
     format.save(dataOutputStream, scene, taskTracker);


### PR DESCRIPTION
This buffers the Input/Output streams for dumps, allowing dump formats that take many small operations to be much much faster. May help on existing dumps by just a little.

(I thought this was added a while ago.)