### PR TITLE
Do not autocomplete `.0` until enter is pressed or focus is lost.

### DIFF
--- a/lib/src/se/llbit/chunky/ui/NumericTextField.java
+++ b/lib/src/se/llbit/chunky/ui/NumericTextField.java
@@ -46,6 +46,7 @@ public class NumericTextField<T extends Property<Number>> extends TextField {
       }
     });
 
+    triggerRefresh();
     textProperty().addListener(observable -> {
       Number result = converter.fromString(textProperty().get());
       if(result != null && isValid()) {

--- a/lib/src/se/llbit/chunky/ui/NumericTextField.java
+++ b/lib/src/se/llbit/chunky/ui/NumericTextField.java
@@ -4,6 +4,7 @@ import javafx.beans.property.Property;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
+import javafx.scene.input.KeyCode;
 
 /**
  * A {@link TextField} that automatically converts the value to a number.
@@ -29,9 +30,22 @@ public class NumericTextField<T extends Property<Number>> extends TextField {
     // TODO: fixme
     converter.getDecimalFormat().setGroupingUsed(false);
 
-    value.addListener(observable -> {
-      textProperty().set(converter.toString(value.getValue()));
+    this.value.addListener((observable, oldValue, newValue) -> {
+      if (!this.focusedProperty().get()) {
+        triggerRefresh(); // Change while not focused
+      }
     });
+    this.setOnKeyPressed(event -> {
+      if (event.getCode().equals(KeyCode.ENTER)) {
+        triggerRefresh(); // Enter pressed
+      }
+    });
+    this.focusedProperty().addListener((observable, oldValue, newValue) -> {
+      if (!newValue) {
+        triggerRefresh(); // Focus lost
+      }
+    });
+
     textProperty().addListener(observable -> {
       Number result = converter.fromString(textProperty().get());
       if(result != null && isValid()) {


### PR DESCRIPTION
When the input box has focus, do not autoformat until enter is pressed or focus is lost. Otherwise, only autoformat when it is not focused.
Closes #1202.