### PR TITLE
Load chunks per-region in Scene#loadChunks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -23,13 +23,15 @@ import se.llbit.chunky.renderer.RenderManager;
 import se.llbit.chunky.renderer.SceneIOProvider;
 import se.llbit.chunky.renderer.SceneProvider;
 import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.World;
 import se.llbit.log.Log;
 import se.llbit.util.TaskTracker;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -202,16 +204,16 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
    * Load chunks and reset camera.
    */
   @Override
-  public void loadFreshChunks(World world, Collection<ChunkPosition> chunks) {
-    enqueueTask(() -> sceneManager.loadFreshChunks(world, chunks));
+  public void loadFreshChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
+    enqueueTask(() -> sceneManager.loadFreshChunks(world, chunksToLoadByRegion));
   }
 
   /**
    * Load chunks without moving the camera.
    */
   @Override
-  public void loadChunks(World world, Collection<ChunkPosition> chunks) {
-    enqueueTask(() -> sceneManager.loadChunks(world, chunks));
+  public void loadChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
+    enqueueTask(() -> sceneManager.loadChunks(world, chunksToLoadByRegion));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.renderer.scene;
 
 import it.unimi.dsi.fastutil.io.FastBufferedInputStream;
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
+import it.unimi.dsi.fastutil.objects.ObjectObjectImmutablePair;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.block.minecraft.Air;
 import se.llbit.chunky.block.Block;
@@ -27,7 +28,6 @@ import se.llbit.chunky.block.minecraft.Water;
 import se.llbit.chunky.block.legacy.LegacyBlocksFinalizer;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
-import se.llbit.chunky.chunk.ChunkLoadingException;
 import se.llbit.chunky.chunk.EmptyChunkData;
 import se.llbit.chunky.chunk.biome.BiomeData;
 import se.llbit.chunky.entity.*;
@@ -73,6 +73,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -561,16 +562,18 @@ public class Scene implements JsonSerializable, Refreshable {
       }
 
       boolean emitterGridNeedChunkReload = false;
-      boolean octreeLoaded = loadOctree(context, taskTracker);
-      if (emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
+      Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion = ChunkSelectionTracker.selectionByRegion(chunks);
+      boolean octreeLoaded = loadOctree(context, taskTracker, chunksToLoadByRegion);
+      if (emitterSamplingStrategy != EmitterSamplingStrategy.NONE) {
         emitterGridNeedChunkReload = !loadEmitterGrid(context, taskTracker);
+      }
       if (emitterGridNeedChunkReload || !octreeLoaded) {
         // Could not load stored octree or emitter grid.
         // Load the chunks from the world.
         if (loadedWorld == EmptyWorld.INSTANCE) {
           Log.warn("Could not load chunks (no world found for scene)");
         } else {
-          loadChunks(taskTracker, loadedWorld, chunks);
+          loadChunks(taskTracker, loadedWorld, chunksToLoadByRegion);
         }
       }
 
@@ -764,7 +767,7 @@ public class Scene implements JsonSerializable, Refreshable {
       return;
     }
     loadedWorld = World.loadWorld(loadedWorld.getWorldDirectory(), worldDimension, World.LoggedWarnings.NORMAL);
-    loadChunks(taskTracker, loadedWorld, chunks);
+    loadChunks(taskTracker, loadedWorld, ChunkSelectionTracker.selectionByRegion(chunks));
     refresh();
   }
 
@@ -775,7 +778,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * The octree finalizer is then run to compute block properties like fence
    * connectedness.
    */
-  public synchronized void loadChunks(TaskTracker taskTracker, World world, Collection<ChunkPosition> chunksToLoad) {
+  public synchronized void loadChunks(TaskTracker taskTracker, World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
     if (world == null)
       return;
 
@@ -784,7 +787,6 @@ public class Scene implements JsonSerializable, Refreshable {
     yMin = yClipMin;
     yMax = yClipMax;
 
-    Set<ChunkPosition> loadedChunks = new HashSet<>();
     int numChunks = 0;
 
     BiomeStructure.Factory biomeStructureFactory = BiomeStructure.get(this.biomeStructureImplementation);
@@ -798,11 +800,11 @@ public class Scene implements JsonSerializable, Refreshable {
       worldPath = loadedWorld.getWorldDirectory().getAbsolutePath();
       worldDimension = world.currentDimensionId();
 
-      if (chunksToLoad.isEmpty()) {
+      if (chunksToLoadByRegion.isEmpty()) {
         return;
       }
 
-      int requiredDepth = calculateOctreeOrigin(chunksToLoad, false);
+      int requiredDepth = calculateOctreeOrigin(chunksToLoadByRegion, false);
 
       // Create new octree to fit all chunks.
       palette = new BlockPalette();
@@ -817,13 +819,7 @@ public class Scene implements JsonSerializable, Refreshable {
       if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
         emitterGrid = new Grid(gridSize);
 
-      // Parse the regions first - force chunk lists to be populated!
-      Set<RegionPosition> regions = new HashSet<>();
-      for (ChunkPosition cp : chunksToLoad) {
-        regions.add(cp.getRegionPosition());
-      }
-
-      for (RegionPosition region : regions) {
+      for (RegionPosition region : chunksToLoadByRegion.keySet()) {
         dimension.getRegion(region).parse(yMin, yMax);
       }
     }
@@ -841,362 +837,371 @@ public class Scene implements JsonSerializable, Refreshable {
     boolean use3dBiomes = biomeStructureFactory.is3d();
     Map<ChunkPosition, ChunkBiomeBlendingHelper> biomeBlendingHelper = new HashMap<>();
 
-    final Mutable<ChunkData> loadingChunkData = new Mutable<>(null); // chunkData currently being used for loading from save
-    final Mutable<ChunkData> activeChunkData = new Mutable<>(null); // chunkData for loading into the octree
+    Set<RegionPosition> loadedRegions = new HashSet<>();
+    Set<ChunkPosition> loadedChunks = new HashSet<>();
 
     try (TaskTracker.Task task = taskTracker.task("(3/6) Loading chunks")) {
       int done = 1;
-      int target = chunksToLoad.size();
+      int target = 0;
+      for (List<ChunkPosition> value : chunksToLoadByRegion.values()) {
+        target += value.size();
+      }
 
-      ChunkPosition[] chunkPositions = chunksToLoad.toArray(new ChunkPosition[0]);
+      RegionPosition[] regionPositions = chunksToLoadByRegion.keySet().toArray(new RegionPosition[0]);
 
       int[] cubeWorldBlocks = new int[16*16*16];
       int[] cubeWaterBlocks = new int[16*16*16];
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
-      Future<?> nextChunkDataTask = executor.submit(() -> { //Initialise first chunk data for the for loop
-        dimension.getChunk(chunkPositions[0]).getChunkData(loadingChunkData, palette, biomePalette, yMin, yMax);
-        return null; // runnable can't throw non-RuntimeExceptions, so we use a callable instead and have to return something
+      Function<RegionPosition, Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition) ->
+        executor.submit(() -> {
+          List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);
+          List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>> chunkDataPairs = new ArrayList<>();
+
+          for (ChunkPosition chunkPosition : chunkPositionsToLoad) {
+            Mutable<ChunkData> reuseChunkData = new Mutable<>(null);
+            dimension.getChunk(chunkPosition).getChunkData(reuseChunkData, palette, biomePalette, yMin, yMax);
+            chunkDataPairs.add(new ObjectObjectImmutablePair<>(chunkPosition, reuseChunkData.get()));
+          }
+          return chunkDataPairs;
       });
-      for (int i = 0; i < chunkPositions.length; i++) {
-        ChunkPosition cp = chunkPositions[i];
 
-        task.updateEta(target, done);
-        done += 1;
+      //Initialise first chunk data for the for loop
+      Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>> nextRegionFuture = createRegionDataFuture.apply(regionPositions[0]);
 
-        ChunkData chunkData;
-        try {
-          //ensure task is complete
-          nextChunkDataTask.get();
-          //swap the chunkData mutables
-          ChunkData loadedChunkData = loadingChunkData.get();
-          loadingChunkData.set(activeChunkData.get());
-          activeChunkData.set(loadedChunkData);
-          chunkData = loadedChunkData;
-        } catch(InterruptedException logged) { // If interrupted, stop loading
-          Log.warn("Chunky loading interrupted.", logged);
-          return;
-        } catch(ExecutionException e) {
-          if (e.getCause() instanceof ChunkLoadingException) {
-            Log.warn(String.format("Failed to load chunk %s", cp), e.getCause());
-            continue;
-          } else {
-            throw new RuntimeException(e.getCause());
-          }
-        } finally { // we always want to schedule the next task even if the current one throws an exception
-          if (i + 1 < chunkPositions.length) { // schedule next task if possible
-            final int finalI = i;
-            nextChunkDataTask = executor.submit(() -> { //request chunk data for the next iteration of the loop
-              dimension.getChunk(chunkPositions[finalI + 1]).getChunkData(loadingChunkData, palette, biomePalette, yMin, yMax);
-              return null; // runnable can't throw non-RuntimeExceptions, so we use a callable instead and have to return something
-            });
-          }
-        }
+      for (int i = 0; i < regionPositions.length; i++) {
+        RegionPosition regionPosition = regionPositions[i];
 
-        if (loadedChunks.contains(cp)) {
+        if (loadedRegions.contains(regionPosition)) {
           continue;
         }
+        loadedRegions.add(regionPosition);
 
-        loadedChunks.add(cp);
+        List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>> chunkDataPairs;
+        { // Get this data from active future, schedule next future
+          try {
+            chunkDataPairs = nextRegionFuture.get();
+          } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+          }
 
-        if (chunkData == null) {
-          chunkData = EmptyChunkData.INSTANCE;
+          if (i + 1 < regionPositions.length) {
+            nextRegionFuture = createRegionDataFuture.apply(regionPositions[i + 1]);
+          }
         }
 
-        numChunks += 1;
+        for (ObjectObjectImmutablePair<ChunkPosition, ChunkData> chunkDataPair : chunkDataPairs) {
+          ChunkPosition cp = chunkDataPair.first();
 
-        int wx0 = cp.x * 16; // Start of this chunk in world coordinates.
-        int wz0 = cp.z * 16;
-        BiomeData biomeData = chunkData.getBiomeData();
-        ChunkBiomeBlendingHelper chunkBiomeHelper = new ChunkBiomeBlendingHelper();
-        biomeBlendingHelper.put(cp, chunkBiomeHelper);
+          task.updateEta(target, done);
+          done += 1;
 
-        if (use3dBiomes) {
-          // We need to load biome data for the full height of the chunk
-          // and not only limited to the sections where there are blocks
-          // because it is possible that a neighboring chunks has blocks
-          // that will observe the biome color (via biome blending)
-          for (int y = yMin; y < yMax; y++) {
+          if (loadedChunks.contains(cp)) {
+            continue;
+          }
+          loadedChunks.add(cp);
+
+          ChunkData chunkData = chunkDataPair.second();
+          if (chunkData == null) {
+            chunkData = EmptyChunkData.INSTANCE;
+          }
+
+          numChunks += 1;
+
+          int wx0 = cp.x * 16; // Start of this chunk in world coordinates.
+          int wz0 = cp.z * 16;
+          BiomeData biomeData = chunkData.getBiomeData();
+          ChunkBiomeBlendingHelper chunkBiomeHelper = new ChunkBiomeBlendingHelper();
+          biomeBlendingHelper.put(cp, chunkBiomeHelper);
+
+          if (use3dBiomes) {
+            // We need to load biome data for the full height of the chunk
+            // and not only limited to the sections where there are blocks
+            // because it is possible that a neighboring chunks has blocks
+            // that will observe the biome color (via biome blending)
+            for (int y = chunkData.minY(); y < chunkData.maxY(); y++) {
+              for (int cz = 0; cz < 16; ++cz) {
+                int wz = cz + wz0;
+                for (int cx = 0; cx < 16; ++cx) {
+                  int wx = cx + wx0;
+                  int biomePaletteIdx = biomeData.getBiome(cx, y, cz);
+                  if(y != yMin) {
+                    int biomeUnder = biomeData.getBiome(cx, y-1, cz);
+                    if(biomeUnder != biomePaletteIdx)
+                      chunkBiomeHelper.addTransition(y);
+                  }
+                  biomePaletteIdxStructure.set(wx, y, wz, biomePaletteIdx);
+                }
+              }
+            }
+          } else {
             for (int cz = 0; cz < 16; ++cz) {
               int wz = cz + wz0;
               for (int cx = 0; cx < 16; ++cx) {
                 int wx = cx + wx0;
-                int biomePaletteIdx = biomeData.getBiome(cx, y, cz);
-                if(y != yMin) {
-                  int biomeUnder = biomeData.getBiome(cx, y-1, cz);
-                  if(biomeUnder != biomePaletteIdx)
-                    chunkBiomeHelper.addTransition(y);
-                }
-                biomePaletteIdxStructure.set(wx, y, wz, biomePaletteIdx);
+                int biomePaletteIdx = biomeData.getBiome(cx, chunkData.minY(), cz); // TODO: add an option to set the biome sample height?
+                biomePaletteIdxStructure.set(wx, chunkData.minY(), wz, biomePaletteIdx);
               }
             }
           }
-        } else {
-          for (int cz = 0; cz < 16; ++cz) {
-            int wz = cz + wz0;
-            for (int cx = 0; cx < 16; ++cx) {
-              int wx = cx + wx0;
-              int biomePaletteIdx = biomeData.getBiome(cx, chunkData.minY(), cz); // TODO: add an option to set the biome sample height?
-              biomePaletteIdxStructure.set(wx, chunkData.minY(), wz, biomePaletteIdx);
-            }
-          }
-        }
 
-        entities.loadEntitiesInChunk(this, chunkData);
+          entities.loadEntitiesInChunk(this, chunkData);
 
-        int yCubeMin = Math.floorDiv(yMin, 16); // round towards -infinity
-        int yCubeMax = (yMax+15) / 16;
-        for(int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
-          // Reset the cubes
-          Arrays.fill(cubeWorldBlocks, 0);
-          Arrays.fill(cubeWaterBlocks, 0);
-          for(int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
-            int y = yCube * 16 + cy;
-            if(y < yMin || y >= yMax)
-              continue;
-            for(int cz = 0; cz < 16; ++cz) {
-              int z = cz + cp.z * 16 - origin.z;
-              for(int cx = 0; cx < 16; ++cx) {
-                int x = cx + cp.x * 16 - origin.x;
+          int yCubeMin = Math.floorDiv(yMin, 16); // round towards -infinity
+          int yCubeMax = (yMax+15) / 16;
+          for(int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
+            // Reset the cubes
+            Arrays.fill(cubeWorldBlocks, 0);
+            Arrays.fill(cubeWaterBlocks, 0);
+            for(int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
+              int y = yCube * 16 + cy;
+              if(y < yMin || y >= yMax)
+                continue;
+              for(int cz = 0; cz < 16; ++cz) {
+                int z = cz + cp.z * 16 - origin.z;
+                for(int cx = 0; cx < 16; ++cx) {
+                  int x = cx + cp.x * 16 - origin.x;
 
-                int cubeIndex = (cz * 16 + cy) * 16 + cx;
+                  int cubeIndex = (cz * 16 + cy) * 16 + cx;
 
-                // Change the type of hidden blocks to ANY_TYPE
-                boolean onEdge = y <= yMin || y >= yMax - 1 || chunkData.isBlockOnEdge(cx, y, cz);
-                boolean isHidden = !onEdge
-                        && palette.get(chunkData.getBlockAt(cx + 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx - 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y + 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y - 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz + 1)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz - 1)).opaque;
+                  // Change the type of hidden blocks to ANY_TYPE
+                  boolean onEdge = y <= yMin || y >= yMax - 1 || chunkData.isBlockOnEdge(cx, y, cz);
+                  boolean isHidden = !onEdge
+                    && palette.get(chunkData.getBlockAt(cx + 1, y, cz)).opaque
+                    && palette.get(chunkData.getBlockAt(cx - 1, y, cz)).opaque
+                    && palette.get(chunkData.getBlockAt(cx, y + 1, cz)).opaque
+                    && palette.get(chunkData.getBlockAt(cx, y - 1, cz)).opaque
+                    && palette.get(chunkData.getBlockAt(cx, y, cz + 1)).opaque
+                    && palette.get(chunkData.getBlockAt(cx, y, cz - 1)).opaque;
 
-                if(isHidden) {
-                  cubeWorldBlocks[cubeIndex] = Octree.ANY_TYPE;
-                } else {
-                  int currentBlock = chunkData.getBlockAt(cx, y, cz);
-                  int octNode = currentBlock;
-                  Block block = palette.get(currentBlock);
+                  if (isHidden) {
+                    cubeWorldBlocks[cubeIndex] = Octree.ANY_TYPE;
+                  } else {
+                    int currentBlock = chunkData.getBlockAt(cx, y, cz);
+                    int octNode = currentBlock;
+                    Block block = palette.get(currentBlock);
 
-                  if(block.isBiomeDependant())
-                    chunkBiomeHelper.makeBiomeRelevant(y);
+                    if (block.isBiomeDependant()) {
+                      chunkBiomeHelper.makeBiomeRelevant(y);
+                    }
 
-                  if(block.isEntity()) {
-                    Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
-                    Entity entity = block.toEntity(position);
+                    if (block.isEntity()) {
+                      Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
+                      Entity entity = block.toEntity(position);
 
-                    if (entities.shouldLoad(entity)) {
-                      if(entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
-                        entities.addActor(entity);
-                      } else {
-                        entities.addEntity(entity);
-                        if (emitterGrid != null) {
-                          for (Grid.EmitterPosition emitterPos : entity.getEmitterPosition()) {
-                            emitterPos.x -= origin.x;
-                            emitterPos.y -= origin.y;
-                            emitterPos.z -= origin.z;
-                            emitterGrid.addEmitter(emitterPos);
+                      if (entities.shouldLoad(entity)) {
+                        if (entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
+                          entities.addActor(entity);
+                        } else {
+                          entities.addEntity(entity);
+                          if (emitterGrid != null) {
+                            for (Grid.EmitterPosition emitterPos : entity.getEmitterPosition()) {
+                              emitterPos.x -= origin.x;
+                              emitterPos.y -= origin.y;
+                              emitterPos.z -= origin.z;
+                              emitterGrid.addEmitter(emitterPos);
+                            }
+                          }
+                        }
+
+                        if (!block.isBlockWithEntity()) {
+                          if (block.waterlogged) {
+                            block = palette.water;
+                            octNode = palette.waterId;
+                          } else {
+                            block = Air.INSTANCE;
+                            octNode = palette.airId;
                           }
                         }
                       }
+                    }
 
-                      if(!block.isBlockWithEntity()) {
-                        if(block.waterlogged) {
-                          block = palette.water;
-                          octNode = palette.waterId;
+                    // check if block is water filled, but exclude waterlogged air blocks. This is a temporary fix for #1692
+                    if(block.isWaterFilled() && !(block instanceof Air)) {
+                      int waterNode = palette.waterId;
+                      if(y + 1 < yMax) {
+                        if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)).isWaterFilled()) {
+                          waterNode = palette.getWaterId(0, 1 << Water.FULL_BLOCK);
+                        }
+                      }
+                      if(block.isWater()) {
+                        // Move plain water blocks to the water octree.
+                        octNode = palette.airId;
+
+                        if (!onEdge) {
+                          // Perform water computation now for water blocks that are not on th edge of the chunk
+                          // Test if the block has not already be marked as full
+                          if (((Water) palette.get(waterNode)).data == 0) {
+                            int level0 = 8 - ((Water) block).level;
+                            int corner0 = level0;
+                            int corner1 = level0;
+                            int corner2 = level0;
+                            int corner3 = level0;
+
+                            int level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz, level0);
+                            corner3 += level;
+                            corner0 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
+                            corner0 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz + 1, level0);
+                            corner0 += level;
+                            corner1 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
+                            corner1 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz, level0);
+                            corner1 += level;
+                            corner2 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
+                            corner2 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz - 1, level0);
+                            corner2 += level;
+                            corner3 += level;
+
+                            level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
+                            corner3 += level;
+
+                            corner0 = Math.min(7, 8 - (corner0 / 4));
+                            corner1 = Math.min(7, 8 - (corner1 / 4));
+                            corner2 = Math.min(7, 8 - (corner2 / 4));
+                            corner3 = Math.min(7, 8 - (corner3 / 4));
+                            waterNode = palette.getWaterId(((Water) block).level, (corner0 << Water.CORNER_0)
+                              | (corner1 << Water.CORNER_1)
+                              | (corner2 << Water.CORNER_2)
+                              | (corner3 << Water.CORNER_3));
+                          }
                         } else {
-                          block = Air.INSTANCE;
-                          octNode = palette.airId;
+                          // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
+                          waterNode = palette.getWaterId(((Water) block).level, 0);
                         }
                       }
-                    }
-                  }
+                      cubeWaterBlocks[cubeIndex] = waterNode;
+                    } else if (y + 1 < yMax && block instanceof Lava) {
+                      if (palette.get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
+                        octNode = palette.getLavaId(0, 1 << Water.FULL_BLOCK);
+                      } else if (!onEdge) {
+                        // Compute lava level for blocks not on edge
+                        Lava lava = (Lava) block;
+                        int level0 = 8 - lava.level;
+                        int corner0 = level0;
+                        int corner1 = level0;
+                        int corner2 = level0;
+                        int corner3 = level0;
 
-                  // check if block is water filled, but exclude waterlogged air blocks. This is a temporary fix for #1692
-                  if(block.isWaterFilled() && !(block instanceof Air)) {
-                    int waterNode = palette.waterId;
-                    if(y + 1 < yMax) {
-                      if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)).isWaterFilled()) {
-                        waterNode = palette.getWaterId(0, 1 << Water.FULL_BLOCK);
+                        int level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz, level0);
+                        corner3 += level;
+                        corner0 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
+                        corner0 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz + 1, level0);
+                        corner0 += level;
+                        corner1 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
+                        corner1 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz, level0);
+                        corner1 += level;
+                        corner2 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
+                        corner2 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz - 1, level0);
+                        corner2 += level;
+                        corner3 += level;
+
+                        level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
+                        corner3 += level;
+
+                        corner0 = Math.min(7, 8 - (corner0 / 4));
+                        corner1 = Math.min(7, 8 - (corner1 / 4));
+                        corner2 = Math.min(7, 8 - (corner2 / 4));
+                        corner3 = Math.min(7, 8 - (corner3 / 4));
+                        octNode = palette.getLavaId(
+                          lava.level,
+                          (corner0 << Water.CORNER_0)
+                            | (corner1 << Water.CORNER_1)
+                            | (corner2 << Water.CORNER_2)
+                            | (corner3 << Water.CORNER_3)
+                        );
                       }
                     }
-                    if(block.isWater()) {
-                      // Move plain water blocks to the water octree.
-                      octNode = palette.airId;
+                    cubeWorldBlocks[cubeIndex] = octNode;
 
-                      if(!onEdge) {
-                        // Perform water computation now for water blocks that are not on th edge of the chunk
-                        // Test if the block has not already be marked as full
-                        if(((Water) palette.get(waterNode)).data == 0) {
-                          int level0 = 8 - ((Water) block).level;
-                          int corner0 = level0;
-                          int corner1 = level0;
-                          int corner2 = level0;
-                          int corner3 = level0;
-
-                          int level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                          corner3 += level;
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                          corner0 += level;
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                          corner1 += level;
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                          corner2 += level;
-                          corner3 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                          corner3 += level;
-
-                          corner0 = Math.min(7, 8 - (corner0 / 4));
-                          corner1 = Math.min(7, 8 - (corner1 / 4));
-                          corner2 = Math.min(7, 8 - (corner2 / 4));
-                          corner3 = Math.min(7, 8 - (corner3 / 4));
-                          waterNode = palette.getWaterId(((Water) block).level, (corner0 << Water.CORNER_0)
-                                          | (corner1 << Water.CORNER_1)
-                                          | (corner2 << Water.CORNER_2)
-                                          | (corner3 << Water.CORNER_3));
-                        }
-                      } else {
-                        // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
-                        waterNode = palette.getWaterId(((Water) block).level, 0);
-                      }
+                    if (emitterGrid != null && block.emittance > 1e-4) {
+                      // X and Z are Chunky position but Y is world position
+                      emitterGrid.addEmitter(new Grid.EmitterPosition(x, y - origin.y, z, block));
                     }
-                    cubeWaterBlocks[cubeIndex] = waterNode;
-                  } else if(y + 1 < yMax && block instanceof Lava) {
-                    if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
-                      octNode = palette.getLavaId(0, 1 << Water.FULL_BLOCK);
-                    } else if(!onEdge) {
-                      // Compute lava level for blocks not on edge
-                      Lava lava = (Lava) block;
-                      int level0 = 8 - lava.level;
-                      int corner0 = level0;
-                      int corner1 = level0;
-                      int corner2 = level0;
-                      int corner3 = level0;
-
-                      int level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                      corner3 += level;
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                      corner0 += level;
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                      corner1 += level;
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                      corner2 += level;
-                      corner3 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                      corner3 += level;
-
-                      corner0 = Math.min(7, 8 - (corner0 / 4));
-                      corner1 = Math.min(7, 8 - (corner1 / 4));
-                      corner2 = Math.min(7, 8 - (corner2 / 4));
-                      corner3 = Math.min(7, 8 - (corner3 / 4));
-                      octNode = palette.getLavaId(
-                              lava.level,
-                              (corner0 << Water.CORNER_0)
-                                      | (corner1 << Water.CORNER_1)
-                                      | (corner2 << Water.CORNER_2)
-                                      | (corner3 << Water.CORNER_3)
-                      );
-                    }
-                  }
-                  cubeWorldBlocks[cubeIndex] = octNode;
-
-                  if(emitterGrid != null && block.emittance > 1e-4) {
-                    // X and Z are Chunky position but Y is world position
-                    emitterGrid.addEmitter(new Grid.EmitterPosition(x, y - origin.y, z, block));
                   }
                 }
               }
             }
+            worldOctree.setCube(4, cubeWorldBlocks, cp.x * 16 - origin.x, yCube * 16 - origin.y, cp.z * 16 - origin.z);
+            waterOctree.setCube(4, cubeWaterBlocks, cp.x * 16 - origin.x, yCube * 16 - origin.y, cp.z * 16 - origin.z);
           }
-          worldOctree.setCube(4, cubeWorldBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
-          waterOctree.setCube(4, cubeWaterBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
-        }
 
-        // Block entities are also called "tile entities". These are extra bits of metadata
-        // about certain blocks or entities.
-        // Block entities are loaded after the base block data so that metadata can be updated.
-        for (CompoundTag entityTag : chunkData.getTileEntities()) {
-          int y = entityTag.get("y").intValue(0);
-          if (y >= yMin && y < yMax) {
-            int x = entityTag.get("x").intValue(0) - wx0; // Chunk-local coordinates.
-            int z = entityTag.get("z").intValue(0) - wz0;
-            if (x < 0 || x > 15 || z < 0 || z > 15) {
-              // Block entity is out of range (bad chunk data?), ignore it
-              continue;
-            }
-            Block block = palette.get(chunkData.getBlockAt(x, y, z));
-            // Metadata is the old block data (to be replaced in future Minecraft versions?).
-            Vector3 position = new Vector3(x + wx0, y, z + wz0);
-            if (block.isModifiedByBlockEntity()) {
-              Tag newTag = block.getNewTagWithBlockEntity(palette.getBlockSpec(chunkData.getBlockAt(x, y, z)).getTag(), entityTag);
-              if (newTag != null) {
-                int id = palette.put(newTag);
-                block = palette.get(id);
-                chunkData.setBlockAt(x, y, z, id);
-                worldOctree.set(id, cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z);
-              }
-            }
-            if (block.isBlockEntity()) {
-              Entity blockEntity = block.toBlockEntity(position, entityTag);
-              if (blockEntity == null) {
+          // Block entities are also called "tile entities". These are extra bits of metadata
+          // about certain blocks or entities.
+          // Block entities are loaded after the base block data so that metadata can be updated.
+          for (CompoundTag entityTag : chunkData.getTileEntities()) {
+            int y = entityTag.get("y").intValue(0);
+            if (y >= yMin && y < yMax) {
+              int x = entityTag.get("x").intValue(0) - wx0; // Chunk-local coordinates.
+              int z = entityTag.get("z").intValue(0) - wz0;
+              if (x < 0 || x > 15 || z < 0 || z > 15) {
+                // Block entity is out of range (bad chunk data?), ignore it
                 continue;
               }
+              Block block = palette.get(chunkData.getBlockAt(x, y, z));
+              // Metadata is the old block data (to be replaced in future Minecraft versions?).
+              Vector3 position = new Vector3(x + wx0, y, z + wz0);
+              if (block.isModifiedByBlockEntity()) {
+                Tag newTag = block.getNewTagWithBlockEntity(palette.getBlockSpec(chunkData.getBlockAt(x, y, z)).getTag(), entityTag);
+                if (newTag != null) {
+                  int id = palette.put(newTag);
+                  block = palette.get(id);
+                  chunkData.setBlockAt(x, y, z, id);
+                  worldOctree.set(id, cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z);
+                }
+              }
+              if (block.isBlockEntity()) {
+                Entity blockEntity = block.toBlockEntity(position, entityTag);
+                if (blockEntity == null) {
+                  continue;
+                }
 
-              if (entities.shouldLoad(blockEntity)) {
-                if (blockEntity instanceof Poseable) {
-                  entities.addActor(blockEntity);
-                } else {
-                  entities.addEntity(blockEntity);
-                  if (emitterGrid != null) {
-                    for (Grid.EmitterPosition emitterPos : blockEntity.getEmitterPosition()) {
-                      emitterPos.x -= origin.x;
-                      emitterPos.y -= origin.y;
-                      emitterPos.z -= origin.z;
-                      emitterGrid.addEmitter(emitterPos);
+                if (entities.shouldLoad(blockEntity)) {
+                  if (blockEntity instanceof Poseable) {
+                    entities.addActor(blockEntity);
+                  } else {
+                    entities.addEntity(blockEntity);
+                    if (emitterGrid != null) {
+                      for (Grid.EmitterPosition emitterPos : blockEntity.getEmitterPosition()) {
+                        emitterPos.x -= origin.x;
+                        emitterPos.y -= origin.y;
+                        emitterPos.z -= origin.z;
+                        emitterGrid.addEmitter(emitterPos);
+                      }
                     }
                   }
                 }
               }
             }
           }
-        }
 
-        if (!chunkData.isEmpty()){
-          nonEmptyChunks.add(cp);
-          if (dimension.getChunk(cp).getVersion() == ChunkVersion.PRE_FLATTENING) {
-            legacyChunks.add(cp);
+          if (!chunkData.isEmpty()) {
+            nonEmptyChunks.add(cp);
+            if (dimension.getChunk(cp).getVersion() == ChunkVersion.PRE_FLATTENING) {
+              legacyChunks.add(cp);
+            }
           }
         }
       }
@@ -1440,23 +1445,25 @@ public class Scene implements JsonSerializable, Refreshable {
     refresh();
   }
 
-  private int calculateOctreeOrigin(Collection<ChunkPosition> chunksToLoad, boolean centerOctree) {
+  private int calculateOctreeOrigin(Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion, boolean centerOctree) {
     int xmin = Integer.MAX_VALUE;
     int xmax = Integer.MIN_VALUE;
     int zmin = Integer.MAX_VALUE;
     int zmax = Integer.MIN_VALUE;
-    for (ChunkPosition cp : chunksToLoad) {
-      if (cp.x < xmin) {
-        xmin = cp.x;
-      }
-      if (cp.x > xmax) {
-        xmax = cp.x;
-      }
-      if (cp.z < zmin) {
-        zmin = cp.z;
-      }
-      if (cp.z > zmax) {
-        zmax = cp.z;
+    for (List<ChunkPosition> chunkPositions : chunksToLoadByRegion.values()) {
+      for (ChunkPosition cp : chunkPositions) {
+        if (cp.x < xmin) {
+          xmin = cp.x;
+        }
+        if (cp.x > xmax) {
+          xmax = cp.x;
+        }
+        if (cp.z < zmin) {
+          zmin = cp.z;
+        }
+        if (cp.z > zmax) {
+          zmax = cp.z;
+        }
       }
     }
 
@@ -2185,7 +2192,7 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
-  private synchronized boolean loadOctree(SceneIOProvider ioContext, TaskTracker taskTracker) {
+  private synchronized boolean loadOctree(SceneIOProvider ioContext, TaskTracker taskTracker, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
     String fileName = name + ".octree2";
     try (TaskTracker.Task task = taskTracker.task("(1/3) Loading octree", 2)) {
       task.update(1);
@@ -2227,7 +2234,7 @@ public class Scene implements JsonSerializable, Refreshable {
         palette = data.palette;
         palette.applyMaterials();
         Log.info("Octree loaded");
-        calculateOctreeOrigin(chunks, data.version < 6);
+        calculateOctreeOrigin(chunksToLoadByRegion, data.version < 6);
         camera.setWorldSize(1 << worldOctree.getDepth());
 
         try (TaskTracker.Task bvhTask = taskTracker.task("(2/3) Building world BVH")) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -53,6 +53,7 @@ import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.Biome;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
+import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.json.*;
 import se.llbit.log.Log;
 import se.llbit.math.*;
@@ -72,8 +73,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -853,21 +854,26 @@ public class Scene implements JsonSerializable, Refreshable {
       int[] cubeWaterBlocks = new int[16*16*16];
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
-      Function<RegionPosition, Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition) ->
-        executor.submit(() -> {
-          List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);
-          List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>> chunkDataPairs = new ArrayList<>();
 
-          for (ChunkPosition chunkPosition : chunkPositionsToLoad) {
-            Mutable<ChunkData> reuseChunkData = new Mutable<>(null);
-            dimension.getChunk(chunkPosition).getChunkData(reuseChunkData, palette, biomePalette, yMin, yMax);
-            chunkDataPairs.add(new ObjectObjectImmutablePair<>(chunkPosition, reuseChunkData.get()));
-          }
-          return chunkDataPairs;
+      ChunkData[] regionParsingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
+      ChunkData[] chunkLoadingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
+
+      BiFunction<RegionPosition, ChunkData[], Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition, chunkDataArray) -> executor.submit(() -> {
+        List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);
+        List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>> chunkDataPairs = new ArrayList<>();
+
+        for (int i = 0, chunkPositionsToLoadSize = chunkPositionsToLoad.size(); i < chunkPositionsToLoadSize; i++) {
+          ChunkPosition chunkPosition = chunkPositionsToLoad.get(i);
+          Mutable<ChunkData> chunkData = new Mutable<>(chunkDataArray[i]);
+          dimension.getChunk(chunkPosition).getChunkData(chunkData, palette, biomePalette, yMin, yMax);
+          chunkDataArray[i] = chunkData.get();
+          chunkDataPairs.add(new ObjectObjectImmutablePair<>(chunkPosition, chunkData.get()));
+        }
+        return chunkDataPairs;
       });
 
       //Initialise first chunk data for the for loop
-      Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>> nextRegionFuture = createRegionDataFuture.apply(regionPositions[0]);
+      Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>> nextRegionFuture = createRegionDataFuture.apply(regionPositions[0], regionParsingDataArray);
 
       for (int i = 0; i < regionPositions.length; i++) {
         RegionPosition regionPosition = regionPositions[i];
@@ -881,12 +887,17 @@ public class Scene implements JsonSerializable, Refreshable {
         { // Get this data from active future, schedule next future
           try {
             chunkDataPairs = nextRegionFuture.get();
+
+            //swap the arrays
+            ChunkData[] temp = regionParsingDataArray;
+            regionParsingDataArray = chunkLoadingDataArray;
+            chunkLoadingDataArray = temp;
           } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e.getCause());
           }
 
           if (i + 1 < regionPositions.length) {
-            nextRegionFuture = createRegionDataFuture.apply(regionPositions[i + 1]);
+            nextRegionFuture = createRegionDataFuture.apply(regionPositions[i + 1], regionParsingDataArray);
           }
         }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -772,6 +772,11 @@ public class Scene implements JsonSerializable, Refreshable {
     refresh();
   }
 
+  @PluginApi
+  public synchronized void loadChunks(TaskTracker taskTracker, World world, Collection<ChunkPosition> chunksToLoadByRegion) {
+    loadChunks(taskTracker, world, ChunkSelectionTracker.selectionByRegion(chunksToLoadByRegion));
+  }
+
   /**
    * Load chunks into the octree.
    *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
@@ -19,12 +19,14 @@ package se.llbit.chunky.renderer.scene;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.SceneProvider;
 import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.World;
 import se.llbit.util.TaskTracker;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A scene manager can save and load scenes.
@@ -67,13 +69,13 @@ public interface SceneManager {
    * Load chunks and reset camera and scene.
    * The scene name should be set before the call to loadFreshChunks().
    */
-  void loadFreshChunks(World world, Collection<ChunkPosition> chunks);
+  void loadFreshChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion);
 
   /**
    * Load chunks without resetting the current scene.
    * This preserves camera position, etc.
    */
-  void loadChunks(World world, Collection<ChunkPosition> chunks);
+  void loadChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion);
 
   /**
    * Attempt to reload all loaded chunks.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.World;
 import se.llbit.log.Log;
 import se.llbit.util.ProgressListener;
@@ -28,7 +29,8 @@ import se.llbit.util.TaskTracker;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.BiConsumer;
@@ -233,10 +235,10 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
     onSceneLoaded.run();
   }
 
-  @Override public void loadFreshChunks(World world, Collection<ChunkPosition> chunksToLoad) {
+  @Override public void loadFreshChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
     synchronized (scene) {
       scene.clear();
-      scene.loadChunks(taskTracker, world, chunksToLoad);
+      scene.loadChunks(taskTracker, world, chunksToLoadByRegion);
       scene.resetScene(null, context.getChunky().getSceneFactory());
       context.setSceneDirectory(new File(context.getChunky().options.sceneDir, scene.name));
       scene.refresh();
@@ -246,10 +248,10 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
     onSceneLoaded.run();
   }
 
-  @Override public void loadChunks(World world, Collection<ChunkPosition> chunksToLoad) {
+  @Override public void loadChunks(World world, Map<RegionPosition, List<ChunkPosition>> chunksToLoadByRegion) {
     synchronized (scene) {
       int prevChunkCount = scene.numberOfChunks();
-      scene.loadChunks(taskTracker, world, chunksToLoad);
+      scene.loadChunks(taskTracker, world, chunksToLoadByRegion);
       if (prevChunkCount == 0) {
         scene.moveCameraToCenter();
       }

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -154,7 +154,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     newScene.setOnAction(event -> {
       SceneManager sceneManager = controller.getRenderController().getSceneManager();
       sceneManager
-          .loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
+          .loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelectionByRegion());
     });
     newScene.setDisable(chunkSelection.isEmpty());
 
@@ -162,7 +162,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     loadSelection.setOnAction(event -> {
       SceneManager sceneManager = controller.getRenderController().getSceneManager();
       sceneManager
-          .loadChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
+          .loadChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelectionByRegion());
     });
     loadSelection.setDisable(chunkSelection.isEmpty());
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -476,7 +476,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
         .setTooltip(new Tooltip("Load the chunks that are currently selected in the map view"));
     loadSelectedChunks.setOnAction(e -> {
       controller.getSceneManager()
-          .loadChunks(mapLoader.getWorld(), chunkyFxController.getChunkSelection().getSelection());
+          .loadChunks(mapLoader.getWorld(), chunkyFxController.getChunkSelection().getSelectionByRegion());
       reloadChunks.setDisable(chunkyFxController.getChunkSelection().isEmpty());
     });
 

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -386,14 +386,14 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    * @return The currently selected chunks
    */
   public synchronized Collection<ChunkPosition> getSelection() {
-    Map<ChunkPosition, List<ChunkPosition>> selectionByRegion = getSelectionByRegion();
+    Map<RegionPosition, List<ChunkPosition>> selectionByRegion = getSelectionByRegion();
     List<ChunkPosition> selectedChunks = new ArrayList<>();
     selectionByRegion.forEach((regionPosition, chunks) -> selectedChunks.addAll(chunks));
     return selectedChunks;
   }
 
-  public synchronized Map<ChunkPosition, List<ChunkPosition>> getSelectionByRegion() {
-    Map<ChunkPosition, List<ChunkPosition>> selectedChunksByRegionPosition = new Object2ReferenceOpenHashMap<>();
+  public synchronized Map<RegionPosition, List<ChunkPosition>> getSelectionByRegion() {
+    Map<RegionPosition, List<ChunkPosition>> selectedChunksByRegionPosition = new Object2ReferenceOpenHashMap<>();
     selectedChunksByRegion.forEach((regionPosition, selectedChunksBitSet) -> {
       RegionPosition regionPos = new RegionPosition(regionPosition);
       List<ChunkPosition> positions = new ArrayList<>();
@@ -405,8 +405,16 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
           }
         }
       }
-      selectedChunksByRegionPosition.put(new ChunkPosition(regionPosition), positions);
+      selectedChunksByRegionPosition.put(regionPos, positions);
     });
+    return selectedChunksByRegionPosition;
+  }
+
+  public static Map<RegionPosition, List<ChunkPosition>> selectionByRegion(Collection<ChunkPosition> chunkPositions) {
+    Map<RegionPosition, List<ChunkPosition>> selectedChunksByRegionPosition = new Object2ReferenceOpenHashMap<>();
+    chunkPositions.forEach(chunkPosition ->
+      selectedChunksByRegionPosition.computeIfAbsent(new RegionPosition(chunkPosition.x >> 5, chunkPosition.z >> 5), r -> new ArrayList<>())
+        .add(chunkPosition));
     return selectedChunksByRegionPosition;
   }
 


### PR DESCRIPTION
Merge after #1256

Rather than loading chunks in the order they appear in the chunk list, now load chunks region by region, which should lead to much better region loading performance, also the task scheduling has been cleaned up.
Maybe some minor improvements cache-wise for the octree due to loading chunks close to each other too

Still need to create some `ChunkData` cache, as each chunk currently allocates one
