### PR TITLE
Implement more intrusive confirmation dialog for chunk deletion

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -147,9 +147,9 @@ public class ChunkyFxController
   @FXML private Button creditsBtn;
   @FXML private DoubleTextField xPosition;
   @FXML private DoubleTextField zPosition;
-  @FXML private Button deleteChunks;
-  @FXML private Button exportZip;
-  @FXML private Button renderPng;
+  @FXML private Button deleteChunksBtn;
+  @FXML private Button exportZipBtn;
+  @FXML private Button renderPngBtn;
   @FXML private StackPane mapPane;
   @FXML private SplitPane splitPane;
   @FXML private TabPane mapTabs;
@@ -501,8 +501,9 @@ public class ChunkyFxController
           scale.set(newValue.scale);
         }));
 
-    deleteChunks.setTooltip(new Tooltip("Delete selected chunks."));
-    deleteChunks.setOnAction(e -> {
+    deleteChunksBtn.setTooltip(new Tooltip("Delete selected chunks."));
+    deleteChunksBtn.setGraphic(new ImageView(Icon.clear.fxImage()));
+    deleteChunksBtn.setOnAction(e -> {
       Dialog<ButtonType> confirmationDialog = Dialogs.createSpecialApprovalConfirmation(
         "Delete Selected Chunks",
         "This operation will modify your world - be sure to have a backup!",
@@ -513,19 +514,22 @@ public class ChunkyFxController
       }
     });
 
-    exportZip.setTooltip(new Tooltip("Export selected chunks to Zip archive."));
-    exportZip.setOnAction(e -> {
+    exportZipBtn.setTooltip(new Tooltip("Export selected chunks to Zip archive."));
+    exportZipBtn.setGraphic(new ImageView(Icon.save.fxImage()));
+    exportZipBtn.setOnAction(e -> {
       FileChooser fileChooser = new FileChooser();
       fileChooser.setTitle("Export Chunks to Zip");
       fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Zip files", "*.zip"));
       mapLoader.withWorld(world -> fileChooser.setInitialFileName(world.levelName() + ".zip"));
-      File target = fileChooser.showSaveDialog(exportZip.getScene().getWindow());
+      File target = fileChooser.showSaveDialog(exportZipBtn.getScene().getWindow());
       if (target != null) {
         exportZip(target, ProgressTracker.NONE);
       }
     });
 
-    renderPng.setOnAction(e -> {
+    exportZipBtn.setTooltip(new Tooltip("Exports the current map view (not the selected chunks) as a PNG file."));
+    renderPngBtn.setGraphic(new ImageView(Icon.save.fxImage()));
+    renderPngBtn.setOnAction(e -> {
       FileChooser fileChooser = new FileChooser();
       fileChooser.setTitle("Export PNG");
       fileChooser
@@ -534,7 +538,7 @@ public class ChunkyFxController
       if (prevPngDir != null) {
         fileChooser.setInitialDirectory(prevPngDir.toFile());
       }
-      File target = fileChooser.showSaveDialog(exportZip.getScene().getWindow());
+      File target = fileChooser.showSaveDialog(exportZipBtn.getScene().getWindow());
       if (target != null) {
         Path path = target.toPath();
         if (!target.getName().endsWith(".png")) {
@@ -644,6 +648,7 @@ public class ChunkyFxController
 
     menuExit.setAccelerator(new KeyCodeCombination(KeyCode.Q, KeyCombination.CONTROL_DOWN));
     clearSelectionBtn.setOnAction(event -> chunkSelection.clearSelection());
+    clearSelectionBtn.setGraphic(new ImageView(Icon.clear.fxImage()));
 
     mapView.setMapSize((int) mapCanvas.getWidth(), (int) mapCanvas.getHeight());
     mapOverlay.setOnScroll(map::onScroll);

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -47,6 +47,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
@@ -502,11 +503,12 @@ public class ChunkyFxController
 
     deleteChunks.setTooltip(new Tooltip("Delete selected chunks."));
     deleteChunks.setOnAction(e -> {
-      Alert alert = Dialogs.createAlert(Alert.AlertType.CONFIRMATION);
-      alert.setTitle("Delete Selected Chunks");
-      alert.setContentText(
-          "Do you really want to delete the selected chunks? This can not be undone.");
-      if (alert.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
+      Dialog<ButtonType> confirmationDialog = Dialogs.createSpecialApprovalConfirmation(
+        "Delete Selected Chunks",
+        "This operation will modify your world - be sure to have a backup!",
+        "Do you really want to delete the selected chunks? This can not be undone."
+      );
+      if (confirmationDialog.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
         deleteSelectedChunks(ProgressTracker.NONE);
       }
     });

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -505,9 +505,10 @@ public class ChunkyFxController
     deleteChunksBtn.setGraphic(new ImageView(Icon.clear.fxImage()));
     deleteChunksBtn.setOnAction(e -> {
       Dialog<ButtonType> confirmationDialog = Dialogs.createSpecialApprovalConfirmation(
-        "Delete Selected Chunks",
-        "This operation will modify your world - be sure to have a backup!",
-        "Do you really want to delete the selected chunks? This can not be undone."
+        "Delete selected chunks",
+        "Confirm deleting the selected chunks",
+        "Do you really want to delete the selected chunks from the world?\nThis will remove the selected chunks from your disk and cannot be undone. Be sure to have a backup!",
+        "I do want to permanently delete the selected chunks"
       );
       if (confirmationDialog.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
         deleteSelectedChunks(ProgressTracker.NONE);

--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -29,13 +29,14 @@ public class Dialogs {
   public static Dialog<ButtonType> createSpecialApprovalConfirmation(
     String title,
     String header,
-    String content
+    String content,
+    String confirmLabel
   ) {
     return new SpecialApprovalConfirmationDialog(
       title,
       header,
       content,
-      "I know what I'm doing!"
+      confirmLabel
     );
   }
 

--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -2,8 +2,14 @@ package se.llbit.fxutil;
 
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
 
 public class Dialogs {
 
@@ -16,7 +22,49 @@ public class Dialogs {
     // We have to do some adjustments to make the alert dialog resize to
     // the text content on Linux. Source: http://stackoverflow.com/a/33905734
     alert.getDialogPane().getChildren().stream().filter(node -> node instanceof Label)
-        .forEach(node -> ((Label) node).setMinHeight(Region.USE_PREF_SIZE));
+      .forEach(node -> ((Label) node).setMinHeight(Region.USE_PREF_SIZE));
     return alert;
+  }
+
+  public static Dialog<ButtonType> createSpecialApprovalConfirmation(
+    String title,
+    String header,
+    String content
+  ) {
+    return new SpecialApprovalConfirmationDialog(
+      title,
+      header,
+      content,
+      "I know what I'm doing!"
+    );
+  }
+
+  /**
+   * makes extra sure that user wants to confirm things
+   */
+  static class SpecialApprovalConfirmationDialog extends Dialog<ButtonType> {
+    final CheckBox checkBox;
+
+    SpecialApprovalConfirmationDialog(
+      String title,
+      String header,
+      String content,
+      String checkBoxLabel
+    ) {
+      setResultConverter(param -> param);
+      checkBox = new CheckBox(checkBoxLabel);
+
+      final DialogPane dialogPane = getDialogPane();
+      dialogPane.getStyleClass().add("alert");
+      dialogPane.getStyleClass().add("warning");
+
+      setTitle(title);
+      dialogPane.setHeaderText(header);
+      dialogPane.setContent(new VBox(16, new Text(content), checkBox));
+      dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+
+      dialogPane.lookupButton(ButtonType.OK)
+        .disableProperty().bind(checkBox.selectedProperty().not());
+    }
   }
 }

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -148,11 +148,11 @@
           <Button fx:id="clearSelectionBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Clear selection"/>
           <Separator/>
           <Label text="Exports"/>
-          <Button fx:id="exportZip" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export chunks to ZIP"/>
-          <Button fx:id="renderPng" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export view to PNG"/>
+          <Button fx:id="exportZipBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export chunks to ZIP"/>
+          <Button fx:id="renderPngBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export view to PNG"/>
           <Separator/>
           <Label text="World modification - Use with caution!"/>
-          <Button fx:id="deleteChunks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Delete selected chunks"/>
+          <Button fx:id="deleteChunksBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Delete selected chunks"/>
         </VBox>
       </Tab>
       <Tab fx:id="optionsTab" text="Options">

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -146,9 +146,13 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
           </padding>
           <Button fx:id="clearSelectionBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Clear selection"/>
-          <Button fx:id="deleteChunks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Delete selected chunks"/>
+          <Separator/>
+          <Label text="Exports"/>
           <Button fx:id="exportZip" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export chunks to ZIP"/>
           <Button fx:id="renderPng" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Export view to PNG"/>
+          <Separator/>
+          <Label text="World modification - Use with caution!"/>
+          <Button fx:id="deleteChunks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Delete selected chunks"/>
         </VBox>
       </Tab>
       <Tab fx:id="optionsTab" text="Options">


### PR DESCRIPTION
This does not close #1034, but is an simple fix to prevent unwanted deletion of selected chunks when clicking the current confirmation dialog away.

![image](https://user-images.githubusercontent.com/16897056/134699547-d86e1758-e24f-4093-9662-c851197d77c7.png)
