### PR TITLE
Fix empty 16x16x16 sections of identical blocks.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -278,6 +278,23 @@ public class Chunk {
                 }
               }
             }
+          } else {
+            // Single block palette
+            if (localBlockPalette.size() == 1) {
+              // Check it is not air block
+              int block = blockPalette.put(localBlockPalette.get(0));
+              if (block != blockPalette.airId) {
+                // Set the entire section
+                for (int y = 0; y < SECTION_Y_MAX; y++) {
+                  int blockY = sectionMinBlockY + y;
+                  for (int z = 0; z < Z_MAX; z++) {
+                    for(int x = 0; x < X_MAX; x++) {
+                      chunkData.setBlockAt(x, blockY, z, block);
+                    }
+                  }
+                }
+              }
+            }
           }
         } else {
           int yOffset = sectionY & 0xFF;


### PR DESCRIPTION
Closes #1191 
![image](https://user-images.githubusercontent.com/42661490/157995859-90d88aac-fd26-425f-b6f6-5565b1ffc028.png)

Looks like sections that are optimized by not including a block data array and rather just having a single block palette with a non-air block were ignored.