### PR TITLE
Fix issues when using Chunky as a library

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -110,8 +110,11 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
       synchronized (storedScene) {
         String sceneName = storedScene.name();
         Log.info("Saving scene " + sceneName);
-        File sceneDir = resolveSceneDirectory(sceneName);
-        context.setSceneDirectory(sceneDir);
+        File sceneDir = context.getSceneDirectory();
+        if (!sceneDir.isDirectory()) {
+          sceneDir = resolveSceneDirectory(sceneName);
+          context.setSceneDirectory(sceneDir);
+        }
         if (!sceneDir.isDirectory()) {
           boolean success = sceneDir.mkdirs();
           if (!success) {
@@ -143,7 +146,10 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
     // Lock order: scene -> storedScene.
     synchronized (scene) {
       try (TaskTracker.Task ignored = taskTracker.task("Loading scene", 1)) {
-        context.setSceneDirectory(resolveSceneDirectory(sceneName));
+        File sceneDirectory = resolveSceneDirectory(sceneName);
+        if (sceneDirectory.isDirectory()) {
+          context.setSceneDirectory(sceneDirectory);
+        }
         scene.loadScene(context, sceneName, taskTracker);
       }
 

--- a/chunky/src/java/se/llbit/chunky/world/MaterialStore.java
+++ b/chunky/src/java/se/llbit/chunky/world/MaterialStore.java
@@ -16,8 +16,8 @@
  */
 package se.llbit.chunky.world;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import se.llbit.chunky.block.Block;
@@ -25,5 +25,5 @@ import se.llbit.chunky.block.Block;
 // TODO: introduce block tags
 public class MaterialStore {
   public static final Map<String, Collection<Block>> collections = new LinkedHashMap<>();
-  public static final Collection<String> blockIds = new ArrayList<>();
+  public static final Collection<String> blockIds = new HashSet<>();
 }


### PR DESCRIPTION
This PR fixes some issues that happen when embedding Chunky in another tool (e.g. ChunkyCloud or ChunkyMap) and creating new `Chunky` instances.

Makes #670 pretty much obsolete.