### PR TITLE
Build distribution and upload artifact.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,14 @@ jobs:
         name: Chunky Docs
         path: build/docs/
     - name: Build release jar
-      run: ./gradlew build releasejar
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+          ./gradlew build releasejar -PnewVersion="$(git describe)"
+        else
+          ./gradlew build releasejar -PnewVersion="PR-${PR_NUMBER}_$(git describe)"
+        fi
     - name: Cleanup
       run: rm -rf build/docs build/tmp
     - name: Upload build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -24,11 +26,17 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Upload documentation
+      uses: actions/upload-artifact@v2.2.2
+      with:
+        name: Chunky Docs
+        path: build/docs/
     - name: Build release jar
       run: ./gradlew build releasejar
+    - name: Cleanup
+      run: rm -rf build/docs build/tmp
     - name: Upload build
       uses: actions/upload-artifact@v2.2.2
       with:
-        name: Chunky
+        name: Chunky Build
         path: build/
-      

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -25,3 +24,11 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Build release jar
+      run: ./gradlew build releasejar
+    - name: Upload build
+      uses: actions/upload-artifact@v2.2.2
+      with:
+        name: Chunky
+        path: build/
+      


### PR DESCRIPTION
For larger pull requests, it is often helpful for there to be a build for non-developers to try out the new features. This publishes 2 artifacts per build, a documentation artifact and a release jar artifact.