### PR TITLE
Add per-region selection instead of a list of chunks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -48,6 +48,7 @@ import se.llbit.chunky.world.Icon;
 import se.llbit.chunky.world.PlayerEntityData;
 import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.listeners.ChunkUpdateListener;
+import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.log.Log;
 import se.llbit.math.QuickMath;
 import se.llbit.math.Ray;
@@ -56,6 +57,7 @@ import se.llbit.math.Vector3;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -212,6 +214,32 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       repaintRatelimited();
     } else {
       regionUpdated(chunk.getRegionPosition());
+    }
+  }
+
+  @Override public void regionChunksUpdated(ChunkPosition region) {
+    if (view.chunkScale >= 16) {
+      int minChunkX = region.x << 5;
+      int minChunkZ = region.z << 5;
+      for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
+        for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
+          mapBuffer.drawTile(mapLoader, ChunkPosition.get(chunkX, chunkZ), chunkSelection);
+        }
+      }
+      repaintRatelimited();
+    } else {
+      regionUpdated(region);
+    }
+  }
+
+  @Override public void regionChunksUpdated(ChunkPosition region, Collection<ChunkPosition> chunks) {
+    if (view.chunkScale >= 16) {
+      for (ChunkPosition chunk : chunks) {
+        mapBuffer.drawTile(mapLoader, chunk, chunkSelection);
+      }
+      repaintRatelimited();
+    } else {
+      regionUpdated(region);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -139,7 +139,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     MenuItem clearSelection = new MenuItem("Clear selection");
     clearSelection.setGraphic(new ImageView(Icon.clear.fxImage()));
     clearSelection.setOnAction(event -> chunkSelection.clearSelection());
-    clearSelection.setDisable(chunkSelection.size() == 0);
+    clearSelection.setDisable(chunkSelection.isEmpty());
 
     MenuItem newScene = new MenuItem("New scene from selection");
     newScene.setGraphic(new ImageView(Icon.sky.fxImage()));
@@ -148,7 +148,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       sceneManager
           .loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
     });
-    newScene.setDisable(chunkSelection.size() == 0);
+    newScene.setDisable(chunkSelection.isEmpty());
 
     MenuItem loadSelection = new MenuItem("Load selected chunks");
     loadSelection.setOnAction(event -> {
@@ -156,7 +156,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       sceneManager
           .loadChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
     });
-    loadSelection.setDisable(chunkSelection.size() == 0);
+    loadSelection.setDisable(chunkSelection.isEmpty());
 
     moveCameraHere.setOnAction(event -> {
       ChunkView theView = new ChunkView(view);  // Make thread-local copy.
@@ -292,8 +292,8 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       // If ctrlModifier to deselect, then do deselect
       // If no ctrlModifier, select chunks
       // but if they are all already selected, then deselect.
-      if (ctrlModifier || !chunkSelection.selectChunks(mapLoader.getWorld(), x0, z0, x1, z1))
-        chunkSelection.deselectChunks(x0, z0, x1, z1);
+      if (ctrlModifier || !chunkSelection.setChunks(mapLoader.getWorld(), x0, z0, x1, z1, true)) //TODO: what the..?
+        chunkSelection.setChunks(mapLoader.getWorld(), x0, z0, x1, z1, false);
     }
   }
 
@@ -500,7 +500,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
         if (theView.scale >= 16) {
           chunkSelection.toggleChunk(mapLoader.getWorld(), cx, cz);
         } else {
-          chunkSelection.selectRegion(mapLoader.getWorld(), cx, cz);
+          chunkSelection.toggleRegion(mapLoader.getWorld(), cx, cz);
         }
       }
     } else {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -146,13 +146,13 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     loadSelectedChunks.setDisable(
       mapLoader.getWorld() instanceof EmptyWorld ||
       mapLoader.getWorld() == null ||
-      chunkyFxController.getChunkSelection().size() == 0
+      chunkyFxController.getChunkSelection().isEmpty()
     );
     chunkyFxController.getChunkSelection().addSelectionListener(() -> {
       loadSelectedChunks.setDisable(
         mapLoader.getWorld() instanceof EmptyWorld ||
         mapLoader.getWorld() == null ||
-        chunkyFxController.getChunkSelection().size() == 0
+        chunkyFxController.getChunkSelection().isEmpty()
       );
     });
     canvasSizeInput.setSize(scene.canvasWidth(), scene.canvasHeight());
@@ -323,7 +323,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     loadSelectedChunks.setOnAction(e -> {
       controller.getSceneManager()
           .loadChunks(mapLoader.getWorld(), chunkyFxController.getChunkSelection().getSelection());
-      reloadChunks.setDisable(chunkyFxController.getChunkSelection().size() == 0);
+      reloadChunks.setDisable(chunkyFxController.getChunkSelection().isEmpty());
     });
     reloadChunks.setTooltip(new Tooltip("Reload all chunks in the scene."));
     reloadChunks.setGraphic(new ImageView(Icon.reload.fxImage()));

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -86,8 +86,6 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
 
     if(selectionChanged) {
       notifyRegionChunksUpdated(regionPos, changedChunks);
-//      notifyChunksUpdated(changedChunks);
-//      notifyRegionChunksUpdated(regionPos);
     }
     return selectionChanged;
   }

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -46,7 +46,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
     if(previousValue != selected) {
       selectedChunksForRegion.set(bitIndex, selected);
 
-      if (selectedChunksForRegion.nextSetBit(0) >= selectedChunksForRegion.length()) {
+      if (selectedChunksForRegion.nextSetBit(0) == -1) {
         //all bits are 0, we don't need to track this region anymore
         selectedChunksByRegion.remove(ChunkPosition.positionToLong(pos.x >> 5, pos.z >> 5));
       }
@@ -63,17 +63,16 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
   private boolean setRegion(ChunkPosition regionPos, boolean selected) {
     long positionAsLong = regionPos.getLong();
     BitSet selectedChunksForRegion = selectedChunksByRegion.computeIfAbsent(positionAsLong, p -> new BitSet(32 * 32));
-    int size = selectedChunksForRegion.size();
     // We know the bitset will change if all the bits are the same, and the first bit isn't equal to selected
     // or if all the bits aren't the same
-    boolean allBitsAreSame = selectedChunksForRegion.nextSetBit(0) == size
-      || selectedChunksForRegion.nextClearBit(0) == size;
-    boolean willChange = !allBitsAreSame || selectedChunksForRegion.get(0) != selected;
+    boolean allBitsAreSame = selectedChunksForRegion.nextSetBit(0) == -1
+      || selectedChunksForRegion.nextClearBit(0) == -1;
+    boolean willChange = allBitsAreSame || selectedChunksForRegion.get(0) != selected;
 
     if(willChange) {
-      selectedChunksForRegion.set(0, size, selected);
+      selectedChunksForRegion.set(0, selectedChunksForRegion.size(), selected);
 
-      if (selectedChunksForRegion.nextSetBit(0) >= size) {
+      if (selectedChunksForRegion.nextClearBit(0) == -1) {
         //all bits are 0, we don't need to track this region anymore
         selectedChunksByRegion.remove(positionAsLong);
       }

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -198,17 +198,20 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
 
     // If selection area must contain complete regions
     if(maxChunkX - minChunkX >= MCRegion.CHUNKS_X*2 && maxChunkZ - minChunkZ >= MCRegion.CHUNKS_Z*2) {
-      int minBorderX = MCRegion.CHUNKS_X - (minChunkX & (MCRegion.CHUNKS_X-1)); // want the border from minimum region corner to minimum chunk corner, so 32 - borderSize
-      int maxBorderX = maxChunkX & (MCRegion.CHUNKS_X-1);
+      // All full regions are set first, then any chunks on the borders are set, top and bottom include corners, left and right don't
 
-      int minBorderZ = MCRegion.CHUNKS_Z - (minChunkZ & (MCRegion.CHUNKS_Z-1));
-      int maxBorderZ = maxChunkZ & (MCRegion.CHUNKS_Z-1);
+      // left, right, top, bottom are unrelated to the actual map view, and are just treating XZ as if they were XY on traditional cartesian coordinate axes
+      int leftBorder = MCRegion.CHUNKS_X - (minChunkX & (MCRegion.CHUNKS_X-1)); // want the border from minimum region corner to minimum chunk corner, so 32 - borderSize
+      int rightBorder = maxChunkX & (MCRegion.CHUNKS_X-1);
 
-      int minInnerRegionX = (minChunkX + minBorderX) >> 5;
-      int maxInnerRegionX = (maxChunkX - maxBorderX) >> 5;
+      int bottomBorder = MCRegion.CHUNKS_Z - (minChunkZ & (MCRegion.CHUNKS_Z-1));
+      int topBorder = maxChunkZ & (MCRegion.CHUNKS_Z-1);
 
-      int minInnerRegionZ = (minChunkZ + minBorderZ) >> 5;
-      int maxInnerRegionZ = (maxChunkZ - maxBorderZ) >> 5;
+      int minInnerRegionX = (minChunkX + leftBorder) >> 5;
+      int maxInnerRegionX = (maxChunkX - rightBorder) >> 5;
+
+      int minInnerRegionZ = (minChunkZ + bottomBorder) >> 5;
+      int maxInnerRegionZ = (maxChunkZ - topBorder) >> 5;
 
       // set all inner regions from the selection
       for (int regionX = minInnerRegionX; regionX < maxInnerRegionX; regionX++) {
@@ -219,7 +222,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
 
       //set top border
       for (int x = minChunkX; x < maxChunkX; x++) {
-        for (int z = maxChunkZ - maxBorderZ; z < maxChunkZ; z++) {
+        for (int z = maxChunkZ - topBorder; z < maxChunkZ; z++) {
           ChunkPosition chunkPos = ChunkPosition.get(x, z);
           if(!world.getChunk(chunkPos).isEmpty()) {
             selectionChanged |= setChunk(chunkPos, selected);
@@ -228,7 +231,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
       }
       //set bottom border
       for (int x = minChunkX; x < maxChunkX; x++) {
-        for (int z = minChunkZ; z < minChunkZ + minBorderZ; z++) {
+        for (int z = minChunkZ; z < minChunkZ + bottomBorder; z++) {
           ChunkPosition chunkPos = ChunkPosition.get(x, z);
           if(!world.getChunk(chunkPos).isEmpty()) {
             selectionChanged |= setChunk(chunkPos, selected);
@@ -236,8 +239,8 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
         }
       }
       //set left border without corners
-      for (int x = minChunkX; x < minChunkX + minBorderX; x++) {
-        for (int z = minChunkZ + minBorderZ; z < maxChunkZ - maxBorderZ; z++) {
+      for (int x = minChunkX; x < minChunkX + leftBorder; x++) {
+        for (int z = minChunkZ + bottomBorder; z < maxChunkZ - topBorder; z++) {
           ChunkPosition chunkPos = ChunkPosition.get(x, z);
           if(!world.getChunk(chunkPos).isEmpty()) {
             selectionChanged |= setChunk(chunkPos, selected);
@@ -246,8 +249,8 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
       }
 
       //set right border without corners
-      for (int x = maxChunkX - maxBorderX; x < maxChunkX; x++) {
-        for (int z = minChunkZ + minBorderZ; z < maxChunkZ - maxBorderZ; z++) {
+      for (int x = maxChunkX - rightBorder; x < maxChunkX; x++) {
+        for (int z = minChunkZ + bottomBorder; z < maxChunkZ - topBorder; z++) {
           ChunkPosition chunkPos = ChunkPosition.get(x, z);
           if(!world.getChunk(chunkPos).isEmpty()) {
             selectionChanged |= setChunk(chunkPos, selected);

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -344,11 +344,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
   public synchronized int size() {
     int size = 0;
     for (BitSet selectedChunks : selectedChunksByRegion.values()) {
-      for (int idx = 0; idx < selectedChunks.size(); idx++) {
-        if(selectedChunks.get(idx)) {
-          size++;
-        }
-      }
+      size += selectedChunks.cardinality();
     }
     return size;
   }

--- a/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
+++ b/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
@@ -17,9 +17,34 @@
 package se.llbit.chunky.world.listeners;
 
 import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.region.MCRegion;
+
+import java.util.Collection;
 
 public interface ChunkUpdateListener {
   default void regionUpdated(ChunkPosition region) {}
 
-  default void chunkUpdated(ChunkPosition region) {}
+  default void chunkUpdated(ChunkPosition chunkPosition) {}
+
+  /**
+   * All chunks within a region have been updated
+   */
+  default void regionChunksUpdated(ChunkPosition region) {
+    int minChunkX = region.x << 5;
+    int minChunkZ = region.z << 5;
+    for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
+      for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
+        this.chunkUpdated(ChunkPosition.get(chunkX, chunkZ));
+      }
+    }
+  }
+
+  /**
+   * Some chunks within a region have been updated
+   */
+  default void regionChunksUpdated(ChunkPosition region, Collection<ChunkPosition> chunks) {
+    for (ChunkPosition chunk : chunks) {
+      this.chunkUpdated(chunk);
+    }
+  }
 }


### PR DESCRIPTION
In theory this is much faster for large selections, though due to the weirdness of the map view there is no performance gain
(`chunkUpdated` must be fired for each chunk with its selection changed, `regionUpdated` is only correct if the scale is showing regions tiles)

This PR will give a nice way of getting per-region chunk selection for scene loading without having to collect the chunk positions into a map before loading them.