### PR TITLE
Headless mode : Allow json parameter in -set option

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -35,6 +35,7 @@ import se.llbit.util.mojangapi.MojangApi;
 import se.llbit.util.StringUtil;
 import se.llbit.util.TaskTracker;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -313,13 +314,21 @@ public class CommandLineOptions {
           for (int j = 0; j < path.length - 1; ++j) {
             obj = obj.get(path[j]).object();
           }
-          JsonValue jsonValue;
-          try {
-            jsonValue = new JsonNumber(Integer.parseInt(value));
-          } catch (Exception e) {
-            jsonValue = new JsonString(value);
+
+          JsonValue jsonValue = null;
+          if (value.startsWith("{") || value.startsWith("[")) {
+            JsonParser parser = new JsonParser(new ByteArrayInputStream(value.getBytes()));
+            jsonValue = parser.parse();
+          } else {
+            try {
+              jsonValue =  new JsonNumber(Integer.parseInt(value));
+            } catch (Exception e) {
+              jsonValue =  new JsonString(value);
+            }
           }
+
           obj.set(path[path.length - 1], jsonValue);
+
           writeSceneJson(file, desc);
           System.out.println("Updated scene " + file.getAbsolutePath());
         } catch (SyntaxError e) {


### PR DESCRIPTION
Let the following command :
```
chunky -set chunkList "[[1,-2]]" scene
```

Before this commit, scene.json will result in (which is invalid) :
```
{
...
  "chunkList": "[[1,-2]]",
...
}
```

After this commit, scene.json will result in :
```
{
...
  "chunkList": [
    [
      1,
      -2
    ]
  ],
...
}
```
