### PR TITLE
Make load world confirmation always on top.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -71,6 +71,8 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
+import javafx.stage.Stage;
+import javafx.stage.Window;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.launcher.LauncherSettings;
 import se.llbit.chunky.main.Chunky;
@@ -350,6 +352,11 @@ public class ChunkyFxController
           loadWorldConfirm.setTitle("Load scene world");
           loadWorldConfirm.setContentText(
               "This scene shows a different world than the one that is currently loaded. Do you want to load the world of this scene?");
+          Window window = loadWorldConfirm.getDialogPane().getScene().getWindow();
+          if (window instanceof Stage) {
+            ((Stage) window).setAlwaysOnTop(true);
+            ((Stage) window).toFront();
+          }
           if (loadWorldConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
             mapLoader.loadWorld(newWorld.getWorldDirectory());
           }

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -71,8 +71,6 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
-import javafx.stage.Stage;
-import javafx.stage.Window;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.launcher.LauncherSettings;
 import se.llbit.chunky.main.Chunky;
@@ -352,11 +350,7 @@ public class ChunkyFxController
           loadWorldConfirm.setTitle("Load scene world");
           loadWorldConfirm.setContentText(
               "This scene shows a different world than the one that is currently loaded. Do you want to load the world of this scene?");
-          Window window = loadWorldConfirm.getDialogPane().getScene().getWindow();
-          if (window instanceof Stage) {
-            ((Stage) window).setAlwaysOnTop(true);
-            ((Stage) window).toFront();
-          }
+          Dialogs.stayOnTop(loadWorldConfirm);
           if (loadWorldConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
             mapLoader.loadWorld(newWorld.getWorldDirectory());
           }

--- a/chunky/src/java/se/llbit/chunky/ui/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/WorldChooserController.java
@@ -140,6 +140,7 @@ public class WorldChooserController implements Initializable {
         loadTexturesConfirm.setTitle("Bundled resource pack");
         loadTexturesConfirm.setContentText(
                 "The world \"" + world.levelName() + "\" contains a resource pack. Do you want to load it now?");
+        Dialogs.stayOnTop(loadTexturesConfirm);
         if (loadTexturesConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
           if (!texturePacks.contains(worldResourcePack.getAbsolutePath())) {
             texturePacks.add(0, worldResourcePack.getAbsolutePath());

--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -10,6 +10,8 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
+import javafx.stage.Stage;
+import javafx.stage.Window;
 
 public class Dialogs {
 
@@ -38,6 +40,18 @@ public class Dialogs {
       content,
       confirmLabel
     );
+  }
+
+  /**
+   * Makes the given dialog always stay on top of its parent window.
+   * @param dialog A dialog
+   */
+  public static void stayOnTop(Alert dialog) {
+    Window window = dialog.getDialogPane().getScene().getWindow();
+    if (window instanceof Stage) {
+      ((Stage) window).setAlwaysOnTop(true);
+      ((Stage) window).toFront();
+    }
   }
 
   /**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42661490/154415539-850c925e-081c-4fdd-ad0b-0f971215a1ce.png)
