### PR TITLE
Re-allow right panel in map tab to be resizable to 0

### DIFF
--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -63,7 +63,7 @@
             <Canvas fx:id="mapCanvas" />
             <Canvas fx:id="mapOverlay" />
           </StackPane>
-          <VBox maxWidth="500" minWidth="300" spacing="5.0">
+          <VBox maxWidth="500" minWidth="0" spacing="5.0">
             <padding>
               <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
             </padding>


### PR DESCRIPTION
Closes #1275