### PR TITLE
Use the correct scene directory throughout the project

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -139,7 +139,7 @@ public class Chunky {
       if (renderManager.getSnapshotControl().saveRenderDump(scene, spp)) {
         // Save the scene description and current render dump.
         try {
-          sceneManager.saveScene();
+          sceneManager.saveScene(getRenderContext().getSceneDirectory());
         } catch (InterruptedException e) {
           throw new Error(e);
         }
@@ -158,7 +158,7 @@ public class Chunky {
     });
 
     try {
-      sceneManager.loadScene(options.sceneName);
+      sceneManager.loadScene(options.sceneDir, options.sceneName);
       if (options.target != -1) {
         sceneManager.getScene().setTargetSpp(options.target);
       }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -139,6 +139,7 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
       }
     });
   }
+
   @PluginApi
   @Deprecated
   @Override public void saveScene() {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -111,6 +111,7 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
       }
     });
   }
+
   @PluginApi
   @Deprecated
   @Override public void loadScene(String name) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -17,6 +17,7 @@
  */
 package se.llbit.chunky.renderer.scene;
 
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.RenderContext;
 import se.llbit.chunky.renderer.RenderManager;
 import se.llbit.chunky.renderer.SceneProvider;
@@ -98,6 +99,7 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
    *
    * @param name the name of the scene to load.
    */
+  @PluginApi
   @Override public void loadScene(File sceneDirectory, String name) {
     enqueueTask(() -> {
       try {
@@ -109,14 +111,39 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
       }
     });
   }
+  @PluginApi
+  @Deprecated
+  @Override public void loadScene(String name) {
+    enqueueTask(() -> {
+      try {
+        sceneManager.loadScene(name);
+      } catch (IOException e) {
+        Log.warn("Could not load scene.\nReason: " + e.getMessage());
+      } catch (InterruptedException e) {
+        Log.warn("Scene loading was interrupted.");
+      }
+    });
+  }
 
   /**
    * Save the current scene.
    */
+  @PluginApi
   @Override public void saveScene(File sceneDirectory) {
     enqueueTask(() -> {
       try {
         sceneManager.saveScene(sceneDirectory);
+      } catch (InterruptedException e) {
+        Log.warn("Scene saving was interrupted.");
+      }
+    });
+  }
+  @PluginApi
+  @Deprecated
+  @Override public void saveScene() {
+    enqueueTask(() -> {
+      try {
+        sceneManager.saveScene();
       } catch (InterruptedException e) {
         Log.warn("Scene saving was interrupted.");
       }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -98,10 +98,10 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
    *
    * @param name the name of the scene to load.
    */
-  @Override public void loadScene(String name) {
+  @Override public void loadScene(File sceneDirectory, String name) {
     enqueueTask(() -> {
       try {
-        sceneManager.loadScene(name);
+        sceneManager.loadScene(sceneDirectory, name);
       } catch (IOException e) {
         Log.warn("Could not load scene.\nReason: " + e.getMessage());
       } catch (InterruptedException e) {
@@ -113,10 +113,10 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
   /**
    * Save the current scene.
    */
-  @Override public void saveScene() {
+  @Override public void saveScene(File sceneDirectory) {
     enqueueTask(() -> {
       try {
-        sceneManager.saveScene();
+        sceneManager.saveScene(sceneDirectory);
       } catch (InterruptedException e) {
         Log.warn("Scene saving was interrupted.");
       }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -415,9 +415,9 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Export the scene to a zip file.
    */
-  public static void exportToZip(String name, File targetFile) {
+  public static void exportToZip(File sceneDirectory, String name, File targetFile) {
     String[] extensions = { ".json", ".dump", ".octree2", ".foliage", ".grass", ".emittergrid", };
-    ZipExport.zip(targetFile, SynchronousSceneManager.resolveSceneDirectory(name), name, extensions);
+    ZipExport.zip(targetFile, new File(sceneDirectory, name), name, extensions);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.renderer.scene;
 import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.World;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 
@@ -29,12 +30,12 @@ public interface SceneManager {
   /**
    * Save the current scene.
    */
-  void saveScene() throws InterruptedException;
+  void saveScene(File sceneDirectory) throws InterruptedException;
 
   /**
    * Load a saved scene.
    */
-  void loadScene(String sceneName) throws IOException, InterruptedException;
+  void loadScene(File sceneDirectory, String sceneName) throws IOException, InterruptedException;
 
   /**
    * Load chunks and reset camera and scene.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.renderer.scene;
 
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.World;
 
@@ -30,12 +31,20 @@ public interface SceneManager {
   /**
    * Save the current scene.
    */
+  @PluginApi
   void saveScene(File sceneDirectory) throws InterruptedException;
+  @PluginApi
+  @Deprecated /* Remove in 2.6 snapshots */
+  void saveScene() throws InterruptedException;
 
   /**
    * Load a saved scene.
    */
+  @PluginApi
   void loadScene(File sceneDirectory, String sceneName) throws IOException, InterruptedException;
+  @PluginApi
+  @Deprecated /* Remove in 2.6 snapshots */
+  void loadScene(String sceneName) throws IOException, InterruptedException;
 
   /**
    * Load chunks and reset camera and scene.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
@@ -33,8 +33,13 @@ public interface SceneManager {
    */
   @PluginApi
   void saveScene(File sceneDirectory) throws InterruptedException;
+
+  /**
+   * {@link Deprecated} removed in 2.6 snapshots.
+   * replaced by {@link SceneManager#saveScene(File)}
+   */
   @PluginApi
-  @Deprecated /* Remove in 2.6 snapshots */
+  @Deprecated
   void saveScene() throws InterruptedException;
 
   /**
@@ -42,8 +47,13 @@ public interface SceneManager {
    */
   @PluginApi
   void loadScene(File sceneDirectory, String sceneName) throws IOException, InterruptedException;
+
+  /**
+   * {@link Deprecated} removed in 2.6 snapshots.
+   * replaced by {@link SceneManager#loadScene(File, String)}
+   */
   @PluginApi
-  @Deprecated /* Remove in 2.6 snapshots */
+  @Deprecated
   void loadScene(String sceneName) throws IOException, InterruptedException;
 
   /**

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -375,7 +375,7 @@ public class ChunkyFxController
 
       if (renderManager.getSnapshotControl().saveRenderDump(scene1, spp)) {
         // Save the scene description and current render dump.
-        asyncSceneManager.saveScene();
+        asyncSceneManager.saveScene(renderController.getContext().getSceneDirectory());
       }
     });
 
@@ -383,7 +383,7 @@ public class ChunkyFxController
     renderManager.setRenderTask(taskTracker.backgroundTask());
 
     saveScene.setGraphic(new ImageView(Icon.disk.fxImage()));
-    saveScene.setOnAction(e -> saveSceneSafe(sceneNameField.getText()));
+    saveScene.setOnAction(e -> saveSceneSafe(renderController.getContext().getSceneDirectory(), sceneNameField.getText()));
 
     loadScene.setGraphic(new ImageView(Icon.load.fxImage()));
     loadScene.setOnAction(e -> openSceneChooser());
@@ -405,7 +405,7 @@ public class ChunkyFxController
       }
       return change;
     }));
-    sceneNameField.setOnAction(event -> saveSceneSafe(sceneNameField.getText()));
+    sceneNameField.setOnAction(event -> saveSceneSafe(renderController.getContext().getSceneDirectory(), sceneNameField.getText()));
 
     Log.setReceiver(new UILogReceiver(), Level.ERROR, Level.WARNING);
 
@@ -885,9 +885,9 @@ public class ChunkyFxController
    * Loads a scene into chunky
    * @param sceneName The name of the scene. NOTE: Do not include extension.
    */
-  public void loadScene(String sceneName) {
+  public void loadScene(File sceneDirectory, String sceneName) {
     try {
-      chunky.getSceneManager().loadScene(sceneName);
+      chunky.getSceneManager().loadScene(sceneDirectory, sceneName);
     } catch (IOException | InterruptedException e) {
       Log.error("Failed to load scene", e);
     }
@@ -950,7 +950,7 @@ public class ChunkyFxController
     map.cameraViewUpdated();
   }
 
-  private void saveSceneSafe(String sceneName) {
+  private void saveSceneSafe(File sceneDirectory, String sceneName) {
     File oldFormat = new File(PersistentSettings.getSceneDirectory(), sceneName + Scene.EXTENSION);
     File newFormat = new File(PersistentSettings.getSceneDirectory(), sceneName);
     if (oldFormat.exists() || newFormat.exists()) {
@@ -963,7 +963,7 @@ public class ChunkyFxController
     scene.setName(sceneName);
     renderController.getSceneProvider().withSceneProtected(scene1 -> scene1.setName(sceneName));
     updateTitle();
-    asyncSceneManager.saveScene();
+    asyncSceneManager.saveScene(sceneDirectory);
   }
 
 }

--- a/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/SceneChooserController.java
@@ -78,7 +78,7 @@ public class SceneChooserController implements Initializable {
         fileChooser.setInitialFileName(String.format("%s.zip", scene.sceneName));
         File targetFile = fileChooser.showSaveDialog(stage);
         if (targetFile != null) {
-          Scene.exportToZip(scene.sceneName, targetFile);
+          Scene.exportToZip(scene.sceneDirectory, scene.sceneName, targetFile);
         }
       }
     });
@@ -159,7 +159,7 @@ public class SceneChooserController implements Initializable {
           if (scene.sceneName.isEmpty()) {
             Log.error("Can't load scene with unknown filename.");
           } else {
-            controller.loadScene(scene.sceneName);
+            controller.loadScene(scene.sceneDirectory, scene.sceneName);
             e.consume();
             stage.close();
           }
@@ -173,7 +173,7 @@ public class SceneChooserController implements Initializable {
         if (scene.sceneName.isEmpty()) {
           Log.error("Can't load scene with unknown filename.");
         } else {
-          controller.loadScene(scene.sceneName);
+          controller.loadScene(scene.sceneDirectory, scene.sceneName);
           stage.close();
         }
       }


### PR DESCRIPTION
There were several places where we assumed the scene directory was the default location, which is
not the case when using the `-scene-dir` argument.

This PR removes `resolveSceneDirectory()` entirely, as that assumed the default location


In my testing, this works correctly both with no `-scene-dir` argument, and a specified one.
I have not fiddled with this part of chunky before, so some testing from someone more experienced would be appreciated