### PR TITLE
Move render controls UI

### DIFF
--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -56,7 +56,29 @@
   <SplitPane fx:id="splitPane"
              VBox.vgrow="ALWAYS"
              maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308">
-    <ToolPane fx:id="renderControls" prefWidth="350" />
+    <VBox>
+      <ToolPane fx:id="renderControls" prefWidth="350" VBox.vgrow="ALWAYS" />
+      <Separator/>
+      <VBox spacing="5.0">
+        <padding>
+          <Insets top="2.0" bottom="4.0" left="10.0" right="10.0" />
+        </padding>
+        <HBox alignment="CENTER_LEFT" spacing="10.0" >
+          <Label text="Render:" />
+          <ToggleButton fx:id="start" mnemonicParsing="false" text="Start">
+            <toggleGroup>
+              <ToggleGroup fx:id="renderControl" />
+            </toggleGroup>
+          </ToggleButton>
+          <ToggleButton fx:id="pause" mnemonicParsing="false" text="Pause" toggleGroup="$renderControl" />
+          <ToggleButton fx:id="reset" mnemonicParsing="false" text="Reset" toggleGroup="$renderControl" selected="true" />
+        </HBox>
+        <HBox alignment="CENTER_LEFT" spacing="10.0">
+          <IntegerAdjuster fx:id="targetSpp" />
+          <Button fx:id="saveDefaultSpp" mnemonicParsing="false" text="Set default" />
+        </HBox>
+      </VBox>
+    </VBox>
     <TabPane fx:id="mainTabs" maxWidth="1.7976931348623157E308" maxHeight="1.7976931348623157E308" tabClosingPolicy="UNAVAILABLE">
       <Tab fx:id="worldMapTab" text="Map">
         <StackPane fx:id="mapPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="150.0" prefWidth="200.0">
@@ -172,33 +194,26 @@
       </Tab>
     </TabPane>
   </SplitPane>
-  <HBox alignment="CENTER_LEFT" spacing="10.0">
-    <Label text="Render:" />
-    <ToggleButton fx:id="start">
-      <toggleGroup>
-        <ToggleGroup fx:id="renderControl" />
-      </toggleGroup>
-    </ToggleButton>
-    <ToggleButton fx:id="pause" toggleGroup="$renderControl" />
-    <ToggleButton fx:id="reset" mnemonicParsing="false" selected="true" text="Reset" toggleGroup="$renderControl" />
-    <IntegerAdjuster fx:id="targetSpp" />
-    <Button fx:id="saveDefaultSpp" mnemonicParsing="false" text="Set default" />
-  </HBox>
-  <BorderPane>
-    <left>
-      <Label fx:id="renderTimeLbl" text="Render time: 0" />
-    </left>
-    <right>
-      <Label fx:id="sppLbl" text="0 SPP, 0 SPS" />
-    </right>
-  </BorderPane>
-  <BorderPane>
-    <left>
-      <Label fx:id="progressLbl" text="Progress" />
-    </left>
-    <right>
-      <Label fx:id="etaLbl" text="ETA: N/A" />
-    </right>
-  </BorderPane>
+  <VBox spacing="5.0">
+    <padding>
+      <Insets top="5.0" bottom="5.0" left="10.0" right="10.0" />
+    </padding>
+    <BorderPane>
+      <left>
+        <Label fx:id="renderTimeLbl" text="Render time: 0" />
+      </left>
+      <right>
+        <Label fx:id="sppLbl" text="0 SPP, 0 SPS" />
+      </right>
+    </BorderPane>
+    <BorderPane>
+      <left>
+        <Label fx:id="progressLbl" text="Progress" />
+      </left>
+      <right>
+        <Label fx:id="etaLbl" text="ETA: N/A" />
+      </right>
+    </BorderPane>
+  </VBox>
   <ProgressBar fx:id="progressBar" maxWidth="1.7976931348623157E308" minHeight="20" prefHeight="20" progress="0.0" />
 </VBox>


### PR DESCRIPTION
- move render controls into left panel
- give the start and pause buttons text
- add spacing to progress texts

pros: dedicated area for render controls (they even take up about the width of the sidebar) using less vertical space
cons: more "semantic distance" from the progress report in the layout

left side: current Chunky
right side: this PR
![image](https://user-images.githubusercontent.com/16897056/128636851-a4e9e9fb-b54e-4398-a5a6-d18d4f19f99d.png)

behaviour under minimal size:
![image](https://user-images.githubusercontent.com/16897056/128636864-d33615e5-b669-4700-9efb-f96a4a4597ed.png)
