### PR TITLE
Fix parallel projection clipping issue.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -696,8 +696,7 @@ public class Scene implements JsonSerializable, Refreshable {
     state.ray.o.y -= origin.y;
     state.ray.o.z -= origin.z;
 
-    if(camera.getProjectionMode() == ProjectionMode.PARALLEL
-      && worldOctree.isInside(state.ray.o)) {
+    if(camera.getProjectionMode() == ProjectionMode.PARALLEL) {
       // When in parallel projection, push the ray origin back so the
       // ray start outside the octree to prevent ray spawning inside some blocks
       int limit = (1 << worldOctree.getDepth());


### PR DESCRIPTION
Fix parallel camera clipping when the camera plane is outside the octree.
2.4.0:
![image](https://user-images.githubusercontent.com/42661490/138150979-4ce93cb9-e74a-4a10-9030-f8b33f5c4fec.png)

Fix:
![image](https://user-images.githubusercontent.com/42661490/138151334-61034152-6d40-48b6-b03b-15b3cdd193bc.png)

