### PR TITLE
Rename various tests and test classes to have consistent naming scheme

### DIFF
--- a/chunky/src/test/se/llbit/chunky/chunk/BlockPaletteTest.java
+++ b/chunky/src/test/se/llbit/chunky/chunk/BlockPaletteTest.java
@@ -6,7 +6,7 @@ import se.llbit.nbt.StringTag;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestBlockPalette {
+public class BlockPaletteTest {
   // Test that the block palette reuses existing blocks with the same tag data.
   @Test public void testBlockReuse() {
     CompoundTag t1 = new CompoundTag();

--- a/chunky/src/test/se/llbit/chunky/entity/MarshallingTest.java
+++ b/chunky/src/test/se/llbit/chunky/entity/MarshallingTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Test entity marshalling/unmarshalling to/from JSON.
  */
-public class TestMarshalling {
+public class MarshallingTest {
   @Test public void testPlayer() {
     PlayerEntity entity = new PlayerEntity("1234", new Vector3(100, 200, 300));
     JsonArray headPose = new JsonArray();

--- a/chunky/src/test/se/llbit/chunky/nbt/NBTTest.java
+++ b/chunky/src/test/se/llbit/chunky/nbt/NBTTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests to ensure that the NBT library works.
  */
-public class TestNBT {
+public class NBTTest {
   @Test public void testEqualTags() {
     CompoundTag tag1 = new CompoundTag();
     tag1.add("Name", new StringTag("minecraft:stone"));

--- a/chunky/src/test/se/llbit/chunky/renderer/BlankRenderTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/BlankRenderTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.fail;
  * The tests render using a small canvas size and with
  * only two samples per pixel.
  */
-public class TestBlankRender {
+public class BlankRenderTest {
   private static final int WIDTH = Math.max(10, Scene.MIN_CANVAS_WIDTH);
   private static final int HEIGHT = Math.max(10, Scene.MIN_CANVAS_HEIGHT);
 

--- a/chunky/src/test/se/llbit/chunky/renderer/DeadlockTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/DeadlockTest.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 /**
  * Tests for thread liveness issues in the renderer.
  */
-public class TestDeadlock {
+public class DeadlockTest {
   private static final int WIDTH = Math.max(10, Scene.MIN_CANVAS_WIDTH);
   private static final int HEIGHT = Math.max(10, Scene.MIN_CANVAS_HEIGHT);
 

--- a/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RenderDumpTests {
+public class RenderDumpTest {
   protected static final int testWidth = Scene.MIN_CANVAS_WIDTH;
   protected static final int testHeight = Scene.MIN_CANVAS_HEIGHT;
   protected static final int testSPP = 100;
@@ -95,16 +95,16 @@ public class RenderDumpTests {
   }
 
   @Test
-  public void loadClassicFormatDumpTest() throws IOException {
-    loadDumpTest("classicFormatDump");
+  public void testLoadClassicFormatDump() throws IOException {
+    testLoadDump("classicFormatDump");
   }
 
   @Test
-  public void loadCompressedFloatFormatDumpTest() throws IOException {
-    loadDumpTest("compressedFloatFormatDump");
+  public void testLoadCompressedFloatFormatDump() throws IOException {
+    testLoadDump("compressedFloatFormatDump");
   }
 
-  private void loadDumpTest(String dumpName) throws IOException {
+  private void testLoadDump(String dumpName) throws IOException {
     Scene scene = createTestScene(testWidth, testHeight, 0, 0);
     ByteArrayInputStream inputStream = new ByteArrayInputStream(getTestDump(dumpName));
     RenderDump.load(inputStream, scene, taskTracker);
@@ -114,16 +114,16 @@ public class RenderDumpTests {
   }
 
   @Test
-  public void mergeClassicFormatDumpTest() throws IOException {
-    mergeDumpTest("classicFormatDump");
+  public void testMergeClassicFormatDump() throws IOException {
+    testMergeDump("classicFormatDump");
   }
 
   @Test
-  public void mergeCompressedFloatFormatDumpTest() throws IOException {
-    mergeDumpTest("compressedFloatFormatDump");
+  public void testMergeCompressedFloatFormatDump() throws IOException {
+    testMergeDump("compressedFloatFormatDump");
   }
 
-  public void mergeDumpTest(String dumpName) throws IOException {
+  public void testMergeDump(String dumpName) throws IOException {
     int spp = 100;
     long renderTime = 123456L;
     double[] preMergeSamples = {0.5, 1.0, 2.0, 0.5, 1.0, 2.0, 2.0, 1.5, 2.5};
@@ -143,11 +143,11 @@ public class RenderDumpTests {
    * it is currently not expected to write the old format (but it would be possible)
    */
   @Test
-  public void saveCompressedFloatFormatDumpTest() throws IOException {
-    saveDumpTest("compressedFloatFormatDump");
+  public void testSaveCompressedFloatFormatDump() throws IOException {
+    testSaveDump("compressedFloatFormatDump");
   }
 
-  public void saveDumpTest(String dumpName) throws IOException {
+  public void testSaveDump(String dumpName) throws IOException {
     Scene scene = createTestScene(testWidth, testHeight, testSPP, testRenderTime);
     System.arraycopy(testSampleBuffer, 0, scene.getSampleBuffer(), 0, testSampleBuffer.length);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  * Test scene name sanitizing
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class TestSceneManager {
+public class SceneManagerTest {
 	/**
 	 * Sensitive characters are replaced by underscore
 	 */

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/SceneTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/SceneTest.java
@@ -19,7 +19,7 @@ package se.llbit.chunky.renderer.scene;
 
 import org.junit.Test;
 
-public class TestScene {
+public class SceneTest {
   /**
    * Test that modifying material properties does not throw an exception.
    *

--- a/chunky/src/test/se/llbit/fxutil/GroupedChangeListenerTest.java
+++ b/chunky/src/test/se/llbit/fxutil/GroupedChangeListenerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TestGroupedChangeListener {
+public class GroupedChangeListenerTest {
   @Test public void testRecursive() {
     BooleanProperty p1 = new SimpleBooleanProperty(false);
     BooleanProperty p2 = new SimpleBooleanProperty(false);

--- a/chunky/src/test/se/llbit/log/LogTest.java
+++ b/chunky/src/test/se/llbit/log/LogTest.java
@@ -31,7 +31,7 @@ import static com.google.common.truth.Truth.assertThat;
 /**
  * Tests for the logging utility class.
  */
-public class TestLog {
+public class LogTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private final static Receiver DO_NOTHING_RECEIVER = new Receiver() {

--- a/chunky/src/test/se/llbit/math/MutableAABBTest.java
+++ b/chunky/src/test/se/llbit/math/MutableAABBTest.java
@@ -21,8 +21,8 @@ import se.llbit.math.primitive.MutableAABB;
 
 import static org.junit.Assert.assertEquals;
 
-public class TestMutableAABB {
-  @Test public void surfaceArea() {
+public class MutableAABBTest {
+  @Test public void testSurfaceArea() {
     MutableAABB unitBox1 = new MutableAABB(0, 1, 0, 1, 0, 1);
     MutableAABB unitBox2 = new MutableAABB(-1, 0, -1, 0, -1, 0);
     MutableAABB unitBox3 = new MutableAABB(-Math.PI, 1-Math.PI, -0.5, 0.5, -0.25, 0.75);

--- a/chunky/src/test/se/llbit/math/QuickMathTest.java
+++ b/chunky/src/test/se/llbit/math/QuickMathTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
  * TODO test +-0.0 parameters
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class TestQuickMath {
+public class QuickMathTest {
 
 	/**
 	 * Test double precision minimum.

--- a/chunky/src/test/se/llbit/util/RingBufferTest.java
+++ b/chunky/src/test/se/llbit/util/RingBufferTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
-public class TestRingBuffer {
+public class RingBufferTest {
 	@Test
 	public void testEmpty() {
 		assertTrue(new RingBuffer<Integer>(10).isEmpty());


### PR DESCRIPTION
This fixes inconsistent test class naming (e.g. TestBlockPalette/PluginAPITest/RenderDumpTests) and test method naming.

Now follows the Java Unit Naming Convention https://wiki.c2.com/?JavaUnitNamingConvention
and https://stackoverflow.com/questions/3146821/naming-convention-junit-suffix-or-prefix-test

Naming schema is now:
`<<ClassName>>Test.java`
`@Test void test<<WhatIsTested>>()`