### PR TITLE
Move block properties from Material to Block.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -30,6 +30,14 @@ public abstract class Block extends Material {
    */
   public boolean invisible = false;
 
+  /**
+   * The solid property controls various block behaviours like if the block connects to fences,
+   * gates, walls, etc.
+   */
+  public boolean solid = true;
+
+  public boolean waterlogged = false;
+
   public Block(String name, Texture texture) {
     super(name, texture);
   }
@@ -119,5 +127,9 @@ public abstract class Block extends Material {
    */
   public Tag getNewTagWithBlockEntity(Tag blockTag, CompoundTag entityTag) {
     return null;
+  }
+
+  public boolean isWaterFilled() {
+    return waterlogged || isWater();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/FinalizationState.java
+++ b/chunky/src/java/se/llbit/chunky/block/FinalizationState.java
@@ -12,24 +12,24 @@ public abstract class FinalizationState {
     this.palette = palette;
   }
 
-  public abstract Material getMaterial();
+  public abstract Block getBlock();
 
-  public abstract Material getMaterial(int rx, int ry, int rz);
+  public abstract Block getBlock(int rx, int ry, int rz);
 
-  public Material getMaterial(BlockFace direction) {
+  public Block getBlock(BlockFace direction) {
     switch (direction) {
       case NORTH:
-        return getMaterial(0, 0, -1);
+        return getBlock(0, 0, -1);
       case EAST:
-        return getMaterial(1, 0, 0);
+        return getBlock(1, 0, 0);
       case SOUTH:
-        return getMaterial(0, 0, 1);
+        return getBlock(0, 0, 1);
       case WEST:
-        return getMaterial(-1, 0, 0);
+        return getBlock(-1, 0, 0);
       case UP:
-        return getMaterial(0, 1, 0);
+        return getBlock(0, 1, 0);
       case DOWN:
-        return getMaterial(0, -1, 0);
+        return getBlock(0, -1, 0);
       default:
         throw new IllegalArgumentException("Invalid direction: " + direction);
     }

--- a/chunky/src/java/se/llbit/chunky/block/OctreeFinalizationState.java
+++ b/chunky/src/java/se/llbit/chunky/block/OctreeFinalizationState.java
@@ -1,7 +1,6 @@
 package se.llbit.chunky.block;
 
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.world.Material;
 import se.llbit.math.Octree;
 
 public class OctreeFinalizationState extends FinalizationState {
@@ -24,14 +23,14 @@ public class OctreeFinalizationState extends FinalizationState {
   }
 
   @Override
-  public Material getMaterial() {
-    return worldTree.getMaterial(x, y, z, getPalette());
+  public Block getBlock() {
+    return worldTree.getBlock(x, y, z, getPalette());
   }
 
   @Override
-  public Material getMaterial(int rx, int ry, int rz) {
+  public Block getBlock(int rx, int ry, int rz) {
     return worldTree
-        .getMaterial(x + rx, y + ry, z + rz, getPalette());
+        .getBlock(x + rx, y + ry, z + rz, getPalette());
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlockUtils.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlockUtils.java
@@ -1,9 +1,6 @@
 package se.llbit.chunky.block.legacy;
 
-import se.llbit.chunky.block.BlockFace;
-import se.llbit.chunky.block.FenceGate;
-import se.llbit.chunky.block.FinalizationState;
-import se.llbit.chunky.block.Stairs;
+import se.llbit.chunky.block.*;
 import se.llbit.chunky.block.legacy.blocks.LegacyFenceGate;
 import se.llbit.chunky.block.legacy.blocks.LegacyStairs;
 import se.llbit.chunky.world.Material;
@@ -47,14 +44,14 @@ public class LegacyBlockUtils {
    */
   public static class FinalizationStateCache extends FinalizationState {
 
-    private final Material[] cache;
+    private final Block[] cache;
     private final FinalizationState state;
 
     public FinalizationStateCache(FinalizationState state) {
-      this(state, new Material[27]);
+      this(state, new Block[27]);
     }
 
-    public FinalizationStateCache(FinalizationState state, Material[] cache) {
+    public FinalizationStateCache(FinalizationState state, Block[] cache) {
       super(state.getPalette());
       this.state = state;
       this.cache = cache;
@@ -65,18 +62,18 @@ public class LegacyBlockUtils {
     }
 
     @Override
-    public Material getMaterial() {
-      return state.getMaterial();
+    public Block getBlock() {
+      return state.getBlock();
     }
 
     @Override
-    public Material getMaterial(int rx, int ry, int rz) {
+    public Block getBlock(int rx, int ry, int rz) {
       int index = getCacheIndex(rx, ry, rz);
 
       if (cache[index] != null) {
         return cache[index];
       }
-      cache[index] = state.getMaterial(rx, ry, rz);
+      cache[index] = state.getBlock(rx, ry, rz);
       return cache[index];
     }
 

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocksFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocksFinalizer.java
@@ -1,10 +1,9 @@
 package se.llbit.chunky.block.legacy;
 
-import se.llbit.chunky.block.FinalizationState;
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.OctreeFinalizationState;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.world.ChunkPosition;
-import se.llbit.chunky.world.Material;
 import se.llbit.math.Octree;
 import se.llbit.math.Vector3i;
 
@@ -35,9 +34,9 @@ public class LegacyBlocksFinalizer {
           int x = cx + cp.x * 16 - origin.x;
           // TODO as in 1.13+ finalization we could finalize non-edge blocks during chunk loading
           finalizerState.setPosition(x, y, z);
-          Material mat = finalizerState.getMaterial();
-          if (mat instanceof UnfinalizedLegacyBlock) {
-            ((UnfinalizedLegacyBlock) mat).finalizeBlock(finalizerState);
+          Block block = finalizerState.getBlock();
+          if (block instanceof UnfinalizedLegacyBlock) {
+            ((UnfinalizedLegacyBlock) block).finalizeBlock(finalizerState);
           }
         }
       }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChest.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChest.java
@@ -20,22 +20,22 @@ public class LegacyChest extends UnfinalizedLegacyBlock {
     String name = block.name.substring(10);
     if (data < 4) {
       // facing east or west
-      if (LegacyBlockUtils.getName(state.getMaterial(-1, 0, 0)).equals(name)) {
+      if (LegacyBlockUtils.getName(state.getBlock(-1, 0, 0)).equals(name)) {
         state.replaceCurrentBlock(
             createTag(data, data == 2 ? "right" : "left"));
         return;
-      } else if (LegacyBlockUtils.getName(state.getMaterial(1, 0, 0)).equals(name)) {
+      } else if (LegacyBlockUtils.getName(state.getBlock(1, 0, 0)).equals(name)) {
         state.replaceCurrentBlock(
             createTag(data, data == 2 ? "left" : "right"));
         return;
       }
     } else {
       // facing north or south
-      if (LegacyBlockUtils.getName(state.getMaterial(0, 0, -1)).equals(name)) {
+      if (LegacyBlockUtils.getName(state.getBlock(0, 0, -1)).equals(name)) {
         state.replaceCurrentBlock(
             createTag(data, data == 5 ? "right" : "left"));
         return;
-      } else if (LegacyBlockUtils.getName(state.getMaterial(0, 0, 1)).equals(name)) {
+      } else if (LegacyBlockUtils.getName(state.getBlock(0, 0, 1)).equals(name)) {
         state.replaceCurrentBlock(
             createTag(data, data == 5 ? "left" : "right"));
         return;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChorusPlant.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyChorusPlant.java
@@ -17,12 +17,12 @@ public class LegacyChorusPlant extends UnfinalizedLegacyBlock {
   public void finalizeBlock(FinalizationState state) {
     CompoundTag newTag = LegacyBlocks.createTag(this.name);
 
-    LegacyBlocks.boolTag(newTag, "up", isConnect(state.getMaterial(0, 1, 0)));
-    LegacyBlocks.boolTag(newTag, "down", isConnectDown(state.getMaterial(0, -1, 0)));
-    LegacyBlocks.boolTag(newTag, "east", isConnect(state.getMaterial(1, 0, 0)));
-    LegacyBlocks.boolTag(newTag, "west", isConnect(state.getMaterial(-1, 0, 0)));
-    LegacyBlocks.boolTag(newTag, "north", isConnect(state.getMaterial(0, 0, -1)));
-    LegacyBlocks.boolTag(newTag, "south", isConnect(state.getMaterial(0, 0, 1)));
+    LegacyBlocks.boolTag(newTag, "up", isConnect(state.getBlock(0, 1, 0)));
+    LegacyBlocks.boolTag(newTag, "down", isConnectDown(state.getBlock(0, -1, 0)));
+    LegacyBlocks.boolTag(newTag, "east", isConnect(state.getBlock(1, 0, 0)));
+    LegacyBlocks.boolTag(newTag, "west", isConnect(state.getBlock(-1, 0, 0)));
+    LegacyBlocks.boolTag(newTag, "north", isConnect(state.getBlock(0, 0, -1)));
+    LegacyBlocks.boolTag(newTag, "south", isConnect(state.getBlock(0, 0, 1)));
 
     state.replaceCurrentBlock(newTag);
   }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyCobblestoneWall.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyCobblestoneWall.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -16,10 +17,10 @@ public class LegacyCobblestoneWall extends UnfinalizedLegacyBlock {
 
   @Override
   public void finalizeBlock(FinalizationState state) {
-    boolean north = isStoneWallConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-    boolean south = isStoneWallConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-    boolean east = isStoneWallConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-    boolean west = isStoneWallConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+    boolean north = isStoneWallConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+    boolean south = isStoneWallConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+    boolean east = isStoneWallConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+    boolean west = isStoneWallConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
     boolean up = false;
 
     if (!(north && south && !east && !west) && !(!north && !south && east && west)) {
@@ -27,14 +28,14 @@ public class LegacyCobblestoneWall extends UnfinalizedLegacyBlock {
       up = true;
     } else if (state.getY() < state.getYMax() - 1) {
       // check if connected to a block above
-      Material above = state.getMaterial(0, 1, 0);
+      Block above = state.getBlock(0, 1, 0);
       up = isStoneWallTopConnector(above);
     }
 
     state.replaceCurrentBlock(createTag(north, south, east, west, up));
   }
 
-  private static boolean isStoneWallConnector(Material block, BlockFace direction) {
+  private static boolean isStoneWallConnector(Block block, BlockFace direction) {
     String name = LegacyBlockUtils.getName(block);
     if (name.equals("cobblestone_wall") || name.equals("mossy_cobblestone_wall")) {
       return true;
@@ -71,7 +72,7 @@ public class LegacyCobblestoneWall extends UnfinalizedLegacyBlock {
     return block.solid;
   }
 
-  private static boolean isStoneWallTopConnector(Material block) {
+  private static boolean isStoneWallTopConnector(Block block) {
     String name = LegacyBlockUtils.getName(block);
     return block.solid || name.equals("water") || name.equals("lava") || name.equals("torch")
         || name.endsWith("_fence") || name.equals("chest") || name.equals("redstone_torch")

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyDoorPart.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyDoorPart.java
@@ -1,11 +1,11 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.Door;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
-import se.llbit.chunky.world.Material;
 import se.llbit.nbt.CompoundTag;
 
 public class LegacyDoorPart extends UnfinalizedLegacyBlock {
@@ -19,7 +19,7 @@ public class LegacyDoorPart extends UnfinalizedLegacyBlock {
     if (isTopPart(data)) {
       // top part
       if (state.getY() > state.getYMin()) {
-        Material bottomPart = state.getMaterial(0, -1, 0);
+        Block bottomPart = state.getBlock(0, -1, 0);
         if (bottomPart instanceof Door) {
           // finalization is from bottom to top, so the bottom part is already finalized
           Door doorBelow = (Door) bottomPart;
@@ -31,7 +31,7 @@ public class LegacyDoorPart extends UnfinalizedLegacyBlock {
     } else {
       // bottom part
       if (state.getY() < state.getYMax() - 1) {
-        Material topPart = state.getMaterial(0, 1, 0);
+        Block topPart = state.getBlock(0, 1, 0);
         if (topPart instanceof LegacyDoorPart) {
           // finalization is from bottom to top, so the top part is not finalized yet
           LegacyDoorPart doorAbove = (LegacyDoorPart) topPart;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFence.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFence.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -18,10 +19,10 @@ public class LegacyFence extends UnfinalizedLegacyBlock {
   public void finalizeBlock(FinalizationState state) {
     if (id == 113) {
       // nether brick fence
-      boolean north = isNetherBrickFenceConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-      boolean south = isNetherBrickFenceConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-      boolean east = isNetherBrickFenceConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-      boolean west = isNetherBrickFenceConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+      boolean north = isNetherBrickFenceConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+      boolean south = isNetherBrickFenceConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+      boolean east = isNetherBrickFenceConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+      boolean west = isNetherBrickFenceConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
 
       if (north || south || east || west) {
         state.replaceCurrentBlock(createTag(north, south, east, west));
@@ -31,10 +32,10 @@ public class LegacyFence extends UnfinalizedLegacyBlock {
       }
     } else {
       // wood fence
-      boolean north = isFenceConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-      boolean south = isFenceConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-      boolean east = isFenceConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-      boolean west = isFenceConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+      boolean north = isFenceConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+      boolean south = isFenceConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+      boolean east = isFenceConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+      boolean west = isFenceConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
 
       if (north || south || east || west) {
         state.replaceCurrentBlock(createTag(north, south, east, west));
@@ -54,7 +55,7 @@ public class LegacyFence extends UnfinalizedLegacyBlock {
     return tag;
   }
 
-  private boolean isFenceConnector(Material block, BlockFace direction) {
+  private boolean isFenceConnector(Block block, BlockFace direction) {
     String name = LegacyBlockUtils.getName(block);
     if (name.equals("cobblestone_wall") || name.equals("mossy_cobblestone_wall")
         || name.equals("glass") || name.endsWith("_stained_glass")
@@ -89,7 +90,7 @@ public class LegacyFence extends UnfinalizedLegacyBlock {
     return block.solid || block.name.endsWith("_fence");
   }
 
-  private boolean isNetherBrickFenceConnector(Material block, BlockFace direction) {
+  private boolean isNetherBrickFenceConnector(Block block, BlockFace direction) {
     String name = LegacyBlockUtils.getName(block);
     if (name.equals("nether_brick_fence")) {
       return true;

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFenceGate.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFenceGate.java
@@ -20,12 +20,12 @@ public class LegacyFenceGate extends UnfinalizedLegacyBlock {
 
     if ((this.data & 3) % 2 == 0) {
       LegacyBlocks.boolTag(newTag, "in_wall",
-          state.getMaterial(-1, 0, 0).name.endsWith("cobblestone_wall") ||
-              state.getMaterial(1, 0, 0).name.endsWith("cobblestone_wall"));
+          state.getBlock(-1, 0, 0).name.endsWith("cobblestone_wall") ||
+              state.getBlock(1, 0, 0).name.endsWith("cobblestone_wall"));
     } else {
       LegacyBlocks.boolTag(newTag, "in_wall",
-          state.getMaterial(0, 0, -1).name.endsWith("cobblestone_wall") ||
-              state.getMaterial(0, 0, 1).name.endsWith("cobblestone_wall"));
+          state.getBlock(0, 0, -1).name.endsWith("cobblestone_wall") ||
+              state.getBlock(0, 0, 1).name.endsWith("cobblestone_wall"));
     }
 
     state.replaceCurrentBlock(newTag);

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFire.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -24,18 +25,18 @@ public class LegacyFire extends UnfinalizedLegacyBlock {
     CompoundTag tag = LegacyBlocks.createTag("fire");
 
     boolean floorFire =
-        state.getY() > state.getYMin() && isTopBurnable(state.getMaterial(BlockFace.DOWN));
+        state.getY() > state.getYMin() && isTopBurnable(state.getBlock(BlockFace.DOWN));
 
     // a side is burning if the adjacent block at that side is flammable
-    LegacyBlocks.boolTag(tag, "north", !floorFire && isFlammable(state.getMaterial(BlockFace.NORTH)));
-    LegacyBlocks.boolTag(tag, "east", !floorFire && isFlammable(state.getMaterial(BlockFace.EAST)));
-    LegacyBlocks.boolTag(tag, "south", !floorFire && isFlammable(state.getMaterial(BlockFace.SOUTH)));
-    LegacyBlocks.boolTag(tag, "west", !floorFire && isFlammable(state.getMaterial(BlockFace.WEST)));
+    LegacyBlocks.boolTag(tag, "north", !floorFire && isFlammable(state.getBlock(BlockFace.NORTH)));
+    LegacyBlocks.boolTag(tag, "east", !floorFire && isFlammable(state.getBlock(BlockFace.EAST)));
+    LegacyBlocks.boolTag(tag, "south", !floorFire && isFlammable(state.getBlock(BlockFace.SOUTH)));
+    LegacyBlocks.boolTag(tag, "west", !floorFire && isFlammable(state.getBlock(BlockFace.WEST)));
 
     // the up side is visible if this burning on top of the bottom below and the block above is flammable
     LegacyBlocks
         .boolTag(tag, "up", !floorFire &&
-            state.getY() < state.getYMax() - 1 && isFlammable(state.getMaterial(BlockFace.UP)));
+            state.getY() < state.getYMax() - 1 && isFlammable(state.getBlock(BlockFace.UP)));
 
     state.replaceCurrentBlock(tag);
   }
@@ -66,7 +67,7 @@ public class LegacyFire extends UnfinalizedLegacyBlock {
         name.endsWith("_carpet");
   }
 
-  private static boolean isTopBurnable(Material material) {
+  private static boolean isTopBurnable(Block material) {
     // solid blocks like dirt and stone can burn on top but not on the side (i.e. are not flammable)
     return material.solid || isFlammable(material);
   }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyGlassPane.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyGlassPane.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -16,10 +17,10 @@ public class LegacyGlassPane extends UnfinalizedLegacyBlock {
 
   @Override
   public void finalizeBlock(FinalizationState state) {
-    boolean north = isGlassPaneConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-    boolean south = isGlassPaneConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-    boolean east = isGlassPaneConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-    boolean west = isGlassPaneConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+    boolean north = isGlassPaneConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+    boolean south = isGlassPaneConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+    boolean east = isGlassPaneConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+    boolean west = isGlassPaneConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
 
     if (north || south || east || west) {
       state.replaceCurrentBlock(createTag(north, south, east, west));
@@ -29,7 +30,7 @@ public class LegacyGlassPane extends UnfinalizedLegacyBlock {
     }
   }
 
-  private static boolean isGlassPaneConnector(Material block, BlockFace direction) {
+  private static boolean isGlassPaneConnector(Block block, BlockFace direction) {
     String name = LegacyBlockUtils.getName(block);
     if (name.equals("cobblestone_wall") || name.equals("mossy_cobblestone_wall") || name
         .endsWith("_fence") || name

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyIronBars.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyIronBars.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
@@ -16,10 +17,10 @@ public class LegacyIronBars extends UnfinalizedLegacyBlock {
 
   @Override
   public void finalizeBlock(FinalizationState state) {
-    boolean north = isIronBarConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-    boolean south = isIronBarConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-    boolean east = isIronBarConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-    boolean west = isIronBarConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+    boolean north = isIronBarConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+    boolean south = isIronBarConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+    boolean east = isIronBarConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+    boolean west = isIronBarConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
 
     CompoundTag newTag = LegacyBlocks.createTag("iron_bars");
     LegacyBlocks.boolTag(newTag, "east", east);
@@ -30,7 +31,7 @@ public class LegacyIronBars extends UnfinalizedLegacyBlock {
     state.replaceCurrentBlock(newTag);
   }
 
-  private static boolean isIronBarConnector(Material block, BlockFace direction) {
+  private static boolean isIronBarConnector(Block block, BlockFace direction) {
     String name = LegacyBlockUtils.getName(block);
     if (name.equals("cobblestone_wall") || name.equals("mossy_cobblestone_wall") || name
         .endsWith("_fence") || name

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyLargeFlower.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyLargeFlower.java
@@ -1,10 +1,10 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlockUtils;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
-import se.llbit.chunky.world.Material;
 import se.llbit.nbt.CompoundTag;
 
 public class LegacyLargeFlower extends UnfinalizedLegacyBlock {
@@ -18,7 +18,7 @@ public class LegacyLargeFlower extends UnfinalizedLegacyBlock {
     CompoundTag newTag;
 
     if ((this.data&8) != 0) {
-      Material bottom = state.getMaterial(0, -1, 0);
+      Block bottom = state.getBlock(0, -1, 0);
 
       if (bottom instanceof LegacyLargeFlower) {
         newTag = LegacyBlocks.createTag(LegacyBlockUtils.getName(bottom));

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyMelonStem.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyMelonStem.java
@@ -20,7 +20,7 @@ public class LegacyMelonStem extends UnfinalizedLegacyBlock {
   public void finalizeBlock(FinalizationState state) {
     // melon stem points to adjacent melon
     for (BlockFace side : sides) {
-      if (state.getMaterial(side).name.equals("minecraft:melon")) {
+      if (state.getBlock(side).name.equals("minecraft:melon")) {
         state.replaceCurrentBlock(
             LegacyBlocks.stringTag(
                 LegacyBlocks.createTag("attached_melon_stem"), "facing", side.getName()

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyNetherPortal.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyNetherPortal.java
@@ -22,13 +22,13 @@ public class LegacyNetherPortal extends UnfinalizedLegacyBlock {
 
   @Override
   public void finalizeBlock(FinalizationState state) {
-    if (isNetherPortalConnector(state.getMaterial(BlockFace.NORTH))) {
+    if (isNetherPortalConnector(state.getBlock(BlockFace.NORTH))) {
       state.replaceCurrentBlock(createTag("z"));
-    } else if (isNetherPortalConnector(state.getMaterial(BlockFace.EAST))) {
+    } else if (isNetherPortalConnector(state.getBlock(BlockFace.EAST))) {
       state.replaceCurrentBlock(createTag("x"));
-    } else if (isNetherPortalConnector(state.getMaterial(BlockFace.SOUTH))) {
+    } else if (isNetherPortalConnector(state.getBlock(BlockFace.SOUTH))) {
       state.replaceCurrentBlock(createTag("z"));
-    } else if (isNetherPortalConnector(state.getMaterial(BlockFace.WEST))) {
+    } else if (isNetherPortalConnector(state.getBlock(BlockFace.WEST))) {
       state.replaceCurrentBlock(createTag("x"));
     } else {
       // not connected, just unwrap

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyPumpkinStem.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyPumpkinStem.java
@@ -20,7 +20,7 @@ public class LegacyPumpkinStem extends UnfinalizedLegacyBlock {
   public void finalizeBlock(FinalizationState state) {
     // pumpkin stem points to adjacent pumpkin or carved pumpkin (but not jack-o-lantern)
     for (BlockFace side : sides) {
-      if (state.getMaterial(side).name.endsWith("pumpkin")) {
+      if (state.getBlock(side).name.endsWith("pumpkin")) {
         state.replaceCurrentBlock(
             LegacyBlocks.stringTag(
                 LegacyBlocks.createTag("attached_pumpkin_stem"), "facing", side.getName()

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyRedstoneWire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyRedstoneWire.java
@@ -20,34 +20,34 @@ public class LegacyRedstoneWire extends UnfinalizedLegacyBlock {
     String east, north, south, west;
     east = north = south = west = "none";
 
-    if (isRedstoneConnector(state.getMaterial(-1, 0, 0), 1))
+    if (isRedstoneConnector(state.getBlock(-1, 0, 0), 1))
       west = "side";
-    else if (isAir(state.getMaterial(-1, 0, 0)) && isRedstone(state.getMaterial(-1, -1, 0)))
+    else if (isAir(state.getBlock(-1, 0, 0)) && isRedstone(state.getBlock(-1, -1, 0)))
       west = "side";
 
-    if (isRedstoneConnector(state.getMaterial(1, 0, 0), 1))
+    if (isRedstoneConnector(state.getBlock(1, 0, 0), 1))
       east = "side";
-    else if (isAir(state.getMaterial(1, 0, 0)) && isRedstone(state.getMaterial(1, -1, 0)))
+    else if (isAir(state.getBlock(1, 0, 0)) && isRedstone(state.getBlock(1, -1, 0)))
       east = "side";
 
-    if (isRedstoneConnector(state.getMaterial(0, 0, -1), 0))
+    if (isRedstoneConnector(state.getBlock(0, 0, -1), 0))
       north = "side";
-    else if (isAir(state.getMaterial(0, 0, -1)) && isRedstone(state.getMaterial(0, -1, -1)))
+    else if (isAir(state.getBlock(0, 0, -1)) && isRedstone(state.getBlock(0, -1, -1)))
       north = "side";
 
-    if (isRedstoneConnector(state.getMaterial(0, 0, 1), 0))
+    if (isRedstoneConnector(state.getBlock(0, 0, 1), 0))
       south = "side";
-    else if (isAir(state.getMaterial(0, 0, 1)) && isRedstone(state.getMaterial(0, -1, 1)))
+    else if (isAir(state.getBlock(0, 0, 1)) && isRedstone(state.getBlock(0, -1, 1)))
       south = "side";
 
-    if (state.getMaterial(0, 1, 0).name.equals("minecraft:air")) {
-      if (state.getMaterial(-1, 0, 0).solid && isRedstone(state.getMaterial(-1, 1, 0)))
+    if (state.getBlock(0, 1, 0).name.equals("minecraft:air")) {
+      if (state.getBlock(-1, 0, 0).solid && isRedstone(state.getBlock(-1, 1, 0)))
         west = "up";
-      if (state.getMaterial(1, 0, 0).solid && isRedstone(state.getMaterial(1, 1, 0)))
+      if (state.getBlock(1, 0, 0).solid && isRedstone(state.getBlock(1, 1, 0)))
         east = "up";
-      if (state.getMaterial(0, 0, -1).solid && isRedstone(state.getMaterial(0, 1, -1)))
+      if (state.getBlock(0, 0, -1).solid && isRedstone(state.getBlock(0, 1, -1)))
         north = "up";
-      if (state.getMaterial(0, 0, 1).solid && isRedstone(state.getMaterial(0, 1, 1)))
+      if (state.getBlock(0, 0, 1).solid && isRedstone(state.getBlock(0, 1, 1)))
         south = "up";
     }
 

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySnowCoverableBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySnowCoverableBlock.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Snow;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
@@ -19,7 +20,7 @@ public class LegacySnowCoverableBlock extends UnfinalizedLegacyBlock {
     // (aside: Chunky 1.x only handles this correctly for grass blocks)
     if (id == 2 || (id == 3 && data == 2) || id == 110) {
       if (state.getY() < state.getYMax() - 1) {
-        Material above = state.getMaterial(0, 1, 0);
+        Block above = state.getBlock(0, 1, 0);
         if (above instanceof Snow || above.name.equals("minecraft:snow_block")) {
           state.replaceCurrentBlock(LegacyBlocks
               .boolTag(LegacyBlocks.createTag(block.name), "snowy", true));

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyStairs.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyStairs.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.BlockFace;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.Stairs;
@@ -22,8 +23,8 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
     switch (rotation) {
       case 0: {
         // east
-        Material behind = state.getMaterial(1, 0, 0);
-        Material front = state.getMaterial(-1, 0, 0);
+        Block behind = state.getBlock(1, 0, 0);
+        Block front = state.getBlock(-1, 0, 0);
         if (isStairs(behind) && isTop(behind) == isTop) {
           switch (getOrientation(behind)) {
             case 2:
@@ -67,8 +68,8 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
       }
       case 1: {
         // west
-        Material behind = state.getMaterial(-1, 0, 0);
-        Material front = state.getMaterial(1, 0, 0);
+        Block behind = state.getBlock(-1, 0, 0);
+        Block front = state.getBlock(1, 0, 0);
         if (isStairs(behind) && isTop(behind) == isTop) {
           switch (getOrientation(behind)) {
             case 2:
@@ -112,8 +113,8 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
       }
       case 2: {
         // south
-        Material behind = state.getMaterial(0, 0, 1);
-        Material front = state.getMaterial(0, 0, -1);
+        Block behind = state.getBlock(0, 0, 1);
+        Block front = state.getBlock(0, 0, -1);
         if (isStairs(behind) && isTop(behind) == isTop) {
           switch (getOrientation(behind)) {
             case 0:
@@ -157,8 +158,8 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
       }
       case 3: {
         // north
-        Material behind = state.getMaterial(0, 0, -1);
-        Material front = state.getMaterial(0, 0, 1);
+        Block behind = state.getBlock(0, 0, -1);
+        Block front = state.getBlock(0, 0, 1);
         if (isStairs(behind) && isTop(behind) == isTop) {
           switch (getOrientation(behind)) {
             case 0:
@@ -259,7 +260,7 @@ public class LegacyStairs extends UnfinalizedLegacyBlock {
    * this block, false otherwise
    */
   private boolean isSameStairs(FinalizationState state, int rx, int ry, int rz) {
-    Material other = state.getMaterial(rx, ry, rz);
+    Block other = state.getBlock(rx, ry, rz);
     if (other instanceof LegacyStairs) {
       return (((LegacyStairs) other).data & 0b111) == (data & 0b111);
     } else if (other instanceof Stairs) {

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyTripwire.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyTripwire.java
@@ -19,10 +19,10 @@ public class LegacyTripwire extends UnfinalizedLegacyBlock {
   @Override
   public void finalizeBlock(FinalizationState state) {
     boolean attached = (data & 0b0100) != 0;
-    boolean north = isTripwireConnector(state.getMaterial(0, 0, -1), BlockFace.NORTH);
-    boolean south = isTripwireConnector(state.getMaterial(0, 0, 1), BlockFace.SOUTH);
-    boolean east = isTripwireConnector(state.getMaterial(1, 0, 0), BlockFace.EAST);
-    boolean west = isTripwireConnector(state.getMaterial(-1, 0, 0), BlockFace.WEST);
+    boolean north = isTripwireConnector(state.getBlock(0, 0, -1), BlockFace.NORTH);
+    boolean south = isTripwireConnector(state.getBlock(0, 0, 1), BlockFace.SOUTH);
+    boolean east = isTripwireConnector(state.getBlock(1, 0, 0), BlockFace.EAST);
+    boolean west = isTripwireConnector(state.getBlock(-1, 0, 0), BlockFace.WEST);
     state.replaceCurrentBlock(createTag(attached, north, south, east, west));
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block.legacy.blocks;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.FinalizationState;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.block.legacy.UnfinalizedLegacyBlock;
@@ -16,7 +17,7 @@ public class LegacyVine extends UnfinalizedLegacyBlock {
   public void finalizeBlock(FinalizationState state) {
     // vines have an "up" part if the block above is solid
     if (state.getY() < state.getYMax() - 1) {
-      Material above = state.getMaterial(0, 1, 0);
+      Block above = state.getBlock(0, 1, 0);
       if (above.solid) {
         state.replaceCurrentBlock(
             LegacyBlocks.vineTag(LegacyBlocks.createTag("vine"), data, true));

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/OctreeFinalizer.java
@@ -16,12 +16,11 @@
  */
 package se.llbit.chunky.renderer.scene;
 
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.Lava;
 import se.llbit.chunky.block.Water;
 import se.llbit.chunky.chunk.BlockPalette;
-import se.llbit.chunky.world.Chunk;
 import se.llbit.chunky.world.ChunkPosition;
-import se.llbit.chunky.world.Material;
 import se.llbit.math.Octree;
 import se.llbit.math.Vector3i;
 
@@ -64,12 +63,12 @@ public class OctreeFinalizer {
     int y = cy - origin.y;
     if (cy > yMin && cy < yMax - 1) {
       boolean isHidden =
-          worldTree.getMaterial(x - 1, y, z, palette).opaque
-              && worldTree.getMaterial(x + 1, y, z, palette).opaque
-              && worldTree.getMaterial(x, y, z - 1, palette).opaque
-              && worldTree.getMaterial(x, y, z + 1, palette).opaque
-              && worldTree.getMaterial(x, y - 1, z, palette).opaque
-              && worldTree.getMaterial(x, y + 1, z, palette).opaque;
+          worldTree.getBlock(x - 1, y, z, palette).opaque
+              && worldTree.getBlock(x + 1, y, z, palette).opaque
+              && worldTree.getBlock(x, y, z - 1, palette).opaque
+              && worldTree.getBlock(x, y, z + 1, palette).opaque
+              && worldTree.getBlock(x, y - 1, z, palette).opaque
+              && worldTree.getBlock(x, y + 1, z, palette).opaque;
       if (isHidden) {
         worldTree.set(BlockPalette.ANY_ID, x, y, z);
       }
@@ -79,12 +78,12 @@ public class OctreeFinalizer {
   private static void processBlock(Octree worldTree, Octree waterTree, BlockPalette palette, int x,
       int cy, int z, Vector3i origin) {
     int y = cy - origin.y;
-    Material mat = worldTree.getMaterial(x, y, z, palette);
-    Material wmat = waterTree.getMaterial(x, y, z, palette);
+    Block mat = worldTree.getBlock(x, y, z, palette);
+    Block wmat = waterTree.getBlock(x, y, z, palette);
 
     if (wmat instanceof Water) {
-      Material above = waterTree.getMaterial(x, y + 1, z, palette);
-      Material aboveBlock = worldTree.getMaterial(x, y + 1, z, palette);
+      Block above = waterTree.getBlock(x, y + 1, z, palette);
+      Block aboveBlock = worldTree.getBlock(x, y + 1, z, palette);
       int level0 = 8 - ((Water) wmat).level;
       if (!above.isWaterFilled() && !aboveBlock.solid) {
         int corner0 = level0;
@@ -133,7 +132,7 @@ public class OctreeFinalizer {
         waterTree.set(palette.getWaterId(0, 1 << Water.FULL_BLOCK), x, y, z);
       }
     } else if (mat instanceof Lava) {
-      Material above = worldTree.getMaterial(x, y + 1, z, palette);
+      Block above = worldTree.getBlock(x, y + 1, z, palette);
       if (!(above instanceof Lava)) {
         Lava lava = (Lava) mat;
 
@@ -188,14 +187,14 @@ public class OctreeFinalizer {
 
   private static int waterLevelAt(Octree worldTree, Octree waterTree,
       BlockPalette palette, int x, int cy, int z, int baseLevel) {
-    Material corner = waterTree.getMaterial(x, cy, z, palette);
+    Block corner = waterTree.getBlock(x, cy, z, palette);
     if (corner instanceof Water) {
-      Material above = waterTree.getMaterial(x, cy + 1, z, palette);
+      Block above = waterTree.getBlock(x, cy + 1, z, palette);
       boolean isFullBlock = above.isWaterFilled();
       return isFullBlock ? 8 : 8 - ((Water) corner).level;
     } else if (corner.waterlogged) {
       return 8;
-    } else if (!worldTree.getMaterial(x, cy, z, palette).solid) {
+    } else if (!worldTree.getBlock(x, cy, z, palette).solid) {
       return 0;
     }
     return baseLevel;
@@ -203,9 +202,9 @@ public class OctreeFinalizer {
 
   private static int lavaLevelAt(Octree octree, BlockPalette palette,
       int x, int cy, int z, int baseLevel) {
-    Material corner = octree.getMaterial(x, cy, z, palette);
+    Block corner = octree.getBlock(x, cy, z, palette);
     if (corner instanceof Lava) {
-      Material above = octree.getMaterial(x, cy + 1, z, palette);
+      Block above = octree.getBlock(x, cy + 1, z, palette);
       boolean isFullBlock = above instanceof Lava;
       return isFullBlock ? 8 : 8 - ((Lava) corner).level;
     } else if (!corner.solid) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -405,9 +405,9 @@ public class Chunk {
 
   public static int waterLevelAt(ChunkData chunkData, BlockPalette palette, int cx, int cy, int cz,
                                  int baseLevel) {
-    Material corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
+    Block corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
     if (corner.isWater()) {
-      Material above = palette.get(chunkData.getBlockAt(cx, cy+1, cz));
+      Block above = palette.get(chunkData.getBlockAt(cx, cy+1, cz));
       boolean isFullBlock = above.isWaterFilled();
       return isFullBlock ? 8 : 8 - ((Water) corner).level;
     } else if (corner.waterlogged) {
@@ -420,7 +420,7 @@ public class Chunk {
 
   public static int lavaLevelAt(ChunkData chunkData, BlockPalette palette, int cx, int cy, int cz,
                                 int baseLevel) {
-    Material corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
+    Block corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
     if (corner instanceof Lava) {
       Material above = palette.get(chunkData.getBlockAt(cx, cy+1, cz));
       boolean isFullBlock = above instanceof Lava;

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -45,12 +45,6 @@ public abstract class Material {
   public boolean opaque = false;
 
   /**
-   * The solid property controls various block behaviours like if the block connects to fences,
-   * gates, walls, etc.
-   */
-  public boolean solid = true;
-
-  /**
    * The specular coefficient controlling how shiny the block appears.
    */
   public float specular = 0;
@@ -87,8 +81,6 @@ public abstract class Material {
 
   public boolean refractive = false;
 
-  public boolean waterlogged = false;
-
   public Material(String name, Texture texture) {
     this.name = name;
     this.texture = texture;
@@ -100,7 +92,6 @@ public abstract class Material {
   public void restoreDefaults() {
     ior = DEFAULT_IOR;
     opaque = false;
-    solid = true;
     specular = 0;
     emittance = 0;
     roughness = 0;
@@ -129,10 +120,6 @@ public abstract class Material {
 
   public boolean isWater() {
     return false;
-  }
-
-  public boolean isWaterFilled() {
-    return waterlogged || isWater();
   }
 
   public boolean isSameMaterial(Material other) {

--- a/chunky/src/java/se/llbit/math/NodeBasedOctree.java
+++ b/chunky/src/java/se/llbit/math/NodeBasedOctree.java
@@ -1,6 +1,7 @@
 package se.llbit.math;
 
 import org.apache.commons.math3.util.FastMath;
+import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.UnknownBlock;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.world.Material;
@@ -143,7 +144,7 @@ public class NodeBasedOctree implements Octree.OctreeImplementation {
   }
 
   @Override
-  public Material getMaterial(int x, int y, int z, BlockPalette palette) {
+  public Block getMaterial(int x, int y, int z, BlockPalette palette) {
     Octree.Node node = get(x, y, z);
     if (node.type == BRANCH_NODE) {
       return UnknownBlock.UNKNOWN;

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -54,7 +54,11 @@ public class Octree {
 
   public interface OctreeImplementation {
     void set(int type, int x, int y, int z);
+    @Deprecated
     Material getMaterial(int x, int y, int z, BlockPalette palette);
+    default Block getBlock(int x, int y, int z, BlockPalette palette) {
+      return (Block) getMaterial(x, y, z, palette);
+    }
     void store(DataOutputStream output) throws IOException;
     int getDepth();
     long nodeCount();
@@ -290,11 +294,24 @@ public class Octree {
    * @param palette Block palette
    * @return Material at the given position or {@link Air#INSTANCE} if the position is outside of this octree
    */
+  @Deprecated
   public Material getMaterial(int x, int y, int z, BlockPalette palette) {
+    return getBlock(x, y, z, palette);
+  }
+
+  /**
+   * Get the block at the given position (relative to the octree origin).
+   * @param x x position
+   * @param y y position
+   * @param z z position
+   * @param palette Block palette
+   * @return Block at the given position or {@link Air#INSTANCE} if the position is outside of this octree
+   */
+  public Block getBlock(int x, int y, int z, BlockPalette palette) {
     int size = (1 << implementation.getDepth());
     if(x < 0 || y < 0 || z < 0 || x >= size || y >= size || z >= size)
       return Air.INSTANCE;
-    return implementation.getMaterial(x, y, z, palette);
+    return implementation.getBlock(x, y, z, palette);
   }
 
   /**


### PR DESCRIPTION
`solid` and `waterlogged` are block properties (Minecraft logic) and have nothing to do with the material (affects rendering). 

`opaque` is also more of a optimization for blocks that fill out the entire voxel, that could also be moved.