### PR TITLE
Allow negative numbers as command line arguments in options

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -1,4 +1,6 @@
-/* Copyright (c) 2014 Jesper Öqvist <jesper@llbit.se>
+/*
+ * Copyright (c) 2014 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -125,8 +125,8 @@ public class CommandLineOptions {
     }
   }
 
-  static class ArgumentError extends Exception {
-    public ArgumentError(String message) {
+  static class InvalidCommandLineArgumentsException extends IllegalArgumentException {
+    public InvalidCommandLineArgumentsException(String message) {
       super(message);
     }
   }
@@ -157,9 +157,9 @@ public class CommandLineOptions {
      *
      * @param args the arguments after the current option
      * @return the remaining arguments after removing those used by this option
-     * @throws ArgumentError
+     * @throws InvalidCommandLineArgumentsException
      */
-    List<String> handle(List<String> args) throws ArgumentError {
+    List<String> handle(List<String> args) throws InvalidCommandLineArgumentsException {
       List<String> arguments = new LinkedList<>(args);  // Create local copy to avoid side effects.
       List<String> optionArguments = new ArrayList<>();
       for (int i = 0; i < numOptions.end; i += 1) {
@@ -408,7 +408,7 @@ public class CommandLineOptions {
       if (optionHandlers.containsKey(argument)) {
         try {
           arguments = optionHandlers.get(argument).handle(arguments);
-        } catch (ArgumentError error) {
+        } catch (InvalidCommandLineArgumentsException error) {
           System.err.println(error.getMessage());
           printUsage();
           configurationError = true;

--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -44,6 +44,7 @@ import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -133,23 +134,51 @@ public class CommandLineOptions {
 
   static class OptionHandler {
     private final String flag;
-    private final Range numOptions;
+    private final Range optionRange;
+    private final BitSet numericOptionsFlags;
     private final Consumer<List<String>> consumer;
     private final Runnable errorHandler;
 
-    public OptionHandler(String flag, Range numOptions, Consumer<List<String>> consumer) {
+    public OptionHandler(
+      String flag,
+      Range optionRange,
+      int[] numericOptionsIndices,
+      Consumer<List<String>> consumer,
+      Runnable errorHandler
+    ) {
       this.flag = flag;
-      this.numOptions = numOptions;
-      this.consumer = consumer;
-      errorHandler = null;
-    }
-
-    public OptionHandler(String flag, Range numOptions, Consumer<List<String>> consumer,
-        Runnable errorHandler) {
-      this.flag = flag;
-      this.numOptions = numOptions;
+      this.optionRange = optionRange;
       this.consumer = consumer;
       this.errorHandler = errorHandler;
+      this.numericOptionsFlags = new BitSet(optionRange.end);
+      for(int index : numericOptionsIndices) {
+        if(index > optionRange.end) {
+          throw new IndexOutOfBoundsException("Numeric option index out of option range");
+        }
+        numericOptionsFlags.set(index);
+      }
+    }
+
+    public OptionHandler(
+      String flag,
+      Range optionRange,
+      int[] numericOptionsIndices,
+      Consumer<List<String>> consumer
+    ) {
+      this(flag, optionRange, numericOptionsIndices, consumer, null);
+    }
+
+    public OptionHandler(
+      String flag,
+      Range optionRange,
+      Consumer<List<String>> consumer,
+      Runnable errorHandler
+    ) {
+      this(flag, optionRange, new int[0], consumer, errorHandler);
+    }
+
+    public OptionHandler(String flag, Range optionRange, Consumer<List<String>> consumer) {
+      this(flag, optionRange, consumer, null);
     }
 
     /**
@@ -160,25 +189,41 @@ public class CommandLineOptions {
      * @throws InvalidCommandLineArgumentsException
      */
     List<String> handle(List<String> args) throws InvalidCommandLineArgumentsException {
-      List<String> arguments = new LinkedList<>(args);  // Create local copy to avoid side effects.
+      LinkedList<String> arguments = new LinkedList<>(args);  // Create local copy to avoid side effects.
       List<String> optionArguments = new ArrayList<>();
-      for (int i = 0; i < numOptions.end; i += 1) {
-        if (arguments.isEmpty() || arguments.get(0).startsWith("-")) {
-          if (i >= numOptions.start) {
-            // We don't need to have the maximum number of options.
-            break;
-          }
-          if (errorHandler != null) {
-            errorHandler.run();
-            // Skip handling the rest of the command line.
-            return Collections.emptyList();
-          } else {
-            throw new ArgumentError(String.format(
-                "Missing argument for %s option. Found %d arguments, expected %d.",
-                flag, i, numOptions.start));
+      // gather all option arguments up to the next option or until we have the maximum possible amount
+      for (int i = 0; i < optionRange.end; i += 1) {
+        if(!arguments.isEmpty()) {
+          String currentArg = arguments.peek();
+          if(!currentArg.startsWith("-")) {
+            // not an option, therefore must be an argument
+            optionArguments.add(arguments.pop());
+            continue;
+          } else if(numericOptionsFlags.get(i)) {
+            // option can be numeric at this position - we'll validate, that it indeed is a number
+            try {
+              double ignored = Double.parseDouble(currentArg);
+              optionArguments.add(arguments.pop());
+              continue;
+            } catch(NumberFormatException ignored) {
+              // looks like this is the following option - error handling below
+            }
           }
         }
-        optionArguments.add(arguments.remove(0));
+        if (i >= optionRange.start) {
+          // we don't need to have the maximum number of options
+          break;
+        }
+        if (errorHandler != null) {
+          errorHandler.run();
+          // skip handling the rest of the command line
+          return Collections.emptyList();
+        } else {
+          throw new InvalidCommandLineArgumentsException(String.format(
+            "Missing argument for %s option. Found %d arguments, expected %d.",
+            flag, i, optionRange.start
+          ));
+        }
       }
       consumer.accept(new ArrayList<>(optionArguments));  // Create copy to avoid side effects.
       return arguments;
@@ -253,7 +298,7 @@ public class CommandLineOptions {
       printAvailableScenes();
     });
 
-    registerOption("-set", new Range(2, 3), arguments -> {
+    registerOption("-set", new Range(2, 3), new int[]{1}, arguments -> {
       mode = Mode.NOTHING;
       if (arguments.size() == 3) {
         options.sceneName = arguments.get(2);
@@ -446,6 +491,12 @@ public class CommandLineOptions {
   /** Register an option handler for a single flag. */
   private void registerOption(String flag, Range numOptions, Consumer<List<String>> consumer) {
     OptionHandler handler = new OptionHandler(flag, numOptions, consumer);
+    optionHandlers.put(flag, handler);
+  }
+
+  /** Register an option handler for a single flag with numeric options. */
+  private void registerOption(String flag, Range numOptions, int[] numericOptionsIndices, Consumer<List<String>> consumer) {
+    OptionHandler handler = new OptionHandler(flag, numOptions, numericOptionsIndices, consumer);
     optionHandlers.put(flag, handler);
   }
 

--- a/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
@@ -1,4 +1,6 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/*
+ * Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2021 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
@@ -67,6 +67,10 @@ public class OptionHandlerTest {
     OptionHandler handler2 = new OptionHandler("-bart", new Range(1), this::expectBart);
     List<String> extraArgs2 = handler2.handle(Arrays.asList("bart", "foo"));
     assertThat(extraArgs2).containsExactly("foo");
+
+    OptionHandler handler = new OptionHandler("-bart", new Range(1), new int[]{0}, this::expectBart);
+    List<String> extraArgs = handler.handle(Arrays.asList("bart", "-42"));
+    assertThat(extraArgs).containsExactly("-42");
   }
 
   /** Test an option that accepts 0 to 2 arguments. */
@@ -92,6 +96,42 @@ public class OptionHandlerTest {
     assertThat(extraArgs5).containsExactly("-foo", "bar");
   }
 
+  @Test public void testArgRangeWithNumeric() throws InvalidCommandLineArgumentsException {
+    OptionHandler handler1 = new OptionHandler("-bart", new Range(0, 2), new int[]{0}, this::expectNone);
+    List<String> extraArgs1 = handler1.handle(Collections.emptyList());
+    assertThat(extraArgs1).isEmpty();
+
+    OptionHandler handler2 = new OptionHandler("-bart", new Range(0, 2), new int[]{0}, args -> {
+      assertThat(args).containsExactly("-42", "foo");
+    });
+    List<String> extraArgs2 = handler2.handle(Arrays.asList("-42", "foo"));
+    assertThat(extraArgs2).isEmpty();
+
+    OptionHandler handler3 = new OptionHandler("-bart", new Range(0, 2), new int[]{1}, args -> {
+      assertThat(args).containsExactly("foo", "-42");
+    });
+    List<String> extraArgs3 = handler3.handle(Arrays.asList("foo", "-42"));
+    assertThat(extraArgs3).isEmpty();
+
+    OptionHandler handler4 = new OptionHandler("-bart", new Range(0, 2), new int[]{1}, args -> {
+      assertThat(args).containsExactly("foo");
+    });
+    List<String> extraArgs4 = handler4.handle(Arrays.asList("foo", "-next"));
+    assertThat(extraArgs4).containsExactly("-next");
+
+    OptionHandler handler5 = new OptionHandler("-bart", new Range(0, 2), new int[]{0}, args -> {
+      assertThat(args).containsExactly("-42");
+    });
+    List<String> extraArgs5 = handler5.handle(Arrays.asList("-42", "-next"));
+    assertThat(extraArgs5).containsExactly("-next");
+
+    OptionHandler handler6 = new OptionHandler("-bart", new Range(0, 2), new int[]{0}, args -> {
+      assertThat(args).containsExactly("-42");
+    });
+    List<String> extraArgs6 = handler6.handle(Arrays.asList("-42", "-42"));
+    assertThat(extraArgs6).containsExactly("-42");
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testError_NoOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
@@ -109,5 +149,11 @@ public class OptionHandlerTest {
   public void testError_ArgumentInsteadOfOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
     handler.handle(Collections.singletonList("bort"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testError_NumberInsteadOfOptionGiven() throws InvalidCommandLineArgumentsException {
+    OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
+    handler.handle(Collections.singletonList("-42"));
   }
 }

--- a/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
@@ -19,7 +19,7 @@
 package se.llbit.chunky.main;
 
 import org.junit.Test;
-import se.llbit.chunky.main.CommandLineOptions.ArgumentError;
+import se.llbit.chunky.main.CommandLineOptions.InvalidCommandLineArgumentsException;
 import se.llbit.chunky.main.CommandLineOptions.OptionHandler;
 import se.llbit.chunky.main.CommandLineOptions.Range;
 
@@ -48,83 +48,65 @@ public class OptionHandlerTest {
     assertThat(arguments).hasSize(2);
   }
 
-  @Test public void testNoArg1() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0), arguments -> {});
-    List<String> extraArgs = handler.handle(Collections.emptyList());
-    assertThat(extraArgs).isEmpty();
-  }
+  @Test public void testOptionWithNoArgument() throws InvalidCommandLineArgumentsException {
+    OptionHandler handler1 = new OptionHandler("-bart", new Range(0), arguments -> {});
+    List<String> extraArgs1 = handler1.handle(Collections.emptyList());
+    assertThat(extraArgs1).isEmpty();
 
-  @Test public void testNoArg2() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0), arguments -> {});
+    OptionHandler handler2 = new OptionHandler("-bart", new Range(0), arguments -> {});
     // Extra arguments are ignored.
-    List<String> extraArgs = handler.handle(Arrays.asList("foo", "bar", "bork", "bork", "-spork"));
-    assertThat(extraArgs).containsExactly("foo", "bar", "bork", "bork", "-spork");
+    List<String> extraArgs2 = handler2.handle(Arrays.asList("foo", "bar", "bork", "bork", "-spork"));
+    assertThat(extraArgs2).containsExactly("foo", "bar", "bork", "bork", "-spork");
   }
 
-  @Test public void testOneArg1() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
-    List<String> extraArgs = handler.handle(Collections.singletonList("foo"));
-    assertThat(extraArgs).isEmpty();
-  }
+  @Test public void testOptionWithOneArgument() throws InvalidCommandLineArgumentsException {
+    OptionHandler handler1 = new OptionHandler("-bart", new Range(1), arguments -> {});
+    List<String> extraArgs1 = handler1.handle(Collections.singletonList("foo"));
+    assertThat(extraArgs1).isEmpty();
 
-  @Test public void testOneArg2() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
-    List<String> extraArgs = handler.handle(Arrays.asList("bart", "foo"));
-    assertThat(extraArgs).containsExactly("foo");
-  }
-
-  /** Test an option that accepts 0 to 2 arguments. */
-  @Test public void testArgRange1() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0, 2), this::expectNone);
-    List<String> extraArgs = handler.handle(Collections.emptyList());
-    assertThat(extraArgs).isEmpty();
+    OptionHandler handler2 = new OptionHandler("-bart", new Range(1), this::expectBart);
+    List<String> extraArgs2 = handler2.handle(Arrays.asList("bart", "foo"));
+    assertThat(extraArgs2).containsExactly("foo");
   }
 
   /** Test an option that accepts 0 to 2 arguments. */
-  @Test public void testArgRange2() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0, 2), this::expectOne);
-    List<String> extraArgs = handler.handle(Collections.singletonList("foo"));
-    assertThat(extraArgs).isEmpty();
+  @Test public void testOptionArgumentRanges() throws InvalidCommandLineArgumentsException {
+    OptionHandler handler1 = new OptionHandler("-bart", new Range(0, 2), this::expectNone);
+    List<String> extraArgs1 = handler1.handle(Collections.emptyList());
+    assertThat(extraArgs1).isEmpty();
+
+    OptionHandler handler2 = new OptionHandler("-bart", new Range(0, 2), this::expectOne);
+    List<String> extraArgs2 = handler2.handle(Collections.singletonList("foo"));
+    assertThat(extraArgs2).isEmpty();
+
+    OptionHandler handler3 = new OptionHandler("-bart", new Range(0, 2), this::expectTwo);
+    List<String> extraArgs3 = handler3.handle(Arrays.asList("bart", "foo"));
+    assertThat(extraArgs3).isEmpty();
+
+    OptionHandler handler4 = new OptionHandler("-bart", new Range(0, 2), this::expectOne);
+    List<String> extraArgs4 = handler4.handle(Arrays.asList("foo", "-foo"));
+    assertThat(extraArgs4).containsExactly("-foo");
+
+    OptionHandler handler5 = new OptionHandler("-bart", new Range(0, 2), this::expectTwo);
+    List<String> extraArgs5 = handler5.handle(Arrays.asList("baz", "foo", "-foo", "bar"));
+    assertThat(extraArgs5).containsExactly("-foo", "bar");
   }
 
-  /** Test an option that accepts 0 to 2 arguments. */
-  @Test public void testArgRange3() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0, 2), this::expectTwo);
-    List<String> extraArgs = handler.handle(Arrays.asList("bart", "foo"));
-    assertThat(extraArgs).isEmpty();
-  }
-
-  /** Test an option that accepts 0 to 2 arguments. */
-  @Test public void testArgRange4() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0, 2), this::expectOne);
-    List<String> extraArgs = handler.handle(Arrays.asList("foo", "-foo"));
-    assertThat(extraArgs).containsExactly("-foo");
-  }
-
-  /** Test an option that accepts 0 to 2 arguments. */
-  @Test public void testArgRange5() throws ArgumentError {
-    OptionHandler handler = new OptionHandler("-bart", new Range(0, 2), this::expectTwo);
-    List<String> extraArgs = handler.handle(Arrays.asList("baz", "foo", "-foo", "bar"));
-    assertThat(extraArgs).containsExactly("-foo", "bar");
-  }
-
-  /** Test missing option argument. */
-  @Test(expected = ArgumentError.class)
-  public void testError01() throws ArgumentError {
+  @Test(expected = IllegalArgumentException.class)
+  public void testError_NoOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
     handler.handle(Collections.emptyList());
   }
 
-  /** Test missing option argument. */
-  @Test(expected = ArgumentError.class)
-  public void testError1() throws ArgumentError {
+  @Test(expected = IllegalArgumentException.class)
+  public void testError_WrongOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
     // The -bort argument is treated as a separate option.
     handler.handle(Collections.singletonList("-bort"));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testError02() throws ArgumentError {
+  public void testError_ArgumentInsteadOfOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
     handler.handle(Collections.singletonList("bort"));
   }


### PR DESCRIPTION
Allows negative numbers for _value_ in `-set <NAME> <VALUE> [<SCENE>]`
Fixes #1030 