### PR TITLE
Fix weird special-casing for positive bounds on IntegerAdjuster

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -90,6 +90,7 @@ import se.llbit.chunky.ui.ChunkMap;
 import se.llbit.chunky.ui.dialogs.Credits;
 import se.llbit.chunky.ui.DoubleTextField;
 import se.llbit.chunky.ui.IntegerAdjuster;
+import se.llbit.chunky.ui.PositiveIntegerAdjuster;
 import se.llbit.chunky.ui.ProgressTracker;
 import se.llbit.chunky.ui.RenderCanvasFx;
 import se.llbit.chunky.ui.dialogs.DialogUtils;
@@ -137,7 +138,7 @@ public class ChunkyFxController
   @FXML private ToggleButton overworldBtn;
   @FXML private ToggleButton netherBtn;
   @FXML private ToggleButton endBtn;
-  @FXML private IntegerAdjuster scale;
+  @FXML private PositiveIntegerAdjuster scale;
   @FXML private IntegerAdjuster yMin;
   @FXML private IntegerAdjuster yMax;
   @FXML private ToggleButton trackPlayerBtn;
@@ -184,7 +185,7 @@ public class ChunkyFxController
   @FXML private Label etaLbl;
   @FXML private Label renderTimeLbl;
   @FXML private Label sppLbl;
-  @FXML private IntegerAdjuster targetSpp;
+  @FXML private PositiveIntegerAdjuster targetSpp;
   @FXML private Button saveDefaultSpp;
 
   @FXML private ToggleButton start;

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -24,6 +24,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import se.llbit.chunky.ui.IntegerAdjuster?>
+<?import se.llbit.chunky.ui.PositiveIntegerAdjuster?>
 <?import se.llbit.chunky.ui.DoubleTextField?>
 <?import se.llbit.fx.ToolPane?>
 <?import javafx.scene.layout.FlowPane?>
@@ -72,7 +73,7 @@
           <ToggleButton fx:id="reset" mnemonicParsing="false" text="Reset" toggleGroup="$renderControl" selected="true" />
         </HBox>
         <HBox alignment="CENTER_LEFT" spacing="10.0">
-          <IntegerAdjuster fx:id="targetSpp" />
+          <PositiveIntegerAdjuster fx:id="targetSpp" />
           <Button fx:id="saveDefaultSpp" mnemonicParsing="false" text="Set default" />
         </HBox>
       </VBox>
@@ -116,7 +117,7 @@
           </HBox>
           <Separator />
           <VBox alignment="CENTER_LEFT">
-            <IntegerAdjuster fx:id="scale" name="Scale" />
+            <PositiveIntegerAdjuster fx:id="scale" name="Scale" />
           </VBox>
           <VBox alignment="CENTER_LEFT">
             <IntegerAdjuster fx:id="yMin" name="Min Y level " />

--- a/lib/src/se/llbit/chunky/ui/IntegerAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/IntegerAdjuster.java
@@ -35,7 +35,6 @@ public class IntegerAdjuster extends SliderAdjuster<Integer> {
   public void setRange(double min, double max) {
     super.setRange(min, max);
     this.min = (int) min;
-    this.valueField.getConverter().setParseNonNegativeOnly(min >= 0.0);
     this.max = (int) max;
   }
 
@@ -50,5 +49,4 @@ public class IntegerAdjuster extends SliderAdjuster<Integer> {
     }
     return result;
   }
-
 }

--- a/lib/src/se/llbit/chunky/ui/PositiveIntegerAdjuster.java
+++ b/lib/src/se/llbit/chunky/ui/PositiveIntegerAdjuster.java
@@ -1,0 +1,35 @@
+package se.llbit.chunky.ui;
+
+import javafx.beans.property.SimpleIntegerProperty;
+
+/**
+ * An integer adjuster stores integer values.
+ */
+public class PositiveIntegerAdjuster extends SliderAdjuster<Integer> {
+  private int min = Integer.MIN_VALUE;
+  private int max = Integer.MAX_VALUE;
+
+  public PositiveIntegerAdjuster() {
+    super(new SimpleIntegerProperty());
+    this.valueField.getConverter().setParseIntegerOnly(true);
+    this.valueField.getConverter().setParseNonNegativeOnly(true);
+    this.valueField.triggerRefresh();
+  }
+
+  public void setRange(double min, double max) {
+    super.setRange(min, max);
+    this.min = (int) Math.max(0, min); // PositiveIntegerAdjuster can't have negative bounds
+    this.max = (int) Math.max(0, max);
+  }
+
+  @Override protected Integer clamp(Number value) {
+    int result = value.intValue();
+    if (clampMax) {
+      result = Math.min(result, max);
+    }
+    if (clampMin) {
+      result = Math.max(result, min);
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Closes #1210

Add PositiveIntegerAdjuster to cover the cases where it was required

Negative ints are properly accepted in the correct fields. (As soon as you click off the errored field it will clamp it to the minimum)
![image](https://user-images.githubusercontent.com/16853282/159806339-7705cc9e-8ad3-4fd8-bda6-8e14c3a43bd9.png)
