### PR TITLE
Quick Removal Of The Incorrect Russian Roulette.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -811,12 +811,12 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * Test if the ray should be killed (using Russian Roulette).
+   * Test if the ray should be killed <strike>(using Russian Roulette)</strike>.
    *
    * @return {@code true} if the ray needs to die now
    */
   public final boolean kill(int depth, Random random) {
-    return depth >= rayDepth && random.nextDouble() < .5f;
+    return depth >= rayDepth;
   }
 
   /**


### PR DESCRIPTION
See #1018 for motivation for this.

---

now:

Setting rayDepth to 1 -> light cannot bounce off the ground, thus everything but the sky is black.

Setting rayDepth to 2 -> light can bounce off of the ground/blocks, but cannot bounce off of anything else. Emitters do not work.

Setting rayDepth to 3 -> hey look, torches give off light now!

Setting rayDepth to 4 -> the start of indirect illumination from emitters...