### PR TITLE
Fix palette error due to expecting block name to contian "minecraft:"

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -997,7 +997,6 @@ public class MinecraftBlockProvider implements BlockProvider {
     // drop the minecraft: prefix
     String[] split = namespacedName.split(":", 2); // split into maximum 2 parts
 
-    //TODO: modded block support? non-minecraft prefix is ignored
     if(split.length != 2 || !split[0].equals("minecraft")) {
       return null;
     }

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -994,7 +994,14 @@ public class MinecraftBlockProvider implements BlockProvider {
 
   @Override
   public Block getBlockByTag(String namespacedName, Tag tag) {
-    String name = namespacedName.substring(10); // drop the minecraft: prefix
+    // drop the minecraft: prefix
+    String[] split = namespacedName.split(":", 2); // split into maximum 2 parts
+
+    //TODO: modded block support? non-minecraft prefix is ignored
+    if(split.length != 2 || !split[0].equals("minecraft")) {
+      return null;
+    }
+    String name = split[1];
     switch (name) {
       case "granite":
         return new MinecraftBlock(name, Texture.granite);

--- a/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
@@ -54,26 +54,30 @@ public class RegionParser extends Thread {
   }
 
   @Override public void run() {
-    while (!isInterrupted()) {
-      ChunkPosition position = queue.poll();
-      if (position == null) {
-        Log.warn("Region parser shutting down abnormally.");
-        return;
-      }
-      ChunkView map = mapView.getMapView();
-      if (map.isRegionVisible(position)) {
-        World world = mapLoader.getWorld();
-        Region region = world.getRegionWithinRange(position, mapView.getYMin(), mapView.getYMax());
-        region.parse(mapView.getYMin(), mapView.getYMax());
-        Mutable<ChunkData> chunkData = new Mutable<>(null);
-        for (Chunk chunk : region) {
-          if (map.shouldPreload(chunk)) {
-            if(chunk.loadChunk(chunkData, mapView.getYMin(), mapView.getYMax())) {
-              chunkData.get().clear();
+    try {
+      while (!isInterrupted()) {
+        ChunkPosition position = queue.poll();
+        if (position == null) {
+          Log.warn("Region parser shutting down abnormally.");
+          return;
+        }
+        ChunkView map = mapView.getMapView();
+        if (map.isRegionVisible(position)) {
+          World world = mapLoader.getWorld();
+          Region region = world.getRegionWithinRange(position, mapView.getYMin(), mapView.getYMax());
+          region.parse(mapView.getYMin(), mapView.getYMax());
+          Mutable<ChunkData> chunkData = new Mutable<>(null);
+          for (Chunk chunk : region) {
+            if (map.shouldPreload(chunk)) {
+              if (chunk.loadChunk(chunkData, mapView.getYMin(), mapView.getYMax())) {
+                chunkData.get().clear();
+              }
             }
           }
         }
       }
+    } catch (Throwable t) {
+      Log.warn("Region Parser Error", t);
     }
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
@@ -54,8 +54,8 @@ public class RegionParser extends Thread {
   }
 
   @Override public void run() {
-    try {
-      while (!isInterrupted()) {
+    while (!isInterrupted()) {
+      try {
         ChunkPosition position = queue.poll();
         if (position == null) {
           Log.warn("Region parser shutting down abnormally.");
@@ -75,9 +75,9 @@ public class RegionParser extends Thread {
             }
           }
         }
+      } catch (Throwable t) {
+        Log.warn("Region Parser Error", t);
       }
-    } catch (Throwable t) {
-      Log.warn("Region Parser Error", t);
     }
   }
 }


### PR DESCRIPTION
also add a general catch for the region parser to prevent such errors from going unnoticed / without a stacktrace