### PR TITLE
Fix Mushroom Block and Cartography Table.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -2344,8 +2344,8 @@ public class MinecraftBlockProvider implements BlockProvider {
             name,
             Texture.cartographyTableSide3,
             Texture.cartographyTableSide1,
-            Texture.cartographyTableSide2,
             Texture.cartographyTableSide3,
+            Texture.cartographyTableSide2,
             Texture.cartographyTableTop,
             Texture.darkOakPlanks);
       case "fletching_table":
@@ -2957,8 +2957,8 @@ public class MinecraftBlockProvider implements BlockProvider {
         name,
         north.equals("true") ? skin : Texture.mushroomPores,
         south.equals("true") ? skin : Texture.mushroomPores,
-        west.equals("true") ? skin : Texture.mushroomPores,
         east.equals("true") ? skin : Texture.mushroomPores,
+        west.equals("true") ? skin : Texture.mushroomPores,
         up.equals("true") ? skin : Texture.mushroomPores,
         down.equals("true") ? skin : Texture.mushroomPores);
   }


### PR DESCRIPTION
Mushroom block and cartography table had their east and west texture swapped.

Before:
![block_315_minecraft_cartography_table](https://user-images.githubusercontent.com/42661490/143160371-28b3b84c-228e-4722-a257-cf657c31b993.png)
Now:
![image](https://user-images.githubusercontent.com/42661490/143160362-9be89346-f671-4ffc-a38b-ce45b3cdef28.png)
