### PR TITLE
Legacy map view optimisations

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockSpec.java
@@ -5,6 +5,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
 import se.llbit.util.NbtUtil;
@@ -38,8 +40,11 @@ public class BlockSpec {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    return (obj instanceof BlockSpec) && ((BlockSpec) obj).tag.equals(tag);
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BlockSpec blockSpec = (BlockSpec) o;
+    return Objects.equals(tag, blockSpec.tag);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocks.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocks.java
@@ -21,12 +21,16 @@ public class LegacyBlocks {
   }
 
   public static Tag getTag(int offset, byte[] blocks, byte[] blockData) {
+    return legacyTags[legacyIdx(offset, blocks, blockData)];
+  }
+
+  public static int legacyIdx(int offset, byte[] blocks, byte[] blockData) {
     int id = blocks[offset] & 0xFF;
     int data = 0xFF & blockData[offset / 2];
     data >>= (offset % 2) * 4;
     data &= 0xF;
 
-    return legacyTags[id * (1 << 4) + data];
+    return id * (1 << 4) + data;
   }
 
   private static Tag getTag(int id, int data) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -437,8 +437,7 @@ public class Chunk {
               int blockY = sectionMinBlockY + y;
               for (int z = 0; z < Z_MAX; z++) {
                 for (int x = 0; x < X_MAX; x++) {
-                  chunkData.setBlockAt(x, blockY, z, blockPalette.put(
-                      LegacyBlocks.getTag(offset, blocksBytes, blockDataBytes)));
+                  chunkData.setBlockAt(x, blockY, z, LegacyBlocks.legacyIdx(offset, blocksBytes, blockDataBytes));
                   offset += 1;
                 }
               }

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -85,7 +85,7 @@ public class EmptyChunk extends Chunk {
     // Do nothing.
   }
 
-  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(BlockPalette blockPalette, BiomePalette biomePalette, ChunkData chunkData, int yMin, int yMax) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -85,7 +85,7 @@ public class EmptyRegionChunk extends Chunk {
     // do nothing
   }
 
-  @Override public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(BlockPalette blockPalette, BiomePalette biomePalette, ChunkData chunkData, int yMin, int yMax) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -144,8 +144,7 @@ public class ImposterCubicChunk extends Chunk {
                   int blockY = cubeMinBlockY + y;
                   for (int z = 0; z < CUBE_DIAMETER_IN_BLOCKS; z++) {
                     for (int x = 0; x < CUBE_DIAMETER_IN_BLOCKS; x++) {
-                      chunkData.setBlockAt(x, blockY, z, blockPalette.put(
-                        LegacyBlocks.getTag(offset, blockArray, dataArray)));
+                      chunkData.setBlockAt(x, blockY, z, LegacyBlocks.legacyIdx(offset, blockArray, dataArray));
                       offset += 1;
                     }
                   }

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -52,7 +52,8 @@ public class ImposterCubicChunk extends Chunk {
    * layer, surface and cave maps.
    * @return whether the input chunkdata was modified
    */
-  public synchronized boolean loadChunk(ChunkData chunkData, int yMin, int yMax) {
+  @Override
+  public synchronized boolean loadChunk(BlockPalette blockPalette, BiomePalette biomePalette, ChunkData chunkData, int yMin, int yMax) {
     if (!shouldReloadChunk()) {
       return false;
     }
@@ -68,7 +69,7 @@ public class ImposterCubicChunk extends Chunk {
     }
 
     surfaceTimestamp = dataTimestamp;
-    loadSurfaceCubic(data, chunkData, yMin, yMax);
+    loadSurfaceCubic(blockPalette, biomePalette, data, chunkData, yMin, yMax);
     biomes = IconLayer.UNKNOWN;
 
     biomesTimestamp = dataTimestamp;
@@ -82,15 +83,13 @@ public class ImposterCubicChunk extends Chunk {
     return true;
   }
 
-  private void loadSurfaceCubic(Map<Integer, Map<String, Tag>> data, ChunkData chunkData, int yMin, int yMax) {
+  private void loadSurfaceCubic(BlockPalette blockPalette, BiomePalette biomePalette, Map<Integer, Map<String, Tag>> data, ChunkData chunkData, int yMin, int yMax) {
     if (data == null) {
       surface = IconLayer.CORRUPT;
       return;
     }
 
     Heightmap heightmap = world.heightmap();
-    BlockPalette palette = new BlockPalette();
-    BiomePalette biomePalette = new ArrayBiomePalette();
     biomePalette.put(Biomes.biomes[0]); //We don't currently support cubic chunks biomes, and so default to ocean
 
     for (Map.Entry<Integer, Map<String, Tag>> entry : data.entrySet()) {
@@ -101,15 +100,15 @@ public class ImposterCubicChunk extends Chunk {
       if (sections.isList()) {
 //        extractBiomeData(cubeData.get(LEVEL_BIOMES), chunkData);
         if (version.equals("1.13") || version.equals("1.12")) {
-          loadBlockDataCubic(yPos, cubeData, chunkData, palette, yMin, yMax);
+          loadBlockDataCubic(yPos, cubeData, chunkData, blockPalette, yMin, yMax);
           queueTopography();
         }
       }
     }
 
     int[] heightmapData = extractHeightmapDataCubic(null, chunkData);
-    updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
-    surface = new SurfaceLayer(world.currentDimension(), chunkData, palette, biomePalette, yMin, yMax, heightmapData);
+    updateHeightmap(heightmap, position, chunkData, heightmapData, blockPalette, yMax);
+    surface = new SurfaceLayer(world.currentDimension(), chunkData, blockPalette, biomePalette, yMin, yMax, heightmapData);
   }
 
   private int[] extractHeightmapDataCubic(Map<String, Tag> cubeData, ChunkData chunkData) {


### PR DESCRIPTION
Closes #1074
The main thing here is that the first 4096 blocks in any block palette are now legacy blocks
Those blocks can also be used by non-legacy chunks if their tag matches (thanks redox)

Palettes are created once per `RegionParser` thread now, instead of once per chunk

I also tweaked the load factor of the palette hashmap to somewhat avoid expensive collisions, given ~33000 blocks in the palette, the overhead is ~0.5MiB per palette