### PR TITLE
Fix texture loading from zip files.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3689,7 +3689,7 @@ public class TexturePackLoader {
       } else {
         // jar or zip file
         texturePack = FileSystems.newFileSystem(URI.create("jar:" + tpFile.toURI()), Collections.emptyMap());
-        root = texturePack.getPath("");
+        root = texturePack.getPath("/");
       }
 
       boolean foundAssetDirectory = false;


### PR DESCRIPTION
Closes #1137.
Java was not happy with an empty root path for some reason.