### PR TITLE
Basic support of the new block data location in 1.18

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -286,10 +286,7 @@ public class Chunk {
         if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
           continue; //skip parsing sections that are outside requested bounds
 
-        Tag paletteTag = getTagFromNames(section, "Palette", "block_states");
-        if(paletteTag.isCompoundTag()) {
-          paletteTag = paletteTag.get("palette");
-        }
+        Tag paletteTag = getTagFromNames(section, "Palette", "block_states.palette");
         if (paletteTag.isList()) {
           ListTag palette = paletteTag.asList();
           // Bits per block:
@@ -299,19 +296,16 @@ public class Chunk {
           }
 
           int dataSize = (4096 * bpb) / 64;
-          Tag blockData = getTagFromNames(section, "BlockStates", "block_states");
-          if(blockData.isCompoundTag()) {
-            blockData = blockData.get("data");
-          }
+          Tag blockStates = getTagFromNames(section, "Palette", "block_states.data");
 
-          if (blockData.isLongArray(dataSize)) {
+          if (blockStates.isLongArray(dataSize)) {
             // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
             // unused bits per block state; if so, the array is longer than the expected data size
             boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20W17A;
             if (isAligned) {
               // entries are 64-bit-padded, re-calculate the bits per block
               // this is the dataSize calculation from above reverted, we know the actual data size
-              bpb = blockData.longArray().length / 64;
+              bpb = blockStates.longArray().length / 64;
             }
 
             int[] subpalette = new int[palette.size()];
@@ -320,7 +314,7 @@ public class Chunk {
               subpalette[paletteIndex] = blockPalette.put(item);
               paletteIndex += 1;
             }
-            BitBuffer buffer = new BitBuffer(blockData.longArray(), bpb, isAligned);
+            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb, isAligned);
             for (int y = 0; y < SECTION_Y_MAX; y++) {
               int blockY = sectionMinBlockY + y;
               for (int z = 0; z < Z_MAX; z++) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -286,7 +286,10 @@ public class Chunk {
         if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
           continue; //skip parsing sections that are outside requested bounds
 
-        Tag paletteTag = getTagFromNames(section, "Palette", "block_states.palette");
+        Tag paletteTag = getTagFromNames(section, "Palette", "block_states");
+        if(paletteTag.isCompoundTag()) {
+          paletteTag = paletteTag.get("palette");
+        }
         if (paletteTag.isList()) {
           ListTag palette = paletteTag.asList();
           // Bits per block:
@@ -296,16 +299,19 @@ public class Chunk {
           }
 
           int dataSize = (4096 * bpb) / 64;
-          Tag blockStates = getTagFromNames(section, "Palette", "block_states.data");
+          Tag blockData = getTagFromNames(section, "BlockStates", "block_states");
+          if(blockData.isCompoundTag()) {
+            blockData = blockData.get("data");
+          }
 
-          if (blockStates.isLongArray(dataSize)) {
+          if (blockData.isLongArray(dataSize)) {
             // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
             // unused bits per block state; if so, the array is longer than the expected data size
             boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20w17a;
             if (isAligned) {
               // entries are 64-bit-padded, re-calculate the bits per block
               // this is the dataSize calculation from above reverted, we know the actual data size
-              bpb = blockStates.longArray().length / 64;
+              bpb = blockData.longArray().length / 64;
             }
 
             int[] subpalette = new int[palette.size()];
@@ -314,7 +320,7 @@ public class Chunk {
               subpalette[paletteIndex] = blockPalette.put(item);
               paletteIndex += 1;
             }
-            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb, isAligned);
+            BitBuffer buffer = new BitBuffer(blockData.longArray(), bpb, isAligned);
             for (int y = 0; y < SECTION_Y_MAX; y++) {
               int blockY = sectionMinBlockY + y;
               for (int z = 0; z < Z_MAX; z++) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -55,7 +55,7 @@ public class Chunk {
   public static final String DATAVERSION = ".DataVersion";
   public static final String LEVEL_HEIGHTMAP = ".Level.HeightMap";
   public static final String LEVEL_SECTIONS = ".Level.Sections";
-  public static final String SECTIONS_POST_21W39A = ".sections";
+  public static final String LEVEL_SECTIONS_POST_21W39A = ".sections";
   public static final String LEVEL_BIOMES = ".Level.Biomes";
   public static final String LEVEL_ENTITIES = ".Level.Entities";
   public static final String LEVEL_TILEENTITIES = ".Level.TileEntities";
@@ -74,7 +74,7 @@ public class Chunk {
   public static final int SECTION_HALF_NIBBLES = SECTION_BYTES / 2;
   private static final int CHUNK_BYTES = X_MAX * Y_MAX * Z_MAX;
 
-  public static final int DATAVERSION_20w17a = 2529;
+  public static final int DATAVERSION_20W17A = 2529;
 
   protected final ChunkPosition position;
   protected volatile AbstractLayer surface = IconLayer.UNKNOWN;
@@ -144,7 +144,7 @@ public class Chunk {
     Set<String> request = new HashSet<>();
     request.add(Chunk.DATAVERSION);
     request.add(Chunk.LEVEL_SECTIONS);
-    request.add(Chunk.SECTIONS_POST_21W39A);
+    request.add(Chunk.LEVEL_SECTIONS_POST_21W39A);
     request.add(Chunk.LEVEL_BIOMES);
     request.add(Chunk.LEVEL_HEIGHTMAP);
     Map<String, Tag> dataMap = getChunkTags(request);
@@ -174,7 +174,7 @@ public class Chunk {
     }
 
     Heightmap heightmap = world.heightmap();
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, LEVEL_SECTIONS_POST_21W39A);
     if (sections.isList()) {
       extractBiomeData(data.get(LEVEL_BIOMES), chunkData);
       if (version.equals("1.13") || version.equals("1.12")) {
@@ -259,7 +259,7 @@ public class Chunk {
 
   /** Detect Minecraft version that generated the chunk. */
   private static String chunkVersion(@NotNull Tag data) {
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, LEVEL_SECTIONS_POST_21W39A);
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
         if (!section.get("Palette").isList()) {
@@ -276,7 +276,7 @@ public class Chunk {
   private static void loadBlockData(@NotNull Tag data, @NotNull ChunkData chunkData,
       BlockPalette blockPalette, int minY, int maxY) {
 
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, LEVEL_SECTIONS_POST_21W39A);
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
         Tag yTag = section.get("Y");
@@ -307,7 +307,7 @@ public class Chunk {
           if (blockData.isLongArray(dataSize)) {
             // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
             // unused bits per block state; if so, the array is longer than the expected data size
-            boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20w17a;
+            boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20W17A;
             if (isAligned) {
               // entries are 64-bit-padded, re-calculate the bits per block
               // this is the dataSize calculation from above reverted, we know the actual data size
@@ -465,7 +465,7 @@ public class Chunk {
     Set<String> request = new HashSet<>();
     request.add(DATAVERSION);
     request.add(LEVEL_SECTIONS);
-    request.add(SECTIONS_POST_21W39A);
+    request.add(LEVEL_SECTIONS_POST_21W39A);
     request.add(LEVEL_BIOMES);
     request.add(LEVEL_ENTITIES);
     request.add(LEVEL_TILEENTITIES);
@@ -481,7 +481,7 @@ public class Chunk {
     }
     Tag data = tagFromMap(dataMap);
     version = chunkVersion(data);
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, LEVEL_SECTIONS_POST_21W39A);
     Tag biomesTag = data.get(LEVEL_BIOMES);
     Tag entitiesTag = data.get(LEVEL_ENTITIES);
     Tag tileEntitiesTag = data.get(LEVEL_TILEENTITIES);

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -16,20 +16,15 @@
  */
 package se.llbit.chunky.world;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import se.llbit.chunky.block.*;
+import se.llbit.chunky.block.Air;
+import se.llbit.chunky.block.Block;
+import se.llbit.chunky.block.Lava;
+import se.llbit.chunky.block.Water;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.EmptyChunkData;
-import se.llbit.chunky.map.AbstractLayer;
-import se.llbit.chunky.map.BiomeLayer;
-import se.llbit.chunky.map.IconLayer;
-import se.llbit.chunky.map.MapTile;
-import se.llbit.chunky.map.SurfaceLayer;
+import se.llbit.chunky.map.*;
 import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.chunky.world.region.Region;
 import se.llbit.math.QuickMath;
@@ -40,6 +35,13 @@ import se.llbit.nbt.Tag;
 import se.llbit.util.BitBuffer;
 import se.llbit.util.Mutable;
 import se.llbit.util.NotNull;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static se.llbit.util.NbtUtil.getTagFromNames;
+import static se.llbit.util.NbtUtil.tagFromMap;
 
 /**
  * This class represents a loaded or not-yet-loaded chunk in the world.
@@ -53,6 +55,7 @@ public class Chunk {
   public static final String DATAVERSION = ".DataVersion";
   public static final String LEVEL_HEIGHTMAP = ".Level.HeightMap";
   public static final String LEVEL_SECTIONS = ".Level.Sections";
+  public static final String SECTIONS_POST_21W39A = ".sections";
   public static final String LEVEL_BIOMES = ".Level.Biomes";
   public static final String LEVEL_ENTITIES = ".Level.Entities";
   public static final String LEVEL_TILEENTITIES = ".Level.TileEntities";
@@ -141,13 +144,15 @@ public class Chunk {
     Set<String> request = new HashSet<>();
     request.add(Chunk.DATAVERSION);
     request.add(Chunk.LEVEL_SECTIONS);
+    request.add(Chunk.SECTIONS_POST_21W39A);
     request.add(Chunk.LEVEL_BIOMES);
     request.add(Chunk.LEVEL_HEIGHTMAP);
-    Map<String, Tag> data = getChunkTags(request);
+    Map<String, Tag> dataMap = getChunkTags(request);
     // TODO: improve error handling here.
-    if (data == null) {
+    if (dataMap == null) {
       return false;
     }
+    Tag data = tagFromMap(dataMap);
 
     surfaceTimestamp = dataTimestamp;
     version = chunkVersion(data);
@@ -162,14 +167,14 @@ public class Chunk {
     return true;
   }
 
-  private void loadSurface(Map<String, Tag> data, ChunkData chunkData, int yMin, int yMax) {
+  private void loadSurface(@NotNull Tag data, ChunkData chunkData, int yMin, int yMax) {
     if (data == null) {
       surface = IconLayer.CORRUPT;
       return;
     }
 
     Heightmap heightmap = world.heightmap();
-    Tag sections = data.get(LEVEL_SECTIONS);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     if (sections.isList()) {
       extractBiomeData(data.get(LEVEL_BIOMES), chunkData);
       if (version.equals("1.13") || version.equals("1.12")) {
@@ -186,7 +191,7 @@ public class Chunk {
     }
   }
 
-  private void loadBiomes(Map<String, Tag> data, ChunkData chunkData) {
+  private void loadBiomes(@NotNull Tag data, ChunkData chunkData) {
     if (data == null) {
       biomes = IconLayer.CORRUPT;
     } else {
@@ -239,7 +244,7 @@ public class Chunk {
     }
   }
 
-  private int[] extractHeightmapData(@NotNull Map<String, Tag> data, ChunkData chunkData) {
+  private int[] extractHeightmapData(@NotNull Tag data, ChunkData chunkData) {
     Tag heightmapTag = data.get(LEVEL_HEIGHTMAP);
     if (heightmapTag.isIntArray(X_MAX * Z_MAX)) {
       return heightmapTag.intArray();
@@ -253,8 +258,8 @@ public class Chunk {
   }
 
   /** Detect Minecraft version that generated the chunk. */
-  private static String chunkVersion(@NotNull Map<String, Tag> data) {
-    Tag sections = data.get(LEVEL_SECTIONS);
+  private static String chunkVersion(@NotNull Tag data) {
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
         if (!section.get("Palette").isList()) {
@@ -268,9 +273,10 @@ public class Chunk {
     return "?";
   }
 
-  private static void loadBlockData(@NotNull Map<String, Tag> data, @NotNull ChunkData chunkData,
+  private static void loadBlockData(@NotNull Tag data, @NotNull ChunkData chunkData,
       BlockPalette blockPalette, int minY, int maxY) {
-    Tag sections = data.get(LEVEL_SECTIONS);
+
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
         Tag yTag = section.get("Y");
@@ -280,8 +286,9 @@ public class Chunk {
         if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
           continue; //skip parsing sections that are outside requested bounds
 
-        if (section.get("Palette").isList()) {
-          ListTag palette = section.get("Palette").asList();
+        Tag paletteTag = getTagFromNames(section, "Palette", "block_states.palette");
+        if (paletteTag.isList()) {
+          ListTag palette = paletteTag.asList();
           // Bits per block:
           int bpb = 4;
           if (palette.size() > 16) {
@@ -289,7 +296,7 @@ public class Chunk {
           }
 
           int dataSize = (4096 * bpb) / 64;
-          Tag blockStates = section.get("BlockStates");
+          Tag blockStates = getTagFromNames(section, "Palette", "block_states.data");
 
           if (blockStates.isLongArray(dataSize)) {
             // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
@@ -452,21 +459,23 @@ public class Chunk {
     Set<String> request = new HashSet<>();
     request.add(DATAVERSION);
     request.add(LEVEL_SECTIONS);
+    request.add(SECTIONS_POST_21W39A);
     request.add(LEVEL_BIOMES);
     request.add(LEVEL_ENTITIES);
     request.add(LEVEL_TILEENTITIES);
-    Map<String, Tag> data = getChunkTags(request);
     if(reuseChunkData == null || reuseChunkData instanceof EmptyChunkData) {
       reuseChunkData = world.createChunkData();
     } else {
       reuseChunkData.clear();
     }
+    Map<String, Tag> dataMap = getChunkTags(request);
     // TODO: improve error handling here.
-    if (data == null) {
+    if (dataMap == null) {
       return reuseChunkData;
     }
+    Tag data = tagFromMap(dataMap);
     version = chunkVersion(data);
-    Tag sections = data.get(LEVEL_SECTIONS);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     Tag biomesTag = data.get(LEVEL_BIOMES);
     Tag entitiesTag = data.get(LEVEL_ENTITIES);
     Tag tileEntitiesTag = data.get(LEVEL_TILEENTITIES);

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -286,7 +286,7 @@ public class Chunk {
         if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
           continue; //skip parsing sections that are outside requested bounds
 
-        Tag paletteTag = getTagFromNames(section, "Palette", "block_states.palette");
+        Tag paletteTag = getTagFromNames(section, "Palette", "block_states\\palette");
         if (paletteTag.isList()) {
           ListTag palette = paletteTag.asList();
           // Bits per block:
@@ -296,7 +296,7 @@ public class Chunk {
           }
 
           int dataSize = (4096 * bpb) / 64;
-          Tag blockStates = getTagFromNames(section, "Palette", "block_states.data");
+          Tag blockStates = getTagFromNames(section, "Palette", "block_states\\data");
 
           if (blockStates.isLongArray(dataSize)) {
             // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb

--- a/chunky/src/java/se/llbit/util/NbtUtil.java
+++ b/chunky/src/java/se/llbit/util/NbtUtil.java
@@ -4,6 +4,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ErrorTag;
 import se.llbit.nbt.ListTag;
@@ -52,5 +54,56 @@ public class NbtUtil {
     } else {
       tag.write(out);
     }
+  }
+
+  /**
+   * Gets the first Non-Error tag from within the tag parameter
+   *
+   * This function:
+   * Tag t = GetTagFromNames(tag, "name1", "name2", "name3");
+   *
+   * is equivalent to this example:
+   * Tag t = tag.get("name1");
+   * if(t.isError()) {
+   *   t = tag.get("name2");
+   * }
+   * if(t.isError()) {
+   *   t = tag.get("name3");
+   * }
+   *
+   * @param tag The tag to extract data from
+   * @param tagNames List of names in priority order
+   * @return First tag found
+   */
+  public static Tag getTagFromNames(@NotNull Tag tag, @NotNull String... tagNames) {
+    Tag outTag = null;
+    for (String tagName : tagNames) {
+      if(tagName.contains(".")) {
+        outTag = tag;
+        String[] split = tagName.split("\\.");
+        for (String name : split) {
+          outTag = outTag.get(name);
+        }
+      } else {
+        outTag = tag.get(tagName);
+      }
+      if (!outTag.isError()) {
+        return outTag;
+      }
+    }
+    return outTag;
+  }
+
+  /**
+   * Creates a compound tag from a map
+   */
+  public static CompoundTag tagFromMap(@NotNull Map<String, Tag> map) {
+    CompoundTag compoundTag = new CompoundTag();
+    for (Map.Entry<String, Tag> entry : map.entrySet()) {
+      String name = entry.getKey();
+      Tag tag = entry.getValue();
+      compoundTag.add(new NamedTag(name, (SpecificTag) tag));
+    }
+    return compoundTag;
   }
 }

--- a/chunky/src/java/se/llbit/util/NbtUtil.java
+++ b/chunky/src/java/se/llbit/util/NbtUtil.java
@@ -78,7 +78,15 @@ public class NbtUtil {
   public static Tag getTagFromNames(@NotNull Tag tag, @NotNull String... tagNames) {
     Tag outTag = null;
     for (String tagName : tagNames) {
-      outTag = tag.get(tagName);
+      if(tagName.contains(".")) {
+        outTag = tag;
+        String[] split = tagName.split("\\.");
+        for (String name : split) {
+          outTag = outTag.get(name);
+        }
+      } else {
+        outTag = tag.get(tagName);
+      }
       if (!outTag.isError()) {
         return outTag;
       }

--- a/chunky/src/java/se/llbit/util/NbtUtil.java
+++ b/chunky/src/java/se/llbit/util/NbtUtil.java
@@ -78,15 +78,7 @@ public class NbtUtil {
   public static Tag getTagFromNames(@NotNull Tag tag, @NotNull String... tagNames) {
     Tag outTag = null;
     for (String tagName : tagNames) {
-      if(tagName.contains(".")) {
-        outTag = tag;
-        String[] split = tagName.split("\\.");
-        for (String name : split) {
-          outTag = outTag.get(name);
-        }
-      } else {
-        outTag = tag.get(tagName);
-      }
+      outTag = tag.get(tagName);
       if (!outTag.isError()) {
         return outTag;
       }

--- a/chunky/src/java/se/llbit/util/NbtUtil.java
+++ b/chunky/src/java/se/llbit/util/NbtUtil.java
@@ -57,15 +57,15 @@ public class NbtUtil {
   }
 
   /**
-   * Gets the first Non-Error tag from within the tag parameter
+   * Gets the first Non-Error tag from within the tag parameter. You can check for nested tag names by using "\" as a separator.
    *
    * This function:
-   * Tag t = GetTagFromNames(tag, "name1", "name2", "name3");
+   * Tag t = GetTagFromNames(tag, "name1", "name2\nested", "name3");
    *
    * is equivalent to this example:
    * Tag t = tag.get("name1");
    * if(t.isError()) {
-   *   t = tag.get("name2");
+   *   t = tag.get("name2").get("nested");
    * }
    * if(t.isError()) {
    *   t = tag.get("name3");
@@ -78,9 +78,9 @@ public class NbtUtil {
   public static Tag getTagFromNames(@NotNull Tag tag, @NotNull String... tagNames) {
     Tag outTag = null;
     for (String tagName : tagNames) {
-      if(tagName.contains(".")) {
+      if(tagName.contains("\\")) {
         outTag = tag;
-        String[] split = tagName.split("\\.");
+        String[] split = tagName.split("\\\\");
         for (String name : split) {
           outTag = outTag.get(name);
         }


### PR DESCRIPTION
Does not support biome palettes.

Across the snapshots the sections array has been in `.Level.Sections` -> `.Level.sections` -> `.sections`
do you want me to add support for `.Level.sections` as well? iirc it's in a few of the snapshots though I can't really remember

Notable changes for review:
- Added `getTagFromNames` function, which gets the first valid tag from the given names (helps with mojang moving around identical structures)
- Changed `Map<String, Tag> data` to `Tag data` for easier use of `getTagFromNames`
