### PR TITLE
Deselect Chunks In Rectangle If All Selected

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -256,11 +256,12 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       int x1 = Math.max(cp0.x, cp1.x);
       int z0 = Math.min(cp0.z, cp1.z);
       int z1 = Math.max(cp0.z, cp1.z);
-      if (ctrlModifier) {
+
+      // If ctrlModifier to deselect, then do deselect
+      // If no ctrlModifier, select chunks
+      // but if they are all already selected, then deselect.
+      if (ctrlModifier || !chunkSelection.selectChunks(mapLoader.getWorld(), x0, z0, x1, z1))
         chunkSelection.deselectChunks(x0, z0, x1, z1);
-      } else {
-        chunkSelection.selectChunks(mapLoader.getWorld(), x0, z0, x1, z1);
-      }
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -140,8 +140,9 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
 
   /**
    * Select chunks within rectangle.
+   * @return true if anything was changed, false if no chunks were selected.
    */
-  public synchronized void selectChunks(World world, int cx0, int cz0, int cx1, int cz1) {
+  public synchronized boolean selectChunks(World world, int cx0, int cz0, int cx1, int cz1) {
     boolean selectionChanged = false;
     for (int cx = cx0; cx <= cx1; ++cx) {
       for (int cz = cz0; cz <= cz1; ++cz) {
@@ -156,12 +157,14 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
     if (selectionChanged) {
       notifyChunkSelectionChange();
     }
+    return selectionChanged;
   }
 
   /**
    * Deselect chunks within rectangle.
+   * @return true if anything was changed, false if no chunks were deselected.
    */
-  public synchronized void deselectChunks(int cx0, int cz0, int cx1, int cz1) {
+  public synchronized boolean deselectChunks(int cx0, int cz0, int cx1, int cz1) {
     boolean selectionChanged = false;
     for (int cx = cx0; cx <= cx1; ++cx) {
       for (int cz = cz0; cz <= cz1; ++cz) {
@@ -176,6 +179,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
     if (selectionChanged) {
       notifyChunkSelectionChange();
     }
+    return selectionChanged;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2012 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2012-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *


### PR DESCRIPTION
I didnt know about the control to deselect groups of chunks until I looked at the code. If a rectangle region of chunks is all selected already, then deselecting them makes sense, as clicking an individual chunk toggles it, and regions do something similar.