### PR TITLE
22w17a - Update Mangrove Roots Model

### DIFF
--- a/chunky/src/java/se/llbit/chunky/model/MangroveRootsModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/MangroveRootsModel.java
@@ -15,27 +15,27 @@ public class MangroveRootsModel extends QuadModel {
 
   private static final Quad[] quads = new Quad[]{
     new Quad(
-      new Vector3(0.8 / 16.0, 16 / 16.0, 8 / 16.0),
-      new Vector3(15.2 / 16.0, 16 / 16.0, 8 / 16.0),
-      new Vector3(0.8 / 16.0, 0 / 16.0, 8 / 16.0),
+      new Vector3(0 / 16.0, 16 / 16.0, 8 / 16.0),
+      new Vector3(16 / 16.0, 16 / 16.0, 8 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 8 / 16.0),
       new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
     ),
     new Quad(
-      new Vector3(15.2 / 16.0, 16 / 16.0, 8 / 16.0),
-      new Vector3(0.8 / 16.0, 16 / 16.0, 8 / 16.0),
-      new Vector3(15.2 / 16.0, 0 / 16.0, 8 / 16.0),
+      new Vector3(16 / 16.0, 16 / 16.0, 8 / 16.0),
+      new Vector3(0 / 16.0, 16 / 16.0, 8 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 8 / 16.0),
       new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
     ),
     new Quad(
-      new Vector3(8 / 16.0, 16 / 16.0, 15.2 / 16.0),
-      new Vector3(8 / 16.0, 16 / 16.0, 0.8 / 16.0),
-      new Vector3(8 / 16.0, 0 / 16.0, 15.2 / 16.0),
+      new Vector3(8 / 16.0, 16 / 16.0, 16 / 16.0),
+      new Vector3(8 / 16.0, 16 / 16.0, 0 / 16.0),
+      new Vector3(8 / 16.0, 0 / 16.0, 16 / 16.0),
       new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
     ),
     new Quad(
-      new Vector3(8 / 16.0, 16 / 16.0, 0.8 / 16.0),
-      new Vector3(8 / 16.0, 16 / 16.0, 15.2 / 16.0),
-      new Vector3(8 / 16.0, 0 / 16.0, 0.8 / 16.0),
+      new Vector3(8 / 16.0, 16 / 16.0, 0 / 16.0),
+      new Vector3(8 / 16.0, 16 / 16.0, 16 / 16.0),
+      new Vector3(8 / 16.0, 0 / 16.0, 0 / 16.0),
       new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
     ),
     new Quad(


### PR DESCRIPTION
Fixes #1248 

The pixels of the inner planes of the mangrove roots texture now line up with the pixels on the outer planes.

The same fix for Minecraft, "This is a very easy fix - all of the "0.8" values in the model should be changed to "0" and every "15.2" to "16"," ([MC-250075](https://bugs.mojang.com/browse/MC-250075)), also applied to Chunky.

Minecraft 22w17a:
![2022-04-29_20 58 23](https://user-images.githubusercontent.com/92183530/166055100-d5555e7e-30e9-4e20-ac90-0b0b4974131e.png)

Chunky latest snapshot:
![Mangrove roots incorrect](https://user-images.githubusercontent.com/92183530/166055287-908f7db3-3794-457d-b90a-3fc4e3d9e449.png)

Fixed:
![Mangrove roots correct test 1](https://user-images.githubusercontent.com/92183530/166055363-42600cbc-46ae-4fc7-b3fa-69192c2bf02c.png)