### PR TITLE
Doc patch

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -140,7 +140,6 @@ public class ChunkyFxController
   @FXML private Button openSceneDirBtn;
   @FXML private Button changeSceneDirBtn;
   @FXML private Hyperlink documentationLink;
-  @FXML private Hyperlink originalDocumentationLink;
   @FXML private Hyperlink gitHubLink;
   @FXML private Hyperlink issueTrackerLink;
   @FXML private Hyperlink forumLink;
@@ -754,10 +753,7 @@ public class ChunkyFxController
 
   public void setApplication(Application app) {
     documentationLink.setOnAction(
-        e -> app.getHostServices().showDocument("https://lemaik.github.io/chunky"));
-
-    originalDocumentationLink.setOnAction(
-        e -> app.getHostServices().showDocument("http://chunky.llbit.se"));
+        e -> app.getHostServices().showDocument("https://chunky-dev.github.io/docs/"));
 
     issueTrackerLink.setOnAction(
         e -> app.getHostServices().showDocument("https://github.com/llbit/chunky/issues"));

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -185,7 +185,7 @@
           <Hyperlink fx:id="guideLink" text="jackjt8's Guide to Chunky" />
           <Separator />
           <Label wrapText="true" text="Chunky was created by Jesper Öqvist (jesper@llbit.se)"/>
-          <Label wrapText="true" text="Chunky is Copyright (c) 2010-2021, Jesper Öqvist and Chunky contributors." />
+          <Label wrapText="true" text="Chunky is Copyright (c) 2010-2022, Jesper Öqvist and Chunky contributors." />
           <FlowPane>
             <Label wrapText="true" text="Permission to modify and redistribute is granted under the terms of the " />
             <Hyperlink fx:id="gplv3" wrapText="true" text="GNU General Public License v3">

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -177,8 +177,7 @@
             <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
           </padding>
           <Label text="Links:"/>
-          <Hyperlink fx:id="originalDocumentationLink" text="Online Documentation"/>
-          <Hyperlink fx:id="documentationLink" text="Chunky 2.1 Documentation"/>
+          <Hyperlink fx:id="documentationLink" text="Online Documentation"/>
           <Hyperlink fx:id="gitHubLink" text="GitHub Page"/>
           <Hyperlink fx:id="issueTrackerLink" text="Issue Tracker"/>
           <Hyperlink fx:id="forumLink" text="Discussion Forum"/>


### PR DESCRIPTION
Related to issue #1068 mainly surrounding links within the `About` tab. The link within the Launcher was already changed to a different direction site.

Also updated copyright to 2022.