### PR TITLE
Rename getN to getNormal.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Lava.java
+++ b/chunky/src/java/se/llbit/chunky/block/Lava.java
@@ -52,9 +52,7 @@ public class Lava extends MinecraftBlockTranslucent {
 
     boolean hit = false;
     if (bottom.intersect(ray)) {
-      Vector3 n = new Vector3(bottom.n);
-      n.scale(-QuickMath.signum(ray.d.dot(bottom.n)));
-      ray.setN(n);
+      ray.orientNormal(bottom.n);
       ray.t = ray.tNext;
       hit = true;
     }
@@ -65,17 +63,13 @@ public class Lava extends MinecraftBlockTranslucent {
     int c3 = (0xF & (data >> CORNER_3)) % 8;
     Triangle triangle = Water.t012[c0][c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = Water.t230[c2][c3][c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -83,9 +77,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.westt[c0][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double y = ray.t * ray.d.y + ray.o.y;
       double z = ray.t * ray.d.z + ray.o.z;
@@ -97,9 +89,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.westb[c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double y = ray.t * ray.d.y + ray.o.y;
       double z = ray.t * ray.d.z + ray.o.z;
@@ -111,9 +101,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.eastt[c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double y = ray.t * ray.d.y + ray.o.y;
       double z = ray.t * ray.d.z + ray.o.z;
@@ -125,9 +113,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.eastb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double y = ray.t * ray.d.y + ray.o.y;
       double z = ray.t * ray.d.z + ray.o.z;
@@ -139,9 +125,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.southt[c0][c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double x = ray.t * ray.d.x + ray.o.x;
       double y = ray.t * ray.d.y + ray.o.y;
@@ -153,9 +137,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.southb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double x = ray.t * ray.d.x + ray.o.x;
       double y = ray.t * ray.d.y + ray.o.y;
@@ -167,9 +149,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.northt[c2][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double x = ray.t * ray.d.x + ray.o.x;
       double y = ray.t * ray.d.y + ray.o.y;
@@ -181,9 +161,7 @@ public class Lava extends MinecraftBlockTranslucent {
     }
     triangle = Water.northb[c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       double x = ray.t * ray.d.x + ray.o.x;
       double y = ray.t * ray.d.y + ray.o.y;

--- a/chunky/src/java/se/llbit/chunky/block/Water.java
+++ b/chunky/src/java/se/llbit/chunky/block/Water.java
@@ -184,9 +184,7 @@ public class Water extends MinecraftBlockTranslucent {
         if (quad.intersect(ray)) {
           texture.getAvgColorLinear(ray.color);
           ray.t = ray.tNext;
-          Vector3 n = new Vector3(quad.n);
-          n.scale(-QuickMath.signum(ray.d.dot(quad.n)));
-          ray.setN(n);
+          ray.orientNormal(quad.n);
           hit = true;
         }
       }
@@ -199,9 +197,7 @@ public class Water extends MinecraftBlockTranslucent {
 
     boolean hit = false;
     if (bottom.intersect(ray)) {
-      Vector3 n = new Vector3(bottom.n);
-      n.scale(-QuickMath.signum(ray.d.dot(bottom.n)));
-      ray.setN(n);
+      ray.orientNormal(bottom.n);
       ray.t = ray.tNext;
       hit = true;
     }
@@ -212,17 +208,13 @@ public class Water extends MinecraftBlockTranslucent {
     int c3 = (0xF & (data >> CORNER_3)) % 8;
     Triangle triangle = t012[c0][c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = t230[c2][c3][c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -230,17 +222,13 @@ public class Water extends MinecraftBlockTranslucent {
     }
     triangle = westt[c0][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = westb[c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -248,17 +236,13 @@ public class Water extends MinecraftBlockTranslucent {
     }
     triangle = eastt[c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = eastb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -266,17 +250,13 @@ public class Water extends MinecraftBlockTranslucent {
     }
     triangle = southt[c0][c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = southb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -284,17 +264,13 @@ public class Water extends MinecraftBlockTranslucent {
     }
     triangle = northt[c2][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = northb[c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;

--- a/chunky/src/java/se/llbit/chunky/model/AABBModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AABBModel.java
@@ -61,7 +61,7 @@ public abstract class AABBModel implements BlockModel {
     for (int i = 0; i < boxes.length; ++i) {
       if (boxes[i].intersect(ray)) {
         Tint[] tintedFacesBox = tintedFaces != null ? tintedFaces[i] : null;
-        Vector3 n = ray.getN();
+        Vector3 n = ray.getNormal();
         if (n.y > 0) { // top
           ray.v = 1 - ray.v;
           if (intersectFace(ray, scene, textures[i][4],

--- a/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
@@ -62,7 +62,10 @@ public abstract class AnimatedQuadModel extends QuadModel {
           tint.tint(c, ray, scene);
           color = c;
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          if (quad.doubleSided)
+            ray.orientNormal(quad.n);
+          else
+            ray.setNormal(quad.n);
           hit = true;
         }
       }

--- a/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/CauldronModel.java
@@ -368,7 +368,7 @@ public class CauldronModel {
         if (color[3] > Ray.EPSILON) {
           ray.color.set(color);
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          ray.setNormal(quad.n);
           hit = true;
         }
       }
@@ -380,7 +380,7 @@ public class CauldronModel {
       if (color[3] > Ray.EPSILON) {
         ray.color.set(color);
         ray.t = ray.tNext;
-        ray.setN(water.n);
+        ray.setNormal(water.n);
         hit = true;
       }
     }
@@ -402,7 +402,7 @@ public class CauldronModel {
         if (color[3] > Ray.EPSILON) {
           ray.color.set(color);
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          ray.setNormal(quad.n);
           hit = true;
         }
       }
@@ -414,7 +414,7 @@ public class CauldronModel {
       if (!stillWater) {
         WaterModel.doWaterDisplacement(ray);
       } else {
-        ray.setN(water.n);
+        ray.setNormal(water.n);
       }
       ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());
       ray.setCurrentMaterial(Water.INSTANCE);
@@ -438,7 +438,7 @@ public class CauldronModel {
         if (color[3] > Ray.EPSILON) {
           ray.color.set(color);
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          ray.setNormal(quad.n);
           hit = true;
         }
       }
@@ -450,7 +450,7 @@ public class CauldronModel {
       if (color[3] > Ray.EPSILON) {
         ray.color.set(color);
         ray.t = ray.tNext;
-        ray.setN(lava.n);
+        ray.setNormal(lava.n);
         hit = true;
 
         // set the current material to lava so that only the lava is emissive and not the cauldron

--- a/chunky/src/java/se/llbit/chunky/model/HoneyBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/HoneyBlockModel.java
@@ -97,7 +97,7 @@ public class HoneyBlockModel {
                 float[] color = tex[i].getColor(ray.u, ray.v);
                 if (color[3] > Ray.EPSILON) {
                     ColorUtil.overlayColor(ray.color, color);
-                    ray.setN(quad.n);
+                    ray.setNormal(quad.n);
                     ray.t = ray.tNext;
                     hit = true;
                 }
@@ -115,7 +115,7 @@ public class HoneyBlockModel {
                 float[] color = tex[i].getColor(ray.u, ray.v);
                 if (color[3] > Ray.EPSILON) {
                     ColorUtil.overlayColor(ray.color, color);
-                    ray.setN(quad.n);
+                    ray.setNormal(quad.n);
                     ray.t = ray.tNext;
                     hit = true;
                 }

--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -48,11 +48,10 @@ public abstract class QuadModel implements BlockModel {
           tint.tint(c, ray, scene);
           color = c;
           ray.t = ray.tNext;
-          Vector3 n = new Vector3(quad.n);
-          if (quad.doubleSided) {
-            n.scale(QuickMath.signum(-ray.d.dot(quad.n)));
-          }
-          ray.setN(n);
+          if (quad.doubleSided)
+            ray.orientNormal(quad.n);
+          else
+            ray.setNormal(quad.n);
           hit = true;
         }
       }

--- a/chunky/src/java/se/llbit/chunky/model/SlimeBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/SlimeBlockModel.java
@@ -95,7 +95,7 @@ public class SlimeBlockModel {
                 float[] color = tex[i].getColor(ray.u, ray.v);
                 if (color[3] > Ray.EPSILON) {
                     ColorUtil.overlayColor(ray.color, color);
-                    ray.setN(quad.n);
+                    ray.setNormal(quad.n);
                     ray.t = ray.tNext;
                     hit = true;
                 }
@@ -113,7 +113,7 @@ public class SlimeBlockModel {
                 float[] color = tex[i].getColor(ray.u, ray.v);
                 if (color[3] > Ray.EPSILON) {
                     ColorUtil.overlayColor(ray.color, color);
-                    ray.setN(quad.n);
+                    ray.setNormal(quad.n);
                     ray.t = ray.tNext;
                     hit = true;
                 }

--- a/chunky/src/java/se/llbit/chunky/model/SpriteModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/SpriteModel.java
@@ -81,7 +81,10 @@ public class SpriteModel extends QuadModel {
         if (color[3] > Ray.EPSILON) {
           ray.color.set(color);
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          if (quad.doubleSided)
+            ray.orientNormal(quad.n);
+          else
+            ray.setNormal(quad.n);
           hit = true;
         }
       }
@@ -102,7 +105,10 @@ public class SpriteModel extends QuadModel {
         if (color[3] > Ray.EPSILON) {
           ray.color.set(color);
           ray.t = ray.tNext;
-          ray.setN(quad.n);
+          if (quad.doubleSided)
+            ray.orientNormal(quad.n);
+          else
+            ray.setNormal(quad.n);
           hit = true;
         }
       }

--- a/chunky/src/java/se/llbit/chunky/model/TexturedBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/TexturedBlockModel.java
@@ -75,7 +75,7 @@ public class TexturedBlockModel extends AABBModel {
     int bx = (int) QuickMath.floor(ray.o.x);
     int by = (int) QuickMath.floor(ray.o.y);
     int bz = (int) QuickMath.floor(ray.o.z);
-    Vector3 n = ray.getN();
+    Vector3 n = ray.getNormal();
     if (n.y != 0) {
       ray.u = ray.o.x - bx;
       ray.v = ray.o.z - bz;

--- a/chunky/src/java/se/llbit/chunky/model/TorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/TorchModel.java
@@ -120,50 +120,6 @@ public class TorchModel extends QuadModel {
     this.rotation = rotation;
   }
 
-  public static boolean intersect(Ray ray, Texture texture) {
-    int rot = ray.getBlockData() % 6;
-    return intersect(ray, texture, rot);
-  }
-
-  public static boolean intersect(Ray ray, Texture texture, int rot) {
-    boolean hit = false;
-    ray.t = Double.POSITIVE_INFINITY;
-    float[] color = null;
-    Quad[] quads = rot < 5 ? rotatedQuadsWall[rot] : quadsGround;
-    for (Quad quad : quads) {
-      if (quad.intersect(ray)) {
-        float[] c = texture.getColor(ray.u, ray.v);
-        if (c[3] > Ray.EPSILON) {
-          color = c;
-          ray.setN(quad.n);
-          ray.t = ray.tNext;
-          hit = true;
-        }
-      }
-    }
-    if (hit) {
-      if (rot < 5) {
-        // the wall torch model goes out of the 1x1x1 block range so we need to check if the hit
-        // is actually inside of the block and ignore it if it doesn't
-        double px = ray.o.x - Math.floor(ray.o.x + ray.d.x * Ray.OFFSET) + ray.d.x * ray.tNext;
-        double py = ray.o.y - Math.floor(ray.o.y + ray.d.y * Ray.OFFSET) + ray.d.y * ray.tNext;
-        double pz = ray.o.z - Math.floor(ray.o.z + ray.d.z * Ray.OFFSET) + ray.d.z * ray.tNext;
-        if (px >= 0 && px <= 1 && py >= 0 && py <= 1 && pz >= 0 && pz <= 1) {
-          ray.color.set(color);
-          ray.distance += ray.t;
-          ray.o.scaleAdd(ray.t, ray.d);
-          return true;
-        }
-      } else {
-        ray.color.set(color);
-        ray.distance += ray.t;
-        ray.o.scaleAdd(ray.t, ray.d);
-        return true;
-      }
-    }
-    return false;
-  }
-
   @Override
   public Quad[] getQuads() {
     if (rotation < 5) {

--- a/chunky/src/java/se/llbit/chunky/model/WaterModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/WaterModel.java
@@ -186,9 +186,7 @@ public class WaterModel {
         if (quad.intersect(ray)) {
           Texture.water.getAvgColorLinear(ray.color);
           ray.t = ray.tNext;
-          Vector3 n = new Vector3(quad.n);
-          n.scale(-QuickMath.signum(ray.d.dot(quad.n)));
-          ray.setN(n);
+          ray.orientNormal(quad.n);
           hit = true;
         }
       }
@@ -201,9 +199,7 @@ public class WaterModel {
 
     boolean hit = false;
     if (bot.intersect(ray)) {
-      Vector3 n = new Vector3(bot.n);
-      n.scale(-QuickMath.signum(ray.d.dot(bot.n)));
-      ray.setN(n);
+      ray.orientNormal(bot.n);
       ray.t = ray.tNext;
       hit = true;
     }
@@ -214,17 +210,13 @@ public class WaterModel {
     int c3 = (0xF & (data >> 28)) % 8;
     Triangle triangle = t012[c0][c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = t230[c2][c3][c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -232,17 +224,13 @@ public class WaterModel {
     }
     triangle = westt[c0][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = westb[c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -250,17 +238,13 @@ public class WaterModel {
     }
     triangle = eastt[c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = eastb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -268,17 +252,13 @@ public class WaterModel {
     }
     triangle = southt[c0][c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = southb[c1];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -286,17 +266,13 @@ public class WaterModel {
     }
     triangle = northt[c2][c3];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = northb[c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -322,17 +298,13 @@ public class WaterModel {
     int c3 = (0xF & (data >> 28)) % 8;
     Triangle triangle = t012[c0][c1][c2];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       hit = true;
     }
     triangle = t230[c2][c3][c0];
     if (triangle.intersect(ray)) {
-      Vector3 n = new Vector3(triangle.n);
-      n.scale(-QuickMath.signum(ray.d.dot(triangle.n)));
-      ray.setN(n);
+      ray.orientNormal(triangle.n);
       ray.t = ray.tNext;
       ray.u = 1 - ray.u;
       ray.v = 1 - ray.v;
@@ -364,6 +336,6 @@ public class WaterModel {
     n.x += normalMap[(u*normalMapW + v) * 2] / 2;
     n.z += normalMap[(u*normalMapW + v) * 2 + 1] / 2;
     n.normalize();
-    ray.setShadingN(n.x, n.y, n.z);
+    ray.setShadingNormal(n.x, n.y, n.z);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/TileBasedRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/TileBasedRenderer.java
@@ -19,9 +19,6 @@ package se.llbit.chunky.renderer;
 import it.unimi.dsi.fastutil.ints.IntIntMutablePair;
 import it.unimi.dsi.fastutil.ints.IntIntPair;
 import org.apache.commons.math3.util.FastMath;
-import se.llbit.chunky.renderer.DefaultRenderManager;
-import se.llbit.chunky.renderer.Renderer;
-import se.llbit.chunky.renderer.WorkerState;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.math.Ray;
 
@@ -74,7 +71,7 @@ public abstract class TileBasedRenderer implements Renderer {
         manager.pool.submit(worker -> {
           WorkerState state = new WorkerState();
           state.ray = new Ray();
-          state.ray.setN(0, 0, -1);
+          state.ray.setNormal(0, 0, -1);
           state.random = worker.random;
 
           IntIntMutablePair pair = new IntIntMutablePair(0, 0);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -95,7 +95,7 @@ public class PathTracer implements RayTracer {
       Material currentMat = ray.getCurrentMaterial();
       Material prevMat = ray.getPrevMaterial();
 
-      if (!scene.stillWater && ray.getN().y != 0 &&
+      if (!scene.stillWater && ray.getNormal().y != 0 &&
           ((currentMat.isWater() && prevMat == Air.INSTANCE)
               || (currentMat == Air.INSTANCE && prevMat.isWater()))) {
         WaterModel.doWaterDisplacement(ray);
@@ -199,13 +199,13 @@ public class PathTracer implements RayTracer {
               double directLightG = 0;
               double directLightB = 0;
 
-              boolean frontLight = reflected.d.dot(ray.getN()) > 0;
+              boolean frontLight = reflected.d.dot(ray.getNormal()) > 0;
 
               if (frontLight || (currentMat.subSurfaceScattering
                   && random.nextFloat() < Scene.fSubSurface)) {
 
                 if (!frontLight) {
-                  reflected.o.scaleAdd(-Ray.OFFSET, ray.getN());
+                  reflected.o.scaleAdd(-Ray.OFFSET, ray.getNormal());
                 }
 
                 reflected.setCurrentMaterial(reflected.getPrevMaterial(), reflected.getPrevData());
@@ -214,7 +214,7 @@ public class PathTracer implements RayTracer {
 
                 Vector4 attenuation = state.attenuation;
                 if (attenuation.w > 0) {
-                  double mult = QuickMath.abs(reflected.d.dot(ray.getN()));
+                  double mult = QuickMath.abs(reflected.d.dot(ray.getNormal()));
                   directLightR = attenuation.x * attenuation.w * mult;
                   directLightG = attenuation.y * attenuation.w * mult;
                   directLightB = attenuation.z * attenuation.w * mult;
@@ -266,7 +266,7 @@ public class PathTracer implements RayTracer {
 
           // Refraction.
           float n1n2 = n1 / n2;
-          double cosTheta = -ray.getN().dot(ray.d);
+          double cosTheta = -ray.getNormal().dot(ray.d);
           double radicand = 1 - n1n2 * n1n2 * (1 - cosTheta * cosTheta);
           if (doRefraction && radicand < Ray.EPSILON) {
             // Total internal reflection.
@@ -308,7 +308,7 @@ public class PathTracer implements RayTracer {
                 if (doRefraction) {
 
                   double t2 = FastMath.sqrt(radicand);
-                  Vector3 n = ray.getN();
+                  Vector3 n = ray.getNormal();
                   if (cosTheta > 0) {
                     refracted.d.x = n1n2 * ray.d.x + (n1n2 * cosTheta - t2) * n.x;
                     refracted.d.y = n1n2 * ray.d.y + (n1n2 * cosTheta - t2) * n.y;
@@ -324,9 +324,9 @@ public class PathTracer implements RayTracer {
                   // See Ray.specularReflection for information on why this is needed
                   // This is the same thing but for refraction instead of reflection
                   // so this time we want the signs of the dot product to be the same
-                  if(QuickMath.signum(refracted.getGeomN().dot(refracted.d)) != QuickMath.signum(refracted.getGeomN().dot(ray.d))) {
-                    double factor = QuickMath.signum(refracted.getGeomN().dot(ray.d)) * -Ray.EPSILON - refracted.d.dot(refracted.getGeomN());
-                    refracted.d.scaleAdd(factor, refracted.getGeomN());
+                  if(QuickMath.signum(refracted.getGeometryNormal().dot(refracted.d)) != QuickMath.signum(refracted.getGeometryNormal().dot(ray.d))) {
+                    double factor = QuickMath.signum(refracted.getGeometryNormal().dot(ray.d)) * -Ray.EPSILON - refracted.d.dot(refracted.getGeometryNormal());
+                    refracted.d.scaleAdd(factor, refracted.getGeometryNormal());
                     refracted.d.normalize();
                   }
 
@@ -451,7 +451,7 @@ public class PathTracer implements RayTracer {
     emitterRay.d.sub(emitterRay.o);
     double distance = emitterRay.d.length();
     emitterRay.d.normalize();
-    double indirectEmitterCoef = emitterRay.d.dot(emitterRay.getN());
+    double indirectEmitterCoef = emitterRay.d.dot(emitterRay.getNormal());
     if(indirectEmitterCoef > 0) {
       // Here We need to invert the material.
       // The fact that the dot product is > 0 guarantees that the ray is going away from the surface

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -122,7 +122,7 @@ public class PreviewRayTracer implements RayTracer {
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
-        ray.setN(0, 1, 0);
+        ray.setNormal(0, 1, 0);
         ray.setCurrentMaterial(scene.getPalette().water);
         return true;
       }
@@ -131,7 +131,7 @@ public class PreviewRayTracer implements RayTracer {
       if (t > 0 && t < ray.t) {
         ray.t = t;
         Water.INSTANCE.getColor(ray);
-        ray.setN(0, -1, 0);
+        ray.setNormal(0, -1, 0);
         ray.setCurrentMaterial(Air.INSTANCE);
         return true;
       }
@@ -191,7 +191,7 @@ public class PreviewRayTracer implements RayTracer {
         }
         // handle like a solid horizontal plane
         ray.setCurrentMaterial(MinecraftBlock.STONE);
-        ray.setN(0, 1, 0);
+        ray.setNormal(0, 1, 0);
         return true;
       }
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -51,8 +51,6 @@ import se.llbit.chunky.block.*;
 import se.llbit.chunky.block.legacy.LegacyBlocksFinalizer;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
-import se.llbit.chunky.chunk.GenericChunkData;
-import se.llbit.chunky.chunk.SimpleChunkData;
 import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.Entity;
 import se.llbit.chunky.entity.Lectern;
@@ -784,7 +782,7 @@ public class Scene implements JsonSerializable, Refreshable {
     r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
     if (worldOctree.enterBlock(this, r, palette) && r.distance < ray.t) {
       ray.t = r.distance;
-      ray.setN(r.getN());
+      ray.setNormal(r.getNormal());
       ray.color.set(r.color);
       ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
       ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
@@ -795,7 +793,7 @@ public class Scene implements JsonSerializable, Refreshable {
       r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
       if(waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
         ray.t = r.distance;
-        ray.setN(r.getN());
+        ray.setNormal(r.getNormal());
         ray.color.set(r.color);
         ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
         ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
@@ -808,7 +806,7 @@ public class Scene implements JsonSerializable, Refreshable {
       r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
       if (waterOctree.enterBlock(this, r, palette) && r.distance < ray.t) {
         ray.t = r.distance;
-        ray.setN(r.getN());
+        ray.setNormal(r.getNormal());
         ray.color.set(r.color);
         ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
         ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -883,7 +883,7 @@ public class Sky implements JsonSerializable {
       // Ray is entering cloud.
       if (inCloud((ray.d.x * t_offset + ox) * inv_size + offsetX,
           (ray.d.z * t_offset + oz) * inv_size + offsetZ)) {
-        ray.setN(0, -Math.signum(ray.d.y), 0);
+        ray.setNormal(0, -Math.signum(ray.d.y), 0);
         enterCloud(ray, t_offset);
         return true;
       }
@@ -1008,7 +1008,7 @@ public class Sky implements JsonSerializable {
         // fix ray.n being set to zero (issue #643)
         return false;
       }
-      ray.setN(nx, ny, nz);
+      ray.setNormal(nx, ny, nz);
       enterCloud(ray, t + t_offset);
       return true;
     } else {
@@ -1025,7 +1025,7 @@ public class Sky implements JsonSerializable {
         // fix ray.n being set to zero (issue #643)
         return false;
       }
-      ray.setN(nx, ny, nz);
+      ray.setNormal(nx, ny, nz);
       exitCloud(ray, t);
     }
     return true;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -268,7 +268,7 @@ public class Sun implements JsonSerializable {
    * Calculate flat shading for ray.
    */
   public void flatShading(Ray ray) {
-    Vector3 n = ray.getN();
+    Vector3 n = ray.getNormal();
     double shading = n.x * sw.x + n.y * sw.y + n.z * sw.z;
     shading = QuickMath.max(AMBIENT, shading);
     ray.color.x *= emittance.x * shading;

--- a/chunky/src/java/se/llbit/math/AABB.java
+++ b/chunky/src/java/se/llbit/math/AABB.java
@@ -66,7 +66,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = u;
         ray.v = v;
-        ray.setN(-1, 0, 0);
+        ray.setNormal(-1, 0, 0);
       }
     }
     t = (xmax - ix) / ray.d.x;
@@ -79,7 +79,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = 1 - u;
         ray.v = v;
-        ray.setN(1, 0, 0);
+        ray.setNormal(1, 0, 0);
       }
     }
     t = (ymin - iy) / ray.d.y;
@@ -92,7 +92,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = u;
         ray.v = v;
-        ray.setN(0, -1, 0);
+        ray.setNormal(0, -1, 0);
       }
     }
     t = (ymax - iy) / ray.d.y;
@@ -105,7 +105,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = u;
         ray.v = v;
-        ray.setN(0, 1, 0);
+        ray.setNormal(0, 1, 0);
       }
     }
     t = (zmin - iz) / ray.d.z;
@@ -118,7 +118,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = 1 - u;
         ray.v = v;
-        ray.setN(0, 0, -1);
+        ray.setNormal(0, 0, -1);
       }
     }
     t = (zmax - iz) / ray.d.z;
@@ -131,7 +131,7 @@ public class AABB {
         ray.tNext = t;
         ray.u = u;
         ray.v = v;
-        ray.setN(0, 0, 1);
+        ray.setNormal(0, 0, 1);
       }
     }
     return hit;

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import it.unimi.dsi.fastutil.ints.IntIntMutablePair;
-import it.unimi.dsi.fastutil.ints.IntObjectImmutablePair;
 import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import org.apache.commons.math3.util.FastMath;
@@ -464,7 +463,7 @@ public class Octree {
       return false;
 
     ray.o.scaleAdd(tMin, ray.d);
-    ray.setN(nx, ny, nz);
+    ray.setNormal(nx, ny, nz);
     ray.distance += tMin;
     return true;
   }
@@ -609,7 +608,7 @@ public class Octree {
         nx = ny = 0;
       }
 
-      ray.setN(nx, ny, nz);
+      ray.setNormal(nx, ny, nz);
 
       distance = tNear;
     }
@@ -735,7 +734,7 @@ public class Octree {
       }
 
       ray.o.scaleAdd(tNear, ray.d);
-      ray.setN(nx, ny, nz);
+      ray.setNormal(nx, ny, nz);
       ray.distance += tNear;
     }
   }

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -530,26 +530,56 @@ public class Ray {
   public int getCurrentData() {
     return currentData;
   }
-  
-  public Vector3 getN() {
+
+  /**
+   * Get the normal of the previously hit surface.
+   */
+  public Vector3 getNormal() {
     return n;
   }
-
-  public Vector3 getGeomN() {
+  /**
+   * Get the geometric normal of the previously hit surface. When using normal maps,
+   * this is the normal of the geometry that was hit, not taking the normal map into account.
+   */
+  public Vector3 getGeometryNormal() {
     return geomN;
   }
 
-  public void setN(double x, double y, double z) {
+  /**
+   * Set the geometry normal (not taking normal mapping into account)
+   * and the shading normal (taking normal mapping into account)
+   */
+  public void setNormal(double x, double y, double z) {
     n.set(x, y, z);
     geomN.set(x, y, z);
   }
 
-  public void setN(Vector3 newN) {
+  /**
+   * Set the geometry normal (not taking normal mapping into account)
+   * and the shading normal (taking normal mapping into account)
+   */
+  public void setNormal(Vector3 newN) {
     n.set(newN);
     geomN.set(newN);
   }
 
-  public void setShadingN(double x, double y, double z) {
+  /**
+   * Sets n to the given value and optionally flip it so the normal
+   * is in the opposite direction as the ray direction (dot(d, n) < 0)
+   */
+  public void orientNormal(Vector3 normal) {
+    if(d.dot(normal) > 0) {
+      n.set(-normal.x, -normal.y, -normal.z);
+    } else {
+      n.set(normal);
+    }
+    geomN.set(n);
+  }
+
+  /**
+   * Set the shading normal (taking normal mapping into account)
+   */
+  public void setShadingNormal(double x, double y, double z) {
     n.set(x, y, z);
   }
 

--- a/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
+++ b/chunky/src/java/se/llbit/math/primitive/TexturedTriangle.java
@@ -124,7 +124,7 @@ public class TexturedTriangle implements Primitive {
         ray.color.set(color);
         ray.setCurrentMaterial(material);
         ray.t = t;
-        ray.setN(n);
+        ray.setNormal(n);
         return true;
       }
     }


### PR DESCRIPTION
This was unintentionally changed in #901. Change `Ray.getN()` back to `Ray.getNormal()` to fix compatibility with plugins such as denoiser. Also re-add `Ray.orientNormal(...)` which saves on a `Vector3` allocation which should improve rendering performance. Clean up the old intersection logic from `TorchModel` which was not being used.