### PR TITLE
Show the actual version next to "latest" in the version dropdown.

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
+++ b/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
@@ -91,6 +91,15 @@ public final class ChunkyLauncherController implements Initializable, UpdateList
         e.printStackTrace();
       }
     });
+    CustomizedListCellFactory.install(version, new CustomizedListCellFactory.Adapter<VersionInfo>() {
+      @Override
+      public String getLabel(VersionInfo item) {
+        if (item == VersionInfo.LATEST) {
+          return "latest (" + ChunkyDeployer.availableVersions().get(0).name + ")";
+        }
+        return item.name;
+      }
+    });
     launchButton.setTooltip(new Tooltip("Launch Chunky using the current settings."));
     launchButton.setOnAction(event -> launchChunky());
     launcherVersion.setText("v" + ChunkyLauncher.LAUNCHER_VERSION);

--- a/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
+++ b/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
@@ -39,6 +39,7 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.function.Consumer;
 
@@ -95,7 +96,10 @@ public final class ChunkyLauncherController implements Initializable, UpdateList
       @Override
       public String getLabel(VersionInfo item) {
         if (item == VersionInfo.LATEST) {
-          return "latest (" + ChunkyDeployer.availableVersions().get(0).name + ")";
+          List<VersionInfo> availableVersions = ChunkyDeployer.availableVersions();
+          if (!availableVersions.isEmpty()) {
+            return "latest (" + availableVersions.get(0).name + ")";
+          }
         }
         return item.name;
       }


### PR DESCRIPTION
We frequently get questions from people who use the "latest version", but not knowing the actual version makes providing help pretty difficult.