### PR TITLE
Replace the map used by Heightmap to reduce gc pressure

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -48,7 +48,11 @@ public class ChunkPosition {
   private static final Map<Long, ChunkPosition> positions = new ConcurrentHashMap<>();
 
   public static ChunkPosition get(int x, int z) {
-    return positions.computeIfAbsent((z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32, (position) -> new ChunkPosition(x, z));
+    return positions.computeIfAbsent(positionToLong(x, z), (position) -> new ChunkPosition(x, z));
+  }
+
+  public static long positionToLong(int x, int z) {
+    return (z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32;
   }
 
   /**
@@ -62,7 +66,7 @@ public class ChunkPosition {
    * @return The long representation of the chunk position
    */
   public long getLong() {
-    return (((long) x) << 32) | (0xFFFFFFFFL & z);
+    return positionToLong(x, z);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/Heightmap.java
+++ b/chunky/src/java/se/llbit/chunky/world/Heightmap.java
@@ -16,6 +16,9 @@
  */
 package se.llbit.chunky.world;
 
+import it.unimi.dsi.fastutil.longs.Long2ReferenceMap;
+import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,17 +29,17 @@ import java.util.Map;
  */
 public class Heightmap {
 
-  private Map<ChunkPosition, ChunkHeightmap> map = new HashMap<>();
+  private final Long2ReferenceMap<ChunkHeightmap> map = new Long2ReferenceOpenHashMap<>();
 
   /**
    * Set height y at (x, z).
    */
   public synchronized void set(int y, int x, int z) {
-    ChunkPosition cp = ChunkPosition.get(x >> 5, z >> 5);
-    ChunkHeightmap hm = map.get(cp);
+    long key = ChunkPosition.positionToLong(x >> 5, z >> 5);
+    ChunkHeightmap hm = map.get(key);
     if (hm == null) {
       hm = new ChunkHeightmap();
-      map.put(cp, hm);
+      map.put(key, hm);
     }
     hm.set(y, x & 0x1F, z & 0x1F);
   }
@@ -45,11 +48,11 @@ public class Heightmap {
    * @return Height at (x, z)
    */
   public synchronized int get(int x, int z) {
-    ChunkPosition cp = ChunkPosition.get(x >> 5, z >> 5);
-    ChunkHeightmap hm = map.get(cp);
+    long key = ChunkPosition.positionToLong(x >> 5, z >> 5);
+    ChunkHeightmap hm = map.get(key);
     if (hm == null) {
       hm = new ChunkHeightmap();
-      map.put(cp, hm);
+      map.put(key, hm);
     }
     return hm.get(x & 0x1F, z & 0x1F);
   }


### PR DESCRIPTION
By indexing the map used by Heightmpa with a long instead of a ChunkPosition, we don't need to call ChunkPosition.get, which incurs another map lookup and a temporary Long allocation, every time we use HeightMap.get or Heightmap.set. Those temporary Long represent a good chunk of the allocation during the 2D map loading so removing them reduces gc pressure.
This makes the 2D map loads faster, about -12% to get the same area completely loaded. I don't know how much is due to having only one hash map lookup vs 2 and how much is because of reduce gc pressure but it doesn't really matter