### PR TITLE
Simple map view optimisations

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocks.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocks.java
@@ -9,12 +9,27 @@ import se.llbit.nbt.Tag;
 
 public class LegacyBlocks {
 
+  /** statically initialised array of every possible tag */
+  private static final Tag[] legacyTags = new Tag[(1 << 8) * (1 << 4)];
+
+  static {
+    for (int id = 0; id < 1 << 8; id++) { //id is 8 bits
+      for (int data = 0; data < 1 << 4; data++) { //data is 4 bits
+        legacyTags[id * (1 << 4) + data] = getTag(id, data);
+      }
+    }
+  }
+
   public static Tag getTag(int offset, byte[] blocks, byte[] blockData) {
     int id = blocks[offset] & 0xFF;
     int data = 0xFF & blockData[offset / 2];
     data >>= (offset % 2) * 4;
     data &= 0xF;
 
+    return legacyTags[id * (1 << 4) + data];
+  }
+
+  private static Tag getTag(int id, int data) {
     CompoundTag tag = new CompoundTag();
     switch (id) {
       case 0:   return nameTag(tag, "air");

--- a/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
+++ b/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
@@ -50,14 +50,14 @@ public class SurfaceLayer extends BitmapLayer {
    * @param dim current dimension
    * @param chunkData data for the chunk
    */
-  public SurfaceLayer(int dim, ChunkData chunkData, BlockPalette palette, int yMin, int yMax) {
+  public SurfaceLayer(int dim, ChunkData chunkData, BlockPalette palette, int yMin, int yMax, int[] heightmapData) {
     bitmap = new int[Chunk.X_MAX * Chunk.Z_MAX];
     topo = new int[Chunk.X_MAX * Chunk.Z_MAX];
     for (int x = 0; x < Chunk.X_MAX; ++x) {
       for (int z = 0; z < Chunk.Z_MAX; ++z) {
 
         // Find the topmost non-empty block.
-        int y = Math.min(chunkData.maxY() - 1, yMax);
+        int y = Math.min(Math.min(chunkData.maxY() - 1, yMax), heightmapData[z*16 + x]);
         int minY = Math.max(chunkData.minY(), yMin);
         for (; y > minY; --y) {
           if (palette.get(chunkData.getBlockAt(x, y, z)) != Air.INSTANCE) {

--- a/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
+++ b/chunky/src/java/se/llbit/chunky/map/SurfaceLayer.java
@@ -57,7 +57,7 @@ public class SurfaceLayer extends BitmapLayer {
       for (int z = 0; z < Chunk.Z_MAX; ++z) {
 
         // Find the topmost non-empty block.
-        int y = Math.min(Math.min(chunkData.maxY() - 1, yMax), heightmapData[z*16 + x]);
+        int y = Math.min(Math.min(chunkData.maxY() - 1, yMax), heightmapData[z*Chunk.X_MAX + x]);
         int minY = Math.max(chunkData.minY(), yMin);
         for (; y > minY; --y) {
           if (palette.get(chunkData.getBlockAt(x, y, z)) != Air.INSTANCE) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -177,7 +177,7 @@ public class Chunk {
         loadBlockData(data, chunkData, palette, yMin, yMax);
         int[] heightmapData = extractHeightmapData(data, chunkData);
         updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
-        surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMin, yMax);
+        surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMin, yMax, heightmapData);
         queueTopography();
       }
     } else {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -174,6 +174,7 @@ public class Chunk {
       extractBiomeData(data.get(LEVEL_BIOMES), chunkData);
       if (version.equals("1.13") || version.equals("1.12")) {
         BlockPalette palette = new BlockPalette();
+        palette.unsynchronize(); //only this RegionParser will use this palette
         loadBlockData(data, chunkData, palette, yMin, yMax);
         int[] heightmapData = extractHeightmapData(data, chunkData);
         updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);

--- a/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
@@ -76,7 +76,6 @@ public class CubicWorld extends World {
       if (regionExists(pos)) {
         region = createRegion(pos);
       }
-      setRegion(pos, region);
       return region;
     });
   }
@@ -88,7 +87,6 @@ public class CubicWorld extends World {
       if (regionExistsWithinRange(pos, minY, maxY)) {
         region = createRegion(pos);
       }
-      setRegion(pos, region);
       return region;
     });
   }

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -4,15 +4,14 @@ import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.EmptyChunkData;
-import se.llbit.chunky.chunk.GenericChunkData;
 import se.llbit.chunky.map.IconLayer;
 import se.llbit.chunky.map.SurfaceLayer;
 import se.llbit.chunky.world.region.ImposterCubicRegion;
-import se.llbit.math.QuickMath;
-import se.llbit.nbt.*;
-import se.llbit.util.BitBuffer;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.ListTag;
+import se.llbit.nbt.SpecificTag;
+import se.llbit.nbt.Tag;
 import se.llbit.util.Mutable;
-import se.llbit.util.NotNull;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -20,6 +19,11 @@ import java.util.Set;
 
 import static se.llbit.chunky.world.World.VERSION_1_12_2;
 
+/**
+ * An implementation of a cube wrapper for pre flattening cubic chunks (1.10, 1.11, 1.12)
+ *
+ * Represents an infinitely tall column of 16x16x16 Cubes
+ */
 public class ImposterCubicChunk extends Chunk {
   private final CubicWorld world;
 
@@ -100,7 +104,7 @@ public class ImposterCubicChunk extends Chunk {
 
     int[] heightmapData = extractHeightmapDataCubic(null, chunkData);
     updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
-    surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMin, yMax);
+    surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, yMin, yMax, heightmapData);
   }
 
   private int[] extractHeightmapDataCubic(Map<String, Tag> cubeData, ChunkData chunkData) {

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -313,7 +313,6 @@ public class World implements Comparable<World> {
       if (regionExists(pos)) {
         region = createRegion(pos);
       }
-      setRegion(pos, region);
       return region;
     });
   }


### PR DESCRIPTION
The main speedup for legacy worlds is the static initialisation of tags. Instead of creating a new tag object for every single block, it just indexes a pre-initialised 4096 length array.

In `SurfaceLayer#<init>` I *actually use the heightmap data* calculated the line before calling it, instead of recalculating it in the constructor

Ideally don't merge this PR at the same time as #1031 as I have to implement these optimisations there too. I'd prefer merging #1031 first, to keep things together that logically should be, but it doesn't really matter

