### PR TITLE
Fix null pointer exception from StringConverter.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/AdvancedTab.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initializable {
@@ -111,12 +112,13 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     outputMode.setConverter(new StringConverter<PictureExportFormat>() {
       @Override
       public String toString(PictureExportFormat object) {
+        if (object == null) return "";
         return object.getName();
       }
 
       @Override
       public PictureExportFormat fromString(String string) {
-        return PictureExportFormats.getFormat(string).get();
+        return PictureExportFormats.getFormat(string).orElse(PictureExportFormats.PNG);
       }
     });
     outputMode.getSelectionModel().selectedItemProperty()

--- a/chunky/src/java/se/llbit/chunky/ui/render/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/AdvancedTab.java
@@ -83,6 +83,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @Override
   public void initialize(URL location, ResourceBundle resources) {
     outputMode.getItems().addAll(PictureExportFormats.getFormats());
+    outputMode.getSelectionModel().select(PictureExportFormats.PNG);
     cpuLoad.setName("CPU utilization");
     cpuLoad.setTooltip("CPU utilization percentage per render thread.");
     cpuLoad.setRange(1, 100);
@@ -112,8 +113,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     outputMode.setConverter(new StringConverter<PictureExportFormat>() {
       @Override
       public String toString(PictureExportFormat object) {
-        if (object == null) return "";
-        return object.getName();
+        return object == null ? null : object.getName();
       }
 
       @Override

--- a/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
@@ -89,6 +89,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
     postprocessingFilter.setConverter(new StringConverter<PostProcessingFilter>() {
       @Override
       public String toString(PostProcessingFilter object) {
+        if (object == null) return "";
         return object.getName();
       }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/PostprocessingTab.java
@@ -89,8 +89,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
     postprocessingFilter.setConverter(new StringConverter<PostProcessingFilter>() {
       @Override
       public String toString(PostProcessingFilter object) {
-        if (object == null) return "";
-        return object.getName();
+        return object == null ? null : object.getName();
       }
 
       @Override

--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -111,8 +111,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     simulatedSky.setConverter(new StringConverter<SimulatedSky>() {
       @Override
       public String toString(SimulatedSky object) {
-        if (object == null) return "";
-        return object.getName();
+        return object == null ? null : object.getName();
       }
 
       @Override

--- a/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/SkyTab.java
@@ -111,6 +111,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     simulatedSky.setConverter(new StringConverter<SimulatedSky>() {
       @Override
       public String toString(SimulatedSky object) {
+        if (object == null) return "";
         return object.getName();
       }
 


### PR DESCRIPTION
Properly handle `null` cases in StringConverters.

Closes #1016