### PR TITLE
Reuse chunky icon image instances

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -23,7 +23,6 @@ import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.stage.Stage;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.main.Chunky;
@@ -56,7 +55,7 @@ public class ChunkyFx extends Application {
       Parent root = loader.load();
       Scene scene = new Scene(root);
       stage.setScene(scene);
-      stage.getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
+      stage.getIcons().add(Icons.CHUNKY_ICON);
       stage.setOnCloseRequest(event -> {
         PersistentSettings.setWindowPosition(new WindowPosition(stage));
         Platform.exit();

--- a/chunky/src/java/se/llbit/chunky/ui/Icons.java
+++ b/chunky/src/java/se/llbit/chunky/ui/Icons.java
@@ -1,11 +1,19 @@
 package se.llbit.chunky.ui;
 
+import javafx.scene.image.Image;
+
 /**
  * Icons made for Chunky and released under CC0
  *
- * Icons are provided as SVG Paths
+ * Most icons are provided as SVG paths to use with {@link javafx.scene.shape.SVGPath}.
  */
 public class Icons {
+  /**
+   * Chunky icon ("chunky-icon.png")
+   * typically used as window/dialog icon {@link javafx.stage.Stage#getIcons()}
+   */
+  public final static Image CHUNKY_ICON = new Image(Icons.class.getResourceAsStream("/chunky-icon.png"));
+
   public final static String PORTRAIT_TO_LANDSCAPE =
     "M0-8v9h-3v3h-5v-12Zm-7 1v10h3v-3h3v-7Z" + // portrait rectangle with missing edge
     "M8 0v8h-12v-8Zm-11 1v6h10v-6Z" + // landscape rectangle

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/ChunkyErrorDialog.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/ChunkyErrorDialog.java
@@ -21,19 +21,17 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TextArea;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Region;
 import javafx.stage.Stage;
+import se.llbit.chunky.ui.Icons;
 import se.llbit.log.Level;
 
 import java.io.IOException;
@@ -64,7 +62,7 @@ public class ChunkyErrorDialog extends Stage implements Initializable {
     loader.setController(this);
     Parent root = loader.load();
     setTitle(getLevelName(errorType) + " Summary");
-    getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
+    getIcons().add(Icons.CHUNKY_ICON);
     setScene(new Scene(root));
     addEventFilter(KeyEvent.ANY, e -> {
       if (e.getCode() == KeyCode.ESCAPE && e.getEventType() == KeyEvent.KEY_RELEASED) {

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/SceneChooser.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/SceneChooser.java
@@ -20,10 +20,10 @@ package se.llbit.chunky.ui.dialogs;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
+import se.llbit.chunky.ui.Icons;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.chunky.ui.controller.SceneChooserController;
 
@@ -37,7 +37,7 @@ public class SceneChooser extends Stage {
     Parent root = loader.load();
     SceneChooserController controller = loader.getController();
     setTitle("Load Chunky Scene");
-    getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
+    getIcons().add(Icons.CHUNKY_ICON);
     setScene(new Scene(root));
     controller.setController(chunkyFxController);
     controller.setStage(this);

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/SettingsExport.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/SettingsExport.java
@@ -25,12 +25,12 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import se.llbit.chunky.ui.Icons;
 import se.llbit.json.JsonMember;
 import se.llbit.json.JsonObject;
 
@@ -154,7 +154,7 @@ public class SettingsExport extends Stage {
     scrollPane.setContent(vBox);
     setScene(new Scene(scrollPane));
     setTitle("Settings Export");
-    getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
+    getIcons().add(Icons.CHUNKY_ICON);
     addEventFilter(KeyEvent.KEY_PRESSED, e -> {
       if (e.getCode() == KeyCode.ESCAPE) {
         e.consume();

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/WorldChooser.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/WorldChooser.java
@@ -20,11 +20,11 @@ package se.llbit.chunky.ui.dialogs;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import se.llbit.chunky.map.WorldMapLoader;
+import se.llbit.chunky.ui.Icons;
 import se.llbit.chunky.ui.controller.WorldChooserController;
 
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class WorldChooser extends Stage {
     Parent root = loader.load();
     WorldChooserController controller = loader.getController();
     setTitle("Select World");
-    getIcons().add(new Image(getClass().getResourceAsStream("/chunky-icon.png")));
+    getIcons().add(Icons.CHUNKY_ICON);
     setScene(new Scene(root));
     controller.setStage(this);
     controller.populate(mapLoader);


### PR DESCRIPTION
Image instances can be used by different JavaFX nodes simultaneously (window icon, ImageView).
Therefore we don't have to reloading it for every dialog.