### PR TITLE
Add `High Quality` sun sampling mode. Fix issue where enabling draw sun but not enabling sunlight would draw a sun with no contribution to the scene.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
@@ -19,16 +19,27 @@ package se.llbit.chunky.renderer;
 import se.llbit.util.Registerable;
 
 public enum SunSamplingStrategy implements Registerable {
-    Off("Off", "Sun is not sampled with next event estimation."),
-    Fast("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects."),
-    HighQuality("High Quality", "High quality sun sampling. More noise but correctly models visual effects.");
+    Off("Off", "Sun is not sampled with next event estimation.", false, true, false, true),
+    NonLuminous("Non-Luminous", "Sun is drawn on the skybox but it does not contribute to the lighting of the scene.", false, false, false, false),
+    Fast("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects.", true, false, false, false),
+    HighQuality("High Quality", "High quality sun sampling. More noise but correctly models visual effects.", true, true, true, true);
 
     private final String friendlyName;
     private final String description;
 
-    SunSamplingStrategy(String name, String description) {
+    private final boolean sunSampling;
+    private final boolean diffuseSun;
+    private final boolean strictDirectLight;
+    private final boolean sunLuminosity;
+
+    SunSamplingStrategy(String name, String description, boolean sunSampling, boolean diffuseSun, boolean strictDirectLight, boolean sunLuminosity) {
         this.friendlyName = name;
         this.description = description;
+
+        this.sunSampling = sunSampling;
+        this.diffuseSun = diffuseSun;
+        this.strictDirectLight = strictDirectLight;
+        this.sunLuminosity = sunLuminosity;
     }
 
     @Override
@@ -44,5 +55,21 @@ public enum SunSamplingStrategy implements Registerable {
     @Override
     public String getId() {
         return this.name();
+    }
+
+    public boolean doSunSampling() {
+        return sunSampling;
+    }
+
+    public boolean isDiffuseSun() {
+        return diffuseSun;
+    }
+
+    public boolean isStrictDirectLight() {
+        return strictDirectLight;
+    }
+
+    public boolean isSunLuminosity() {
+        return sunLuminosity;
     }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
@@ -1,0 +1,32 @@
+package se.llbit.chunky.renderer;
+
+import se.llbit.util.Registerable;
+
+public enum SunSamplingStrategy implements Registerable {
+    Off("Off", "Sun is not sampled with next event estimation."),
+    Fast("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects."),
+    HighQuality("High Quality", "High quality sun sampling. More noise but correctly models visual effects.");
+
+    private final String friendlyName;
+    private final String description;
+
+    SunSamplingStrategy(String name, String description) {
+        this.friendlyName = name;
+        this.description = description;
+    }
+
+    @Override
+    public String getName() {
+        return this.friendlyName;
+    }
+
+    @Override
+    public String getDescription() {
+        return this.description;
+    }
+
+    @Override
+    public String getId() {
+        return this.name();
+    }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
@@ -1,3 +1,19 @@
+/* Copyright (c) 2022 Chunky Contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package se.llbit.chunky.renderer;
 
 import se.llbit.util.Registerable;

--- a/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
@@ -19,12 +19,12 @@ package se.llbit.chunky.renderer;
 import se.llbit.util.Registerable;
 
 public enum SunSamplingStrategy implements Registerable {
-    Off("Off", "Sun is not sampled with next event estimation.", false, true, false, true),
-    NonLuminous("Non-Luminous", "Sun is drawn on the skybox but it does not contribute to the lighting of the scene.", false, false, false, false),
-    Fast("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects.", true, false, false, false),
-    HighQuality("High Quality", "High quality sun sampling. More noise but correctly models visual effects.", true, true, true, true);
+    OFF("Off", "Sun is not sampled with next event estimation.", false, true, false, true),
+    NON_LUMINOUS("Non-Luminous", "Sun is drawn on the skybox but it does not contribute to the lighting of the scene.", false, false, false, false),
+    FAST("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects.", true, false, false, false),
+    HIGH_QUALITY("High Quality", "High quality sun sampling. More noise but correctly models visual effects such as caustics.", true, true, true, true);
 
-    private final String friendlyName;
+    private final String displayName;
     private final String description;
 
     private final boolean sunSampling;
@@ -32,8 +32,8 @@ public enum SunSamplingStrategy implements Registerable {
     private final boolean strictDirectLight;
     private final boolean sunLuminosity;
 
-    SunSamplingStrategy(String name, String description, boolean sunSampling, boolean diffuseSun, boolean strictDirectLight, boolean sunLuminosity) {
-        this.friendlyName = name;
+    SunSamplingStrategy(String displayName, String description, boolean sunSampling, boolean diffuseSun, boolean strictDirectLight, boolean sunLuminosity) {
+        this.displayName = displayName;
         this.description = description;
 
         this.sunSampling = sunSampling;
@@ -44,7 +44,7 @@ public enum SunSamplingStrategy implements Registerable {
 
     @Override
     public String getName() {
-        return this.friendlyName;
+        return this.displayName;
     }
 
     @Override

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013-2015 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2013-2022 Chunky Contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -87,7 +87,7 @@ public class PathTracer implements RayTracer {
           hit = true;
         } else {
           // Indirect sky hit - diffuse color.
-          scene.sky.getSkyColor(ray, scene.getSunSamplingStrategy() != SunSamplingStrategy.Fast);
+          scene.sky.getSkyColor(ray, scene.getSunSamplingStrategy().isDiffuseSun());
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
         }
@@ -193,7 +193,7 @@ public class PathTracer implements RayTracer {
               }
             }
 
-            if (scene.getSunSamplingStrategy() != SunSamplingStrategy.Off) {
+            if (scene.getSunSamplingStrategy().doSunSampling()) {
               reflected.set(ray);
               scene.sun.getRandomSunDirection(reflected, random);
 
@@ -511,7 +511,7 @@ public class PathTracer implements RayTracer {
           attenuation.w *= Math.exp(-a);
         }
       }
-      if (scene.getSunSamplingStrategy() == SunSamplingStrategy.HighQuality && ray.getPrevMaterial().ior != ray.getCurrentMaterial().ior) {
+      if (scene.getSunSamplingStrategy().isStrictDirectLight() && ray.getPrevMaterial().ior != ray.getCurrentMaterial().ior) {
         attenuation.w = 0;
       }
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -193,7 +193,7 @@ public class PathTracer implements RayTracer {
               }
             }
 
-            if (scene.getSunSamplingStrategy().doSunSampling()) {
+            if (scene.sun().drawTexture() && scene.getSunSamplingStrategy().doSunSampling()) {
               reflected.set(ray);
               scene.sun.getRandomSunDirection(reflected, random);
 
@@ -216,7 +216,7 @@ public class PathTracer implements RayTracer {
 
                 Vector4 attenuation = state.attenuation;
                 if (attenuation.w > 0) {
-                  double mult = QuickMath.abs(reflected.d.dot(ray.getNormal()));
+                  double mult = QuickMath.abs(reflected.d.dot(ray.getNormal())) * (scene.getSunSamplingStrategy().isSunLuminosity() ? scene.sun().getLuminosityPdf() : 1);
                   directLightR = attenuation.x * attenuation.w * mult;
                   directLightG = attenuation.y * attenuation.w * mult;
                   directLightB = attenuation.z * attenuation.w * mult;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.block.Air;
 import se.llbit.chunky.block.Water;
 import se.llbit.chunky.model.WaterModel;
 import se.llbit.chunky.renderer.EmitterSamplingStrategy;
+import se.llbit.chunky.renderer.SunSamplingStrategy;
 import se.llbit.chunky.renderer.WorkerState;
 import se.llbit.chunky.world.Material;
 import se.llbit.math.*;
@@ -85,7 +86,7 @@ public class PathTracer implements RayTracer {
           hit = true;
         } else {
           // Indirect sky hit - diffuse color.
-          scene.sky.getSkyColor(ray, !scene.getFastSunSampling());
+          scene.sky.getSkyColor(ray, scene.getSunSamplingStrategy() != SunSamplingStrategy.Fast);
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
         }
@@ -191,7 +192,7 @@ public class PathTracer implements RayTracer {
               }
             }
 
-            if (scene.sunEnabled) {
+            if (scene.getSunSamplingStrategy() != SunSamplingStrategy.Off) {
               reflected.set(ray);
               scene.sun.getRandomSunDirection(reflected, random);
 
@@ -509,7 +510,7 @@ public class PathTracer implements RayTracer {
           attenuation.w *= Math.exp(-a);
         }
       }
-      if (scene.getFastSunSampling() && ray.getPrevMaterial().ior != ray.getCurrentMaterial().ior) {
+      if (scene.getSunSamplingStrategy() == SunSamplingStrategy.HighQuality && ray.getPrevMaterial().ior != ray.getCurrentMaterial().ior) {
         attenuation.w = 0;
       }
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -80,12 +80,12 @@ public class PathTracer implements RayTracer {
           }
         } else if (ray.specular) {
           // Indirect sky hit - specular color.
-          scene.sky.getSkySpecularColor(ray);
+          scene.sky.getSkyColor(ray, true);
           scene.addSkyFog(ray);
           hit = true;
         } else {
           // Indirect sky hit - diffuse color.
-          scene.sky.getSkyColor(ray);
+          scene.sky.getSkyColor(ray, !scene.getFastSunSampling());
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
         }
@@ -508,6 +508,9 @@ public class PathTracer implements RayTracer {
           double a = ray.distance / scene.waterVisibility;
           attenuation.w *= Math.exp(-a);
         }
+      }
+      if (scene.getFastSunSampling() && ray.getPrevMaterial().ior != ray.getCurrentMaterial().ior) {
+        attenuation.w = 0;
       }
     }
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -1,5 +1,5 @@
-/* Copyright (c) 2013-2021 Jesper Öqvist <jesper@llbit.se>
- * Copyright (c) 2013-2021 Chunky contributors
+/* Copyright (c) 2013-2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2013-2022 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -54,7 +54,7 @@ public class PreviewRayTracer implements RayTracer {
     }
 
     if (ray.getCurrentMaterial() == Air.INSTANCE) {
-      scene.sky.getSkySpecularColor(ray);
+      scene.sky.getSkyColor(ray, true);
     } else {
       scene.sun.flatShading(ray);
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1,5 +1,5 @@
-/* Copyright (c) 2012-2021 Jesper Öqvist <jesper@llbit.se>
- * Copyright (c) 2012-2021 Chunky contributors
+/* Copyright (c) 2012-2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012-2022 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2898,6 +2898,22 @@ public class Scene implements JsonSerializable, Refreshable {
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
 
+    if (json.get("sunSamplingStrategy").isUnknown()) {
+      boolean sunSampling = json.get("sunEnabled").boolValue(false);
+      boolean drawSun = json.get("sun").asObject().get("drawTexture").boolValue(false);
+      if (drawSun) {
+        if (sunSampling) {
+          sunSamplingStrategy = SunSamplingStrategy.Fast;
+        } else {
+          sunSamplingStrategy = SunSamplingStrategy.NonLuminous;
+        }
+      } else {
+        sunSamplingStrategy = SunSamplingStrategy.Fast;
+      }
+    } else {
+      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.Fast.getId()));
+    }
+
     if (json.get("sunEnabled").boolValue(false)) {
       sunSamplingStrategy = SunSamplingStrategy.Fast;
     } else {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -230,7 +230,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
-  protected SunSamplingStrategy sunSamplingStrategy = SunSamplingStrategy.Fast;
+  protected SunSamplingStrategy sunSamplingStrategy = SunSamplingStrategy.FAST;
 
   /**
    * Water opacity modifier.
@@ -2903,21 +2903,21 @@ public class Scene implements JsonSerializable, Refreshable {
       boolean drawSun = json.get("sun").asObject().get("drawTexture").boolValue(false);
       if (drawSun) {
         if (sunSampling) {
-          sunSamplingStrategy = SunSamplingStrategy.Fast;
+          sunSamplingStrategy = SunSamplingStrategy.FAST;
         } else {
-          sunSamplingStrategy = SunSamplingStrategy.NonLuminous;
+          sunSamplingStrategy = SunSamplingStrategy.NON_LUMINOUS;
         }
       } else {
-        sunSamplingStrategy = SunSamplingStrategy.Fast;
+        sunSamplingStrategy = SunSamplingStrategy.FAST;
       }
     } else {
-      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.Fast.getId()));
+      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.FAST.getId()));
     }
 
     if (json.get("sunEnabled").boolValue(false)) {
-      sunSamplingStrategy = SunSamplingStrategy.Fast;
+      sunSamplingStrategy = SunSamplingStrategy.FAST;
     } else {
-      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.Fast.getId()));
+      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.FAST.getId()));
     }
 
     stillWater = json.get("stillWater").boolValue(stillWater);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -231,6 +231,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
   protected boolean sunEnabled = true;
+  protected boolean fastSunSampling = true;
   /**
    * Water opacity modifier.
    */
@@ -488,6 +489,7 @@ public class Scene implements JsonSerializable, Refreshable {
     fogColor.set(other.fogColor);
     biomeColors = other.biomeColors;
     sunEnabled = other.sunEnabled;
+    fastSunSampling = other.fastSunSampling;
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
@@ -682,6 +684,17 @@ public class Scene implements JsonSerializable, Refreshable {
       sunEnabled = value;
       refresh();
     }
+  }
+
+  public synchronized void setFastSunSampling(boolean value) {
+    if (value != fastSunSampling) {
+      fastSunSampling = value;
+      refresh();
+    }
+  }
+
+  public boolean getFastSunSampling() {
+    return fastSunSampling;
   }
 
   /**
@@ -2897,6 +2910,7 @@ public class Scene implements JsonSerializable, Refreshable {
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
     sunEnabled = json.get("sunEnabled").boolValue(sunEnabled);
+    fastSunSampling = json.get("fastSunSampling").boolValue(fastSunSampling);
     stillWater = json.get("stillWater").boolValue(stillWater);
     waterOpacity = json.get("waterOpacity").doubleValue(waterOpacity);
     waterVisibility = json.get("waterVisibility").doubleValue(waterVisibility);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -230,8 +230,8 @@ public class Scene implements JsonSerializable, Refreshable {
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
-  protected boolean sunEnabled = true;
-  protected boolean fastSunSampling = true;
+  protected SunSamplingStrategy sunSamplingStrategy = SunSamplingStrategy.Fast;
+
   /**
    * Water opacity modifier.
    */
@@ -488,8 +488,7 @@ public class Scene implements JsonSerializable, Refreshable {
     waterColor.set(other.waterColor);
     fogColor.set(other.fogColor);
     biomeColors = other.biomeColors;
-    sunEnabled = other.sunEnabled;
-    fastSunSampling = other.fastSunSampling;
+    sunSamplingStrategy = other.sunSamplingStrategy;
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
@@ -660,13 +659,6 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * @return <code>true</code> if sunlight is enabled
-   */
-  public boolean getDirectLight() {
-    return sunEnabled;
-  }
-
-  /**
    * Set emitters enable flag.
    */
   public synchronized void setEmittersEnabled(boolean value) {
@@ -677,24 +669,20 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * Set sunlight enable flag.
+   * Set sun sampling strategy.
    */
-  public synchronized void setDirectLight(boolean value) {
-    if (value != sunEnabled) {
-      sunEnabled = value;
+  public synchronized void setSunSamplingStrategy(SunSamplingStrategy strategy) {
+    if (strategy != this.sunSamplingStrategy) {
+      this.sunSamplingStrategy = strategy;
       refresh();
     }
   }
 
-  public synchronized void setFastSunSampling(boolean value) {
-    if (value != fastSunSampling) {
-      fastSunSampling = value;
-      refresh();
-    }
-  }
-
-  public boolean getFastSunSampling() {
-    return fastSunSampling;
+  /**
+   * Get sun sampling strategy.
+   */
+  public SunSamplingStrategy getSunSamplingStrategy() {
+    return this.sunSamplingStrategy;
   }
 
   /**
@@ -2613,8 +2601,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("saveSnapshots", saveSnapshots);
     json.add("emittersEnabled", emittersEnabled);
     json.add("emitterIntensity", emitterIntensity);
-    json.add("sunEnabled", sunEnabled);
-    json.add("fastSunSampling", fastSunSampling);
+    json.add("sunSamplingStrategy", sunSamplingStrategy.getId());
     json.add("stillWater", stillWater);
     json.add("waterOpacity", waterOpacity);
     json.add("waterVisibility", waterVisibility);
@@ -2910,8 +2897,13 @@ public class Scene implements JsonSerializable, Refreshable {
     saveSnapshots = json.get("saveSnapshots").boolValue(saveSnapshots);
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
-    sunEnabled = json.get("sunEnabled").boolValue(sunEnabled);
-    fastSunSampling = json.get("fastSunSampling").boolValue(fastSunSampling);
+
+    if (json.get("sunEnabled").boolValue(false)) {
+      sunSamplingStrategy = SunSamplingStrategy.Fast;
+    } else {
+      sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.Fast.getId()));
+    }
+
     stillWater = json.get("stillWater").boolValue(stillWater);
     waterOpacity = json.get("waterOpacity").doubleValue(waterOpacity);
     waterVisibility = json.get("waterVisibility").doubleValue(waterVisibility);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2614,6 +2614,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("emittersEnabled", emittersEnabled);
     json.add("emitterIntensity", emitterIntensity);
     json.add("sunEnabled", sunEnabled);
+    json.add("fastSunSampling", fastSunSampling);
     json.add("stillWater", stillWater);
     json.add("waterOpacity", waterOpacity);
     json.add("waterVisibility", waterVisibility);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -446,7 +446,7 @@ public class Sky implements JsonSerializable {
     double g = ray.color.y;
     double b = ray.color.z;
     if (scene.sun().intersect(ray)) {
-      double mult = scene.getSunSamplingStrategy() == SunSamplingStrategy.Fast ? 1 : scene.sun().getLuminosity();
+      double mult = scene.getSunSamplingStrategy().isSunLuminosity() ? 1 : scene.sun().getLuminosity();
 
       // Blend sun color with current color.
       ray.color.x = ray.color.x * mult + r;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -446,7 +446,7 @@ public class Sky implements JsonSerializable {
     double g = ray.color.y;
     double b = ray.color.z;
     if (scene.sun().intersect(ray)) {
-      double mult = scene.getSunSamplingStrategy().isSunLuminosity() ? 1 : scene.sun().getLuminosity();
+      double mult = scene.getSunSamplingStrategy().isSunLuminosity() ? scene.sun().getLuminosity() : 1;
 
       // Blend sun color with current color.
       ray.color.x = ray.color.x * mult + r;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.renderer.scene;
 
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.block.Air;
+import se.llbit.chunky.renderer.SunSamplingStrategy;
 import se.llbit.chunky.resources.HDRTexture;
 import se.llbit.chunky.resources.PFMTexture;
 import se.llbit.chunky.resources.Texture;
@@ -445,7 +446,7 @@ public class Sky implements JsonSerializable {
     double g = ray.color.y;
     double b = ray.color.z;
     if (scene.sun().intersect(ray)) {
-      double mult = scene.getFastSunSampling() ? 1 : scene.sun().getTrueIntensity();
+      double mult = scene.getSunSamplingStrategy() == SunSamplingStrategy.Fast ? 1 : scene.sun().getLuminosity();
 
       // Blend sun color with current color.
       ray.color.x = ray.color.x * mult + r;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -1,5 +1,5 @@
-/* Copyright (c) 2012 - 2021 Jesper Öqvist <jesper@llbit.se>
- * Copyright (c) 2012 - 2021 Chunky contributors
+/* Copyright (c) 2012 - 2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012 - 2022 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -346,9 +346,10 @@ public class Sky implements JsonSerializable {
   /**
    * Panoramic skymap color.
    */
-  public void getSkyColor(Ray ray) {
+  public void getSkyColor(Ray ray, boolean drawSun) {
     getSkyDiffuseColorInner(ray);
     ray.color.scale(skyLightModifier);
+    if (drawSun) addSunColor(ray);
     ray.color.w = 1;
   }
 
@@ -436,14 +437,6 @@ public class Sky implements JsonSerializable {
   }
 
   /**
-   * Get the specular sky color for the ray.
-   */
-  public void getSkySpecularColor(Ray ray) {
-    getSkyColor(ray);
-    addSunColor(ray);
-  }
-
-  /**
    * Add sun color contribution. This does not alpha blend the sun color
    * because the Minecraft sun texture has no alpha channel.
    */
@@ -452,10 +445,12 @@ public class Sky implements JsonSerializable {
     double g = ray.color.y;
     double b = ray.color.z;
     if (scene.sun().intersect(ray)) {
+      double mult = scene.getFastSunSampling() ? 1 : scene.sun().getTrueIntensity();
+
       // Blend sun color with current color.
-      ray.color.x = ray.color.x + r;
-      ray.color.y = ray.color.y + g;
-      ray.color.z = ray.color.z + b;
+      ray.color.x = ray.color.x * mult + r;
+      ray.color.y = ray.color.y * mult + g;
+      ray.color.z = ray.color.z * mult + b;
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -120,8 +120,8 @@ public class Sun implements JsonSerializable {
 
   private double intensity = DEFAULT_INTENSITY;
 
-  private double trueIntensity = 1;
-  private double truePdf = 1;
+  private double trueIntensity = 100;
+  private double truePdf = 1.0 / trueIntensity;
 
   private double azimuth = Math.PI / 2.5;
   private double altitude = Math.PI / 3;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -120,8 +120,8 @@ public class Sun implements JsonSerializable {
 
   private double intensity = DEFAULT_INTENSITY;
 
-  private double trueIntensity = 100;
-  private double truePdf = 1.0 / trueIntensity;
+  private double luminosity = 100;
+  private double luminosityPdf = 1.0 / luminosity;
 
   private double azimuth = Math.PI / 2.5;
   private double altitude = Math.PI / 3;
@@ -176,8 +176,8 @@ public class Sun implements JsonSerializable {
     color.set(other.color);
     drawTexture = other.drawTexture;
     intensity = other.intensity;
-    trueIntensity = other.trueIntensity;
-    truePdf = other.truePdf;
+    luminosity = other.luminosity;
+    luminosityPdf = other.luminosityPdf;
     initSun();
   }
 
@@ -317,18 +317,18 @@ public class Sun implements JsonSerializable {
     return intensity;
   }
 
-  public void setTrueIntensity(double value) {
-    trueIntensity = value;
-    truePdf = 1 / value;
+  public void setLuminosity(double value) {
+    luminosity = value;
+    luminosityPdf = 1 / value;
     scene.refresh();
   }
 
-  public double getTrueIntensity() {
-    return trueIntensity;
+  public double getLuminosity() {
+    return luminosity;
   }
 
-  public double getTruePdf() {
-    return truePdf;
+  public double getLuminosityPdf() {
+    return luminosityPdf;
   }
 
   /**
@@ -359,7 +359,7 @@ public class Sun implements JsonSerializable {
     sun.add("altitude", altitude);
     sun.add("azimuth", azimuth);
     sun.add("intensity", intensity);
-    sun.add("trueIntensity", trueIntensity);
+    sun.add("luminosity", luminosity);
     JsonObject colorObj = new JsonObject();
     colorObj.add("red", color.x);
     colorObj.add("green", color.y);
@@ -373,7 +373,7 @@ public class Sun implements JsonSerializable {
     azimuth = json.get("azimuth").doubleValue(azimuth);
     altitude = json.get("altitude").doubleValue(altitude);
     intensity = json.get("intensity").doubleValue(intensity);
-    setTrueIntensity(json.get("trueIntensity").doubleValue(trueIntensity));
+    setLuminosity(json.get("luminosity").doubleValue(luminosity));
 
     if (json.get("color").isObject()) {
       JsonObject colorObj = json.get("color").object();

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -120,6 +120,9 @@ public class Sun implements JsonSerializable {
 
   private double intensity = DEFAULT_INTENSITY;
 
+  private double trueIntensity = 1;
+  private double truePdf = 1;
+
   private double azimuth = Math.PI / 2.5;
   private double altitude = Math.PI / 3;
 
@@ -173,6 +176,8 @@ public class Sun implements JsonSerializable {
     color.set(other.color);
     drawTexture = other.drawTexture;
     intensity = other.intensity;
+    trueIntensity = other.trueIntensity;
+    truePdf = other.truePdf;
     initSun();
   }
 
@@ -310,6 +315,20 @@ public class Sun implements JsonSerializable {
    */
   public double getIntensity() {
     return intensity;
+  }
+
+  public void setTrueIntensity(double value) {
+    trueIntensity = value;
+    truePdf = 1 / value;
+    scene.refresh();
+  }
+
+  public double getTrueIntensity() {
+    return trueIntensity;
+  }
+
+  public double getTruePdf() {
+    return truePdf;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -1,5 +1,5 @@
-/* Copyright (c) 2012 - 2021 Jesper Öqvist <jesper@llbit.se>
- * Copyright (c) 2012 - 2021 Chunky contributors
+/* Copyright (c) 2012 - 2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2012 - 2022 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -359,6 +359,7 @@ public class Sun implements JsonSerializable {
     sun.add("altitude", altitude);
     sun.add("azimuth", azimuth);
     sun.add("intensity", intensity);
+    sun.add("trueIntensity", trueIntensity);
     JsonObject colorObj = new JsonObject();
     colorObj.add("red", color.x);
     colorObj.add("green", color.y);
@@ -372,6 +373,7 @@ public class Sun implements JsonSerializable {
     azimuth = json.get("azimuth").doubleValue(azimuth);
     altitude = json.get("altitude").doubleValue(altitude);
     intensity = json.get("intensity").doubleValue(intensity);
+    setTrueIntensity(json.get("trueIntensity").doubleValue(trueIntensity));
 
     if (json.get("color").isObject()) {
       JsonObject colorObj = json.get("color").object();

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -59,7 +59,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private AngleAdjuster sunAzimuth;
   @FXML private AngleAdjuster sunAltitude;
   @FXML private CheckBox enableEmitters;
-  @FXML private CheckBox enableSunlight;
+  @FXML private CheckBox enableSunSampling;
   @FXML private CheckBox drawSun;
   @FXML private LuxColorPicker sunColor;
   @FXML private ChoiceBox<EmitterSamplingStrategy> emitterSamplingStrategy;
@@ -89,19 +89,27 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     emitterIntensity.clampMin();
     emitterIntensity.onValueChange(value -> scene.setEmitterIntensity(value));
 
-    sunIntensity.setName("Sun intensity");
-    sunIntensity.setTooltip("Sunlight intensity modifier");
-    sunIntensity.setRange(Sun.MIN_INTENSITY, Sun.MAX_INTENSITY);
-    sunIntensity.makeLogarithmic();
-    sunIntensity.clampMin();
-    sunIntensity.onValueChange(value -> scene.sun().setIntensity(value));
+    drawSun.selectedProperty().addListener(
+            (observable, oldValue, newValue) -> scene.sun().setDrawTexture(newValue));
+    drawSun.setTooltip(new Tooltip("Draws the sun texture on top of the skymap."));
+
+    enableSunSampling.selectedProperty().addListener(
+            (observable, oldValue, newValue) -> scene.setDirectLight(newValue));
+    enableSunSampling.setTooltip(new Tooltip("Enable sun sampling (next event estimation)."));
 
     fastSunSampling.setSelected(true);
     fastSunSampling.setTooltip(new Tooltip("Fast sun sampling. Lower noise but does not correctly model some visual effects."));
     fastSunSampling.selectedProperty().addListener(((observable, oldValue, newValue) -> scene.setFastSunSampling(newValue)));
 
-    trueSunIntensity.setName("True Sun Intensity");
-    trueSunIntensity.setTooltip("Sun intensity used when using slow sun sampling.");
+    sunIntensity.setName("Sun intensity");
+    sunIntensity.setTooltip("Intensity of the sun on the scene.");
+    sunIntensity.setRange(Sun.MIN_INTENSITY, Sun.MAX_INTENSITY);
+    sunIntensity.makeLogarithmic();
+    sunIntensity.clampMin();
+    sunIntensity.onValueChange(value -> scene.sun().setIntensity(value));
+
+    trueSunIntensity.setName("Sun luminosity");
+    trueSunIntensity.setTooltip("Absolute brightness of the sun. Used when fast sun sampling is disabled.");
     trueSunIntensity.setRange(1, 10000);
     trueSunIntensity.makeLogarithmic();
     trueSunIntensity.clampMin();
@@ -117,11 +125,6 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
     enableEmitters.selectedProperty().addListener(
         (observable, oldValue, newValue) -> scene.setEmittersEnabled(newValue));
-    enableSunlight.selectedProperty().addListener(
-        (observable, oldValue, newValue) -> scene.setDirectLight(newValue));
-    drawSun.selectedProperty().addListener(
-        (observable, oldValue, newValue) -> scene.sun().setDrawTexture(newValue));
-    drawSun.setTooltip(new Tooltip("Draws the sun texture on top of the skymap."));
 
     sunColor.colorProperty().addListener(sunColorListener);
 
@@ -160,7 +163,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunAzimuth.set(-QuickMath.radToDeg(scene.sun().getAzimuth()));
     sunAltitude.set(QuickMath.radToDeg(scene.sun().getAltitude()));
     enableEmitters.setSelected(scene.getEmittersEnabled());
-    enableSunlight.setSelected(scene.getDirectLight());
+    enableSunSampling.setSelected(scene.getDirectLight());
     drawSun.setSelected(scene.sun().drawTexture());
     sunColor.colorProperty().removeListener(sunColorListener);
     sunColor.setColor(ColorUtil.toFx(scene.sun().getColor()));

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2016-2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2022 Chunky Contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -54,6 +54,8 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private DoubleAdjuster skyIntensity;
   @FXML private DoubleAdjuster emitterIntensity;
   @FXML private DoubleAdjuster sunIntensity;
+  @FXML private CheckBox fastSunSampling;
+  @FXML private DoubleAdjuster trueSunIntensity;
   @FXML private AngleAdjuster sunAzimuth;
   @FXML private AngleAdjuster sunAltitude;
   @FXML private CheckBox enableEmitters;
@@ -93,6 +95,17 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunIntensity.makeLogarithmic();
     sunIntensity.clampMin();
     sunIntensity.onValueChange(value -> scene.sun().setIntensity(value));
+
+    fastSunSampling.setSelected(true);
+    fastSunSampling.setTooltip(new Tooltip("Fast sun sampling. Lower noise but does not correctly model some visual effects."));
+    fastSunSampling.selectedProperty().addListener(((observable, oldValue, newValue) -> scene.setFastSunSampling(newValue)));
+
+    trueSunIntensity.setName("True Sun Intensity");
+    trueSunIntensity.setTooltip("Sun intensity used when using slow sun sampling.");
+    trueSunIntensity.setRange(1, 10000);
+    trueSunIntensity.makeLogarithmic();
+    trueSunIntensity.clampMin();
+    trueSunIntensity.onValueChange(value -> scene.sun().setTrueIntensity(value));
 
     sunAzimuth.setName("Sun azimuth");
     sunAzimuth.setTooltip("Change the angle to the sun from north.");
@@ -142,6 +155,8 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     skyIntensity.set(scene.sky().getSkyLight());
     emitterIntensity.set(scene.getEmitterIntensity());
     sunIntensity.set(scene.sun().getIntensity());
+    fastSunSampling.setSelected(scene.getFastSunSampling());
+    trueSunIntensity.set(scene.sun().getTrueIntensity());
     sunAzimuth.set(-QuickMath.radToDeg(scene.sun().getAzimuth()));
     sunAltitude.set(QuickMath.radToDeg(scene.sun().getAltitude()));
     enableEmitters.setSelected(scene.getEmittersEnabled());

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -11,6 +11,7 @@
 <?import se.llbit.chunky.ui.elements.AngleAdjuster?>
 <?import se.llbit.fx.LuxColorPicker?>
 <?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.ComboBox?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
@@ -21,10 +22,12 @@
       <ChoiceBox fx:id="emitterSamplingStrategy" />
     </HBox>
     <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
-    <CheckBox fx:id="enableSunSampling" mnemonicParsing="false" text="Sun sampling" />
-    <CheckBox fx:id="fastSunSampling" mnemonicParsing="false" text="Fast sun sampling" />
+    <HBox alignment="CENTER_LEFT" spacing="10.0">
+      <Label text="Sun Sampling Strategy:" />
+      <ComboBox fx:id="sunSamplingStrategy" />
+    </HBox>
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
-    <DoubleAdjuster fx:id="trueSunIntensity" maxWidth="Infinity" />
+    <DoubleAdjuster fx:id="sunLuminosity" maxWidth="Infinity" />
     <AngleAdjuster fx:id="sunAzimuth" />
     <AngleAdjuster fx:id="sunAltitude" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -20,10 +20,10 @@
       <Label text="Emitter Sampling Strategy:" />
       <ChoiceBox fx:id="emitterSamplingStrategy" />
     </HBox>
-    <CheckBox fx:id="enableSunlight" mnemonicParsing="false" text="Enable sunlight" />
     <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
+    <CheckBox fx:id="enableSunSampling" mnemonicParsing="false" text="Sun sampling" />
+    <CheckBox fx:id="fastSunSampling" mnemonicParsing="false" text="Fast sun sampling" />
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
-    <CheckBox fx:id="fastSunSampling" mnemonicParsing="false" text="Fast Sun Sampling" />
     <DoubleAdjuster fx:id="trueSunIntensity" maxWidth="Infinity" />
     <AngleAdjuster fx:id="sunAzimuth" />
     <AngleAdjuster fx:id="sunAltitude" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -23,6 +23,8 @@
     <CheckBox fx:id="enableSunlight" mnemonicParsing="false" text="Enable sunlight" />
     <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
+    <CheckBox fx:id="fastSunSampling" mnemonicParsing="false" text="Fast Sun Sampling" />
+    <DoubleAdjuster fx:id="trueSunIntensity" maxWidth="Infinity" />
     <AngleAdjuster fx:id="sunAzimuth" />
     <AngleAdjuster fx:id="sunAltitude" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">


### PR DESCRIPTION
Closes #1184.
This adds a `Sun Luminosity` setting which changes the true brightness of the sun when intersected with organically and a new sun sampling mode which does both sun samples and allows for sun intersections for diffuse materials. This new sun sampling mode allows for visual effects like caustics (with much render time):
![image](https://user-images.githubusercontent.com/42661490/162601080-d96f82a0-7a46-41f1-abc3-073bd18b72ac.png)
