### PR TITLE
Scene Picker UI: Cleanup & Sort By Last Modified

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooser.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooser.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2016-2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -33,7 +34,7 @@ public class SceneChooser extends Stage {
     FXMLLoader loader = new FXMLLoader(getClass().getResource("SceneChooser.fxml"));
     Parent root = loader.load();
     SceneChooserController controller = loader.getController();
-    setTitle("Select 3D Scene");
+    setTitle("Load Chunky Scene");
     getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
     setScene(new Scene(root));
     controller.setController(chunkyFxController);

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -124,7 +124,10 @@ public class SceneChooserController implements Initializable {
     });
     sizeCol.setCellValueFactory(data -> {
       SceneListItem scene = data.getValue();
-      return new ReadOnlyStringWrapper(scene.dimensions);
+      if (scene.cropping!=null)
+        return new ReadOnlyStringWrapper(scene.dimensions + scene.cropping);
+      else
+        return new ReadOnlyStringWrapper(scene.dimensions);
     });
     sppCol.setCellValueFactory(data -> {
       SceneListItem scene = data.getValue();
@@ -212,6 +215,11 @@ public class SceneChooserController implements Initializable {
      * Whether this scene description file is a backup file and the original .json is missing.
      */
     private final boolean isBackup;
+    /**
+     * Whether scene is cropped smaller than its main canvas size.
+     * Not currently used (Planned for Chunky 2.5.0; See PR #786)
+     */
+    private final String cropping;
 
     private SceneListItem(JsonObject scene, File sceneFile) {
       int width = scene.get("width").intValue(400);
@@ -228,6 +236,20 @@ public class SceneChooserController implements Initializable {
 
       this.dimensions = dimensions;
       sppCount = scene.get("spp").intValue(0);
+
+      cropping = null;
+      // Not currently used (Planned for Chunky 2.5.0; See PR #786)
+      //    JsonValue crop = scene.get("crop");
+      //    if (crop.isArray()) {
+      //      JsonArray cropArray = crop.asArray();
+      //      if (cropArray.size() >= 4) {
+      //        int w = cropArray.get(2).asInt(width);
+      //        int h = cropArray.get(3).asInt(height);
+      //        if (w != width || h != height || cropArray.get(0).asInt(0) != 0 || cropArray.get(1).asInt(0) != 0) {
+      //          cropping = " [" + w + "x" + h + "]";
+      //        } else cropping = null;
+      //      } else cropping = null;
+      //    } else cropping = null;
 
       long milliseconds = scene.get("renderTime").longValue(0);
       if (sppCount==0 || milliseconds<500) {

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -180,7 +180,8 @@ public class SceneChooserController implements Initializable {
     List<File> fileList = SceneHelper.getAvailableSceneFiles(sceneDir);
     // TODO: Sort by recently modified instead of file name.
     Collections.sort(fileList, Comparator
-            .comparing((File o) -> o.toString().toLowerCase()) // ignore case on sort by file name.
+            .comparing((File o) -> -(Long)o.lastModified()) // negative of last modified -> most recent at top
+            .thenComparing((File o) -> o.toString().toLowerCase()) // Then by file name, ignoring case.
             .thenComparing(o -> o));
     for (File sceneFile : fileList) {
 

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -177,7 +178,10 @@ public class SceneChooserController implements Initializable {
   private void populateSceneTable(File sceneDir) {
     List<SceneListItem> scenes = new ArrayList<>();
     List<File> fileList = SceneHelper.getAvailableSceneFiles(sceneDir);
-    Collections.sort(fileList);
+    // TODO: Sort by recently modified instead of file name.
+    Collections.sort(fileList, Comparator
+            .comparing((File o) -> o.toString().toLowerCase()) // ignore case on sort by file name.
+            .thenComparing(o -> o));
     for (File sceneFile : fileList) {
 
       try (JsonParser parser = new JsonParser(new FileInputStream(new File(sceneFile.getParentFile(), sceneFile.getName())))){

--- a/chunky/src/res/se/llbit/chunky/ui/SceneChooser.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/SceneChooser.fxml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2016-2021 Jesper Öqvist <jesper@llbit.se>
+ -   Copyright (c) 2016-2021 Chunky contributors
+ -
+ -   This file is part of Chunky.
+ -
+ -   Chunky is free software: you can redistribute it and/or modify
+ -   it under the terms of the GNU General Public License as published by
+ -   the Free Software Foundation, either version 3 of the License, or
+ -   (at your option) any later version.
+ -
+ -   Chunky is distributed in the hope that it will be useful,
+ -   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ -   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ -   GNU General Public License for more details.
+ -   You should have received a copy of the GNU General Public License
+ -   along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ -->
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
@@ -9,28 +26,28 @@
 <?import javafx.scene.layout.VBox?>
 
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="600.0" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="se.llbit.chunky.ui.SceneChooserController">
-   <children>
-      <Label text="Select scene to load:" />
-      <TableView fx:id="sceneTbl" maxHeight="1.7976931348623157E308" prefHeight="293.0" VBox.vgrow="ALWAYS">
-        <columns>
-          <TableColumn fx:id="nameCol" prefWidth="120.0" text="Name" />
-          <TableColumn fx:id="chunkCountCol" prefWidth="88.0" text="Chunks" />
-            <TableColumn fx:id="sizeCol" prefWidth="104.0" text="Size" />
-            <TableColumn fx:id="sppCol" prefWidth="134.0" text="Current SPP" />
-            <TableColumn fx:id="renderTimeCol" prefWidth="133.0" text="Render time" />
-        </columns>
-      </TableView>
-      <HBox alignment="TOP_RIGHT" spacing="10.0">
-         <children>
-            <Button fx:id="deleteBtn" mnemonicParsing="false" text="Delete" />
-            <Button fx:id="exportBtn" mnemonicParsing="false" text="Export" />
-            <Button fx:id="cancelBtn" cancelButton="true" mnemonicParsing="false" text="Cancel" />
-            <Button fx:id="loadSceneBtn" defaultButton="true" mnemonicParsing="false" text="Load selected scene" />
-         </children>
-      </HBox>
-   </children>
-   <padding>
-      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-   </padding>
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefWidth="690.0" spacing="10.0" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1" fx:controller="se.llbit.chunky.ui.SceneChooserController">
+    <children>
+        <Label text="Select scene to load:"/>
+        <TableView fx:id="sceneTbl" maxHeight="1.7976931348623157E308" prefHeight="293.0" VBox.vgrow="ALWAYS">
+            <columns>
+                <TableColumn fx:id="nameCol" prefWidth="200.0" text="Name"/>
+                <TableColumn fx:id="chunkCountCol" prefWidth="100.0" text="Chunks"/>
+                <TableColumn fx:id="sizeCol" prefWidth="150.0" text="Size"/>
+                <TableColumn fx:id="sppCol" prefWidth="100.0" text="Current SPP"/>
+                <TableColumn fx:id="renderTimeCol" prefWidth="100.0" text="Render time"/>
+            </columns>
+        </TableView>
+        <HBox alignment="TOP_RIGHT" spacing="10.0">
+            <children>
+                <Button fx:id="deleteBtn" mnemonicParsing="false" text="Delete"/>
+                <Button fx:id="exportBtn" mnemonicParsing="false" text="Export"/>
+                <Button fx:id="cancelBtn" cancelButton="true" mnemonicParsing="false" text="Cancel"/>
+                <Button fx:id="loadSceneBtn" defaultButton="true" mnemonicParsing="false" text="Load selected scene"/>
+            </children>
+        </HBox>
+    </children>
+    <padding>
+        <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+    </padding>
 </VBox>


### PR DESCRIPTION
 - Default sorting of scenes is by most recent at the top, just as you've always wanted. You're welcome :)
 - Rebalanced column widths (Can now fit the default scene name)
 - ~~some stuff for cropping scenes, currently unused and/or commented out. Will be used once sub-scene tiling/cropping comes in #786)~~

Closed #437 