### PR TITLE
Revamp javafx locator

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -239,7 +239,7 @@ public class ChunkyLauncher {
       }
     } catch(NoClassDefFoundError e) {
       String cause = e.getMessage();
-      if(cause.contains("javafx")) {
+      if(cause != null && cause.contains("javafx")) {
         // Javafx error
         if(retryIfMissingJavafx)
           JavaFxLocator.retryWithJavafx(args);

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2016 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ChunkyLauncher {
 
-  public static final String LAUNCHER_VERSION = "v1.12.1";
+  public static final String LAUNCHER_VERSION = "v1.12.2";
 
   /**
    * Print a launch error message to the console.

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.launcher;
 
 import java.io.File;

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -4,37 +4,116 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.LinkedHashSet;
 
 public class JavaFxLocator {
 
+  /**
+   * Lazy set of absolute paths to JavaFX library folders.
+   * Filled using {@link #scanForJavaFXLibs()}.
+   */
+  private static final LinkedHashSet<Path> javafxPathCandidates = new LinkedHashSet<>();
 
-  private static final List<String> javafxPathCandidates;
-
-  static {
-    javafxPathCandidates = new ArrayList<>();
-    javafxPathCandidates.add("C:\\Program Files\\openjfx\\lib");
-    javafxPathCandidates.add("/usr/share/openjfx/lib");
-    javafxPathCandidates.add("/usr/lib/jvm/java-11-openjdk/lib");
-    javafxPathCandidates.add("/usr/lib/jvm/java-12-openjdk/lib");
-    javafxPathCandidates.add("/usr/lib/jvm/java-13-openjdk/lib");
-    javafxPathCandidates.add("/usr/lib/jvm/java-14-openjdk/lib");
-    javafxPathCandidates.add("/usr/lib/jvm/java-15-openjdk/lib");
-
-    javafxPathCandidates.add(System.getProperty("java.home", "") + File.separator + "lib"); // java home
-    javafxPathCandidates.add(System.getProperty("user.dir", "") + File.separator + "lib"); // working directory
+  private static void scanForJavaFXLibs() {
+    // working directory (local lib overwrites installed system libs)
+    addJavaFXPathIfValid(getJavaFXPathBySystemProperty("user.dir"));
     try {
-      javafxPathCandidates.add(new File(ChunkyLauncher.class.getProtectionDomain().getCodeSource().getLocation().toURI())
-              .toPath().getParent().toAbsolutePath().toString() + File.separator + "lib"); // directory of the .jar
-    } catch(URISyntaxException e) {
-      e.printStackTrace();
+      // directory of the .jar
+      File executableFile = new File(
+              ChunkyLauncher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+      addJavaFXPathIfValid(executableFile.toPath().getParent());
+    } catch(URISyntaxException ignored) {
+    }
+
+    // home directory installation
+    Path userHomePath = getJavaFXPathBySystemProperty("user.home");
+    if(userHomePath != null) {
+      addJavaFXPathIfValid(userHomePath.resolve(".chunky"), true);
+    }
+
+    // java home
+    Path javaHomePath = getJavaFXPathBySystemProperty("java.home");
+    addJavaFXPathIfValid(javaHomePath);
+
+    if(System.getProperty("os.name").startsWith("Windows")) {
+      // windows paths
+      if(javaHomePath != null &&
+              (javaHomePath.endsWith("jre") || javaHomePath.endsWith("jdk"))) {
+        // if jre is in a subfolder of the jdk, try jdks lib path (example: OpenJDK from odjkbuild)
+        addJavaFXPathIfValid(javaHomePath.getParent(), true);
+      }
+      addJavaFXPathIfValid("C:\\Program Files\\openjfx");
+    } else {
+      // linux paths
+      addJavaFXPathIfValid("/usr/share/openjfx");
+      for(int javaVersion = 11; javaVersion <= 17; javaVersion++) {
+        addJavaFXPathIfValid("/usr/lib/jvm/java-" + javaVersion + "-openjdk");
+      }
     }
   }
 
-  private static boolean validJavafxDirectory(Path dir) {
+  private static Path getJavaFXPathBySystemProperty(String propertyName) {
+    try {
+      String propertyValue = System.getProperty(propertyName);
+      if(propertyValue != null) {
+        return Paths.get(propertyValue);
+      }
+    } catch(SecurityException ignored) {
+    }
+    return null;
+  }
+
+
+  private static void addJavaFXPathIfValid(String path) {
+    addJavaFXPathIfValid(Paths.get(path), false);
+  }
+
+  private static void addJavaFXPathIfValid(Path path) {
+    addJavaFXPathIfValid(path, false);
+  }
+
+  /**
+   * Validates the path to contain the required JavaFX library files.
+   * Retests the path with lib appended, if the initial test does not find the files.
+   *
+   * @param path path to library files, gets converted to absolute while following links
+   * @return true if path contains required files
+   */
+  private static boolean addJavaFXPathIfValid(Path path, boolean searchJavaFXSDK) {
+    try {
+      // get absolute path, follow links
+      path = path.toRealPath();
+
+      if(isValidJavaFXDirectory(path)) {
+        javafxPathCandidates.add(path);
+        return true;
+      }
+      if(!path.endsWith("lib")) {
+        if(addJavaFXPathIfValid(path.resolve("lib"), searchJavaFXSDK)) {
+          return true;
+        }
+      }
+      if(searchJavaFXSDK) {
+        try(DirectoryStream<Path> directoryStream = Files.newDirectoryStream(path, subPath -> subPath.toFile().isDirectory())) {
+          for(Path subPath : directoryStream) {
+            if(subPath.getFileName().toString().contains("javafx")) {
+              addJavaFXPathIfValid(subPath);
+            }
+          }
+        }
+      }
+    } catch(IOException ignored) {
+    }
+    return false;
+  }
+
+  private static boolean isValidJavaFXDirectory(Path dir) {
     return dir.toFile().exists()
             && dir.resolve("javafx.base.jar").toFile().exists()
             && dir.resolve("javafx.controls.jar").toFile().exists()
@@ -48,7 +127,7 @@ public class JavaFxLocator {
     cmd.add(JreUtil.javaCommand(""));
     cmd.addAll(ManagementFactory.getRuntimeMXBean().getInputArguments());
     cmd.add("--module-path");
-    cmd.add(javafxDir.toAbsolutePath().toString());
+    cmd.add(javafxDir.toString());
     cmd.add("--add-modules");
     cmd.add("javafx.controls,javafx.fxml");
 
@@ -61,15 +140,18 @@ public class JavaFxLocator {
     cmd.add("--javaOptions");
     StringBuilder javaOptions = new StringBuilder();
     javaOptions.append("--module-path ");
-    if (System.getProperty("os.name").startsWith("Windows")) {
-      // Escape the path twice to make the second launcher pass the options to Chunky retaining the double speechmarks (fixes paths with spaces)
-      javaOptions.append("\\\"" + javafxDir.toAbsolutePath().toString() + "\\\"");
+    if(System.getProperty("os.name").startsWith("Windows")) {
+      // Escape the path twice to make the second launcher pass the options to Chunky retaining the double quotation marks (fixes paths with spaces)
+      javaOptions.append("\\\"").append(javafxDir.toAbsolutePath()).append("\\\"");
     } else {
-      javaOptions.append(javafxDir.toAbsolutePath().toString());
+      javaOptions.append(javafxDir);
     }
     javaOptions.append(" --add-modules ");
     javaOptions.append("javafx.controls,javafx.fxml");
     cmd.add(javaOptions.toString());
+
+    System.out.println("Trying to start the chunky process with the following arguments:");
+    System.out.println(String.join(" ", cmd));
 
     ProcessBuilder builder = new ProcessBuilder(cmd);
     builder.inheritIO();
@@ -82,11 +164,13 @@ public class JavaFxLocator {
   }
 
   public static void retryWithJavafx(String[] args) {
-    for(String candiate : javafxPathCandidates) {
-      Path directory = new File(candiate).toPath();
-      if(validJavafxDirectory(directory)) {
-        runWithJavafx(directory, args);
-      }
+    if(javafxPathCandidates.isEmpty()) {
+      scanForJavaFXLibs();
+      System.out.println("JavaFX scan found the following candidates:");
+      javafxPathCandidates.forEach(System.out::println);
+    }
+    for(Path pathCandiate : javafxPathCandidates) {
+      runWithJavafx(pathCandiate, args);
     }
   }
 


### PR DESCRIPTION
- add Java version 16 and 17 paths for linux
- add checking parent directory of `jre` and `jdk` folders for windows (relevant for ojdkbuild)
- add home directory installation `.chunky` check
- add checks for lib directory and its parent directory
- add eager check for directories named `*javafx*` in some locations (relevant for JavaFX SDKs extracted from the downloads from https://openjfx.io/ resp. https://gluonhq.com/products/javafx/)