### PR TITLE
Add a simple JavaFX installer to the launcher.

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ChunkyLauncher {
 
-  public static final Semver LAUNCHER_VERSION = new Semver("1.13.3");
+  public static final Semver LAUNCHER_VERSION = new Semver("1.14.0");
   public static final int LAUNCHER_SETTINGS_REVISION = 1;
 
   /**

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -25,17 +25,10 @@ import se.llbit.chunky.launcher.ui.DebugConsole;
 import se.llbit.chunky.launcher.ui.FirstTimeSetupDialog;
 import se.llbit.chunky.resources.SettingsDirectory;
 
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.font.TextAttribute;
 import java.io.*;
 import java.net.*;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Scanner;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -68,8 +68,8 @@ public class ChunkyLauncher {
   public static void main(String[] args) throws FileNotFoundException {
     boolean retryIfMissingJavafx = true;
 
+    final LauncherSettings settings = new LauncherSettings();
     try {
-      final LauncherSettings settings = new LauncherSettings();
       settings.load();
 
       // Currently, there's nothing that changed from previous launcher settings revisions.
@@ -257,7 +257,7 @@ public class ChunkyLauncher {
         // Javafx error
         if (retryIfMissingJavafx)
           JavaFxLocator.retryWithJavafx(args);
-        showJavafxError();
+        JavaFxInstaller.launch(settings, args);
       }
       e.printStackTrace(System.err);
     }
@@ -386,64 +386,5 @@ public class ChunkyLauncher {
     } else {
       return String.format("%.1f %s", fSize, unit);
     }
-  }
-
-  private static void showJavafxError() {
-    String[] errorMessages = new String[]{
-      "Error: Java cannot find JavaFX.",
-      "If you are using a JVM for Java 11 or later, " +
-        "JavaFX is no longer shipped alongside and must be installed separately.",
-      "If you already have JavaFX installed, you need to run Chunky with the command:",
-      "java --module-path <path/to/JavaFX/lib> --add-modules javafx.controls,javafx.fxml -jar <path/to/ChunkyLauncher.jar>"
-    };
-    String faqLink = "https://chunky.lemaik.de/java11";
-    String faqMessage = "Check out this page for more information on how to use Chunky with JavaFX";
-    if (!GraphicsEnvironment.isHeadless()) {
-      JTextField faqLabel;
-      if (Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-        faqLabel = new JTextField(faqMessage);
-        Font font = faqLabel.getFont();
-        Map attributes = font.getAttributes();
-        attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
-        faqLabel.setFont(font.deriveFont(attributes));
-        faqLabel.setForeground(Color.BLUE.darker());
-        faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-        faqLabel.setEditable(false);
-        faqLabel.setBackground(null);
-        faqLabel.setBorder(null);
-        faqLabel.addMouseListener(new MouseAdapter() {
-          @Override
-          public void mouseClicked(MouseEvent e) {
-            try {
-              Desktop.getDesktop().browse(new URI(faqLink));
-            } catch (IOException | URISyntaxException ioException) {
-              ioException.printStackTrace();
-            }
-          }
-        });
-      } else {
-        faqLabel = new JTextField(String.format("%s: %s", faqMessage, faqLink));
-        faqLabel.setEditable(false);
-        faqLabel.setBackground(null);
-        faqLabel.setBorder(null);
-        faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
-      }
-      Object[] dialogContent = {
-        Arrays.stream(errorMessages).map(msg -> {
-          JTextField field = new JTextField(msg);
-          field.setEditable(false);
-          field.setBackground(null);
-          field.setBorder(null);
-          field.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
-          return field;
-        }).toArray(),
-        faqLabel
-      };
-      JOptionPane.showMessageDialog(null, dialogContent, "Cannot find JavaFX", JOptionPane.ERROR_MESSAGE);
-    }
-    for (String message : errorMessages) {
-      System.err.println(message);
-    }
-    System.err.printf("%s: %s\n", faqMessage, faqLink);
   }
 }

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -91,6 +91,9 @@ public class JavaFxDownloads {
     return o;
   }
 
+  /**
+   * Parse a json object for the download list.
+   */
   public static Os[] parse(JsonArray objs) throws SyntaxException {
     ArrayList<Os> out = new ArrayList<>();
     for (JsonValue value : objs.elements) {
@@ -100,6 +103,9 @@ public class JavaFxDownloads {
     return out.toArray(new Os[0]);
   }
 
+  /**
+   * Parse an input stream for the download list.
+   */
   public static Os[] parse(InputStream is) throws SyntaxException, IOException {
     try (JsonParser parser = new JsonParser(is)) {
       JsonValue value = parser.parse();
@@ -110,6 +116,9 @@ public class JavaFxDownloads {
     }
   }
 
+  /**
+   * Fet the download list from a URL.
+   */
   public static Os[] fetch(URL url) throws SyntaxException, IOException {
     // Follow redirects
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -53,7 +53,7 @@ public class JavaFxDownloads {
       ArrayList<Arch> archs = new ArrayList<>();
       JsonValue archsVal = obj.get("archs");
       if (!archsVal.isArray()) throw new SyntaxException("OS object field archs must be array.");
-      for (JsonValue arch: archsVal.asArray().elements) {
+      for (JsonValue arch : archsVal.asArray().elements) {
         if (!arch.isObject()) throw new SyntaxException("OS object field archs must be array of architecture objects");
         archs.add(new Arch(arch.asObject()));
       }
@@ -68,13 +68,15 @@ public class JavaFxDownloads {
   public static class Arch {
     public final String name;
     public final URL url;
+    public final String sha256;
     private final Pattern regex;
 
     Arch(JsonObject obj) throws SyntaxException {
       name = getChecked(obj, "name");
-      this.regex = Pattern.compile(getChecked(obj, "regex"));
+      regex = Pattern.compile(getChecked(obj, "regex"));
+      sha256 = getChecked(obj, "sha256");
       try {
-        this.url = new URL(getChecked(obj, "url"));
+        url = new URL(getChecked(obj, "url"));
       } catch (MalformedURLException e) {
         throw new SyntaxException("Architecture object has invalid URL");
       }

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -1,0 +1,127 @@
+/* Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.launcher;
+
+import se.llbit.json.JsonArray;
+import se.llbit.json.JsonObject;
+import se.llbit.json.JsonParser;
+import se.llbit.json.JsonValue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class JavaFxDownloads {
+  public static class SyntaxException extends Exception {
+    public SyntaxException(String message) {
+      super(message);
+    }
+
+    public SyntaxException(JsonParser.SyntaxError e) {
+      super("Json syntax error:\n" + e.getMessage());
+    }
+  }
+
+  public static class Os {
+    public final String name;
+    public final Arch[] archs;
+    private final Pattern regex;
+
+    Os(JsonObject obj) throws SyntaxException {
+      name = getChecked(obj, "name");
+      this.regex = Pattern.compile(getChecked(obj, "regex"));
+
+      ArrayList<Arch> archs = new ArrayList<>();
+      JsonValue archsVal = obj.get("archs");
+      if (!archsVal.isArray()) throw new SyntaxException("OS object field archs must be array.");
+      for (JsonValue arch: archsVal.asArray().elements) {
+        if (!arch.isObject()) throw new SyntaxException("OS object field archs must be array of architecture objects");
+        archs.add(new Arch(arch.asObject()));
+      }
+      this.archs = archs.toArray(new Arch[0]);
+    }
+
+    public boolean doesMatch(String os) {
+      return regex.matcher(os).matches();
+    }
+  }
+
+  public static class Arch {
+    public final String name;
+    public final URL url;
+    private final Pattern regex;
+
+    Arch(JsonObject obj) throws SyntaxException {
+      name = getChecked(obj, "name");
+      this.regex = Pattern.compile(getChecked(obj, "regex"));
+      try {
+        this.url = new URL(getChecked(obj, "url"));
+      } catch (MalformedURLException e) {
+        throw new SyntaxException("Architecture object has invalid URL");
+      }
+    }
+
+    public boolean doesMatch(String arch) {
+      return regex.matcher(arch).matches();
+    }
+  }
+
+  private static String getChecked(JsonObject obj, String field) throws SyntaxException {
+    String o = obj.get(field).asString(null);
+    if (o == null) throw new SyntaxException("Missing field: " + field);
+    return o;
+  }
+
+  public static Os[] parse(JsonArray objs) throws SyntaxException {
+    ArrayList<Os> out = new ArrayList<>();
+    for (JsonValue value : objs.elements) {
+      if (!value.isObject()) throw new SyntaxException("Expecting array of OS objects.");
+      out.add(new Os(value.asObject()));
+    }
+    return out.toArray(new Os[0]);
+  }
+
+  public static Os[] parse(InputStream is) throws SyntaxException, IOException {
+    try (JsonParser parser = new JsonParser(is)) {
+      JsonValue value = parser.parse();
+      if (!value.isArray()) throw new SyntaxException("Expecting array of OS objects.");
+      return parse(value.asArray());
+    } catch (JsonParser.SyntaxError e) {
+      throw new SyntaxException(e);
+    }
+  }
+
+  public static Os[] fetch(URL url) throws SyntaxException, IOException {
+    // Follow redirects
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    int responseCode = conn.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_MOVED_PERM ||
+      responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+      responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
+      return fetch(new URL(conn.getHeaderField("Location")));
+    }
+
+    try (InputStream is = url.openStream()) {
+      return parse(is);
+    }
+  }
+}

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
@@ -1,0 +1,345 @@
+/* Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.launcher;
+
+import se.llbit.util.OSDetector;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowEvent;
+import java.awt.font.TextAttribute;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class JavaFxInstaller {
+
+  private static final String HELP_LINK = "https://chunky.lemaik.de/java11";
+
+  private final OSDetector.OS os = OSDetector.getOS();
+  private final String arch = System.getProperty("os.arch").toLowerCase();
+  private final Path target;
+  private URL updateSite;
+  private URL fxDownload;
+
+  private JFrame window = null;
+
+  private static class InstallationException extends Exception {
+    public InstallationException(String message) {
+      super(message);
+    }
+  }
+
+  private JavaFxInstaller(LauncherSettings settings) throws InstallationException {
+    // Get installation target directory
+    Path chunkyDir = Paths.get(System.getProperty("user.home"));
+    chunkyDir = chunkyDir.resolve(".chunky");
+    target = chunkyDir.resolve("javafx");
+    if (target.toFile().exists()) {
+      throw new InstallationException("Installation already exists.");
+    }
+
+    // Get update site
+    try {
+      if (settings == null) {
+        updateSite = new URL(LauncherSettings.DEFAULT_UPDATE_SITE);
+      } else {
+        updateSite = new URL(settings.updateSite);
+      }
+    } catch (MalformedURLException e) {
+      throw new InstallationException("Invalid update site: " + e);
+    }
+
+    findFxDownload();
+
+    showInstallDialog();
+  }
+
+  public static void launch(LauncherSettings settings, String[] args) {
+    try {
+      JavaFxInstaller instance = new JavaFxInstaller(settings);
+
+      // Wait until we are finished
+      try {
+        synchronized (instance) {
+          while (!instance.isFinished()) {
+            // Have a timeout in case the window closes but we are not notifed
+            // for some reason
+            instance.wait(10000);
+          }
+        }
+      } catch (InterruptedException ignored) {}
+
+      // Success?
+      JavaFxLocator.retryWithJavafx(args);
+    } catch (InstallationException e) {
+      showJavafxError(e);
+    }
+  }
+
+  private void downloadAndInstall() throws InstallationException {
+    // Zip extraction code from
+    // https://mkyong.com/java/how-to-decompress-files-from-a-zip-file/
+    try (ZipInputStream zis = new ZipInputStream(fxDownload.openStream())) {
+      ZipEntry entry = zis.getNextEntry();
+      while (entry != null) {
+        boolean isDirectory = entry.getName().endsWith("/") || entry.getName().endsWith("\\");
+
+        // Protect against zip slip
+        Path newPath = target.resolve(entry.getName());
+        Path normalizedPath = newPath.normalize();
+        if (!normalizedPath.startsWith(target)) {
+          cleanupTarget();
+          throw new InstallationException("Bad zip entry: " + entry.getName());
+        }
+
+        if (isDirectory) {
+          Files.createDirectories(newPath);
+        } else {
+          if (newPath.getParent() != null) {
+            Files.createDirectories(newPath.getParent());
+          }
+          Files.copy(zis, newPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        entry = zis.getNextEntry();
+      }
+      zis.closeEntry();
+    } catch (IOException ex) {
+      try {
+        cleanupTarget();
+      } catch (IOException ignored) {
+        System.err.println("Could not clean up target directory.");
+      }
+      throw new InstallationException(ex.getMessage());
+    }
+  }
+
+  private void cleanupTarget() throws IOException {
+    Files.walk(target)
+      .sorted(Comparator.reverseOrder())
+      .map(Path::toFile)
+      .forEach(File::delete);
+    assert !target.toFile().exists();
+  }
+
+  private void findFxDownload() throws InstallationException {
+    try {
+      fxDownload = new URL("https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_windows-x64_bin-sdk.zip");
+    } catch (MalformedURLException e) {
+      throw new InstallationException(e.getMessage());
+    }
+  }
+
+  private void showInstallDialog() throws InstallationException {
+    Image chunkyImage = Toolkit.getDefaultToolkit().getImage(getClass().getResource(
+      "/se/llbit/chunky/launcher/ui/chunky-cfg.png"));
+
+    JFrame window = new JFrame("Install JavaFX");
+    window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    window.setIconImage(chunkyImage);
+
+    JPanel textPanel = new JPanel();
+    textPanel.setLayout(new BoxLayout(textPanel, BoxLayout.Y_AXIS));
+
+    // Title
+    JLabel installLabel = new JLabel("Install JavaFX");
+    installLabel.setFont(new Font(installLabel.getFont().getFontName(), Font.BOLD, 36));
+    textPanel.add(installLabel);
+
+    // Description
+    JLabel[] description = new JLabel[3];
+    description[0] = new JLabel("Chunky needs JavaFX to function. If you are using");
+    description[1] = new JLabel("a JVM for Java 11 or later, JavaFX is no longer");
+    description[2] = new JLabel("shipped alongside and must be installed separately.");
+    for (JLabel label : description) {
+      label.setFont(new Font(label.getFont().getFontName(), Font.PLAIN, 12));
+      textPanel.add(label);
+    }
+
+    // Spacer
+    textPanel.add(new JLabel(" "));
+
+    // Computer configuration
+    textPanel.add(new JLabel("Detected computer configuration:"));
+
+    JPanel compPanel = new JPanel();
+    compPanel.setLayout(new GridLayout(2, 3));
+    textPanel.add(compPanel);
+
+    compPanel.add(new JLabel("    "));
+    compPanel.add(new JLabel("OS:"));
+    compPanel.add(new JLabel(String.valueOf(os)));
+
+    compPanel.add(new JLabel("    "));
+    compPanel.add(new JLabel("Arch:"));
+    compPanel.add(new JLabel(arch));
+
+    // Spacer
+    textPanel.add(new JLabel(" "));
+
+    // JavaFX Licensing
+    JLabel licenseText = new JLabel("JavaFX is licensed under GPLv2+LE.");
+    licenseText.setFont(new Font(licenseText.getFont().getFontName(), Font.PLAIN, 12));
+    textPanel.add(licenseText);
+    textPanel.add(getLinkLabel());
+
+    // Spacer
+    textPanel.add(new JLabel(" "));
+
+    // Download and Install button
+    JButton downloadButton = new JButton("Download and Install");
+    textPanel.add(downloadButton);
+    downloadButton.addActionListener(e -> {
+      try {
+        this.downloadAndInstall();
+        window.setVisible(false);
+        window.dispose();
+      } catch (InstallationException ex) {
+        window.setVisible(false);
+        window.dispose();
+        showJavafxError(ex);
+      }
+      synchronized (this) {
+        this.notifyAll();
+      }
+    });
+
+    // Spacer
+    textPanel.add(new JLabel(" "));
+
+    // Add icon and make top layout
+    JPanel topPanel = new JPanel();
+    topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
+    topPanel.add(new JLabel(new ImageIcon(chunkyImage)));
+    topPanel.add(textPanel);
+    topPanel.add(new JLabel("  "));
+
+    window.add(topPanel);
+    window.pack();
+    window.setVisible(true);
+    this.window = window;
+  }
+
+  private boolean isFinished() {
+    if (this.window == null) {
+      return false;
+    }
+    return !this.window.isVisible();
+  }
+
+  private static JLabel getLinkLabel() {
+    JLabel faqLabel;
+    if(Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+      faqLabel = new JLabel("Click here for more information.");
+      Font font = faqLabel.getFont();
+      Map attributes = font.getAttributes();
+      attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
+      faqLabel.setFont(font.deriveFont(attributes));
+      faqLabel.setForeground(Color.BLUE.darker());
+      faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+      faqLabel.addMouseListener(new MouseAdapter() {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+          try {
+            Desktop.getDesktop().browse(new URI(HELP_LINK));
+          } catch(IOException | URISyntaxException ex) {
+            throw new RuntimeException(ex);
+          }
+        }
+      });
+    } else {
+      faqLabel = new JLabel(String.format("For more information see: %s", HELP_LINK));
+      faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+    }
+    return faqLabel;
+  }
+
+  private static void showJavafxError(InstallationException e) {
+    String[] errorMessages = new String[]{
+      "Error installing JavaFX: " + e.getMessage(),
+      "If you are using a JVM for Java 11 or later, " +
+        "JavaFX is no longer shipped alongside and must be installed separately.",
+      "If you already have JavaFX installed, you need to run Chunky with the command:",
+      "java --module-path <path/to/JavaFX/lib> --add-modules javafx.controls,javafx.fxml -jar <path/to/ChunkyLauncher.jar>"
+    };
+    String faqLink = "https://chunky.lemaik.de/java11";
+    String faqMessage = "Check out this page for more information on how to use Chunky with JavaFX";
+    if(!GraphicsEnvironment.isHeadless()) {
+      JTextField faqLabel;
+      if(Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+        faqLabel = new JTextField(faqMessage);
+        Font font = faqLabel.getFont();
+        Map attributes = font.getAttributes();
+        attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
+        faqLabel.setFont(font.deriveFont(attributes));
+        faqLabel.setForeground(Color.BLUE.darker());
+        faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        faqLabel.setEditable(false);
+        faqLabel.setBackground(null);
+        faqLabel.setBorder(null);
+        faqLabel.addMouseListener(new MouseAdapter() {
+          @Override
+          public void mouseClicked(MouseEvent e) {
+            try {
+              Desktop.getDesktop().browse(new URI(faqLink));
+            } catch(IOException | URISyntaxException ioException) {
+              ioException.printStackTrace();
+            }
+          }
+        });
+      } else {
+        faqLabel = new JTextField(String.format("%s: %s", faqMessage, faqLink));
+        faqLabel.setEditable(false);
+        faqLabel.setBackground(null);
+        faqLabel.setBorder(null);
+        faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+      }
+      Object[] dialogContent = {
+        Arrays.stream(errorMessages).map(msg -> {
+          JTextField field = new JTextField(msg);
+          field.setEditable(false);
+          field.setBackground(null);
+          field.setBorder(null);
+          field.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+          return field;
+        }).toArray(),
+        faqLabel
+      };
+      JOptionPane.showMessageDialog(null, dialogContent, "Cannot find JavaFX", JOptionPane.ERROR_MESSAGE);
+    }
+    for(String message : errorMessages) {
+      System.err.println(message);
+    }
+    System.err.printf("%s: %s\n", faqMessage, faqLink);
+  }
+}

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
@@ -387,7 +387,7 @@ public class JavaFxInstaller {
       setup.setBorder(null);
       setup.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
 
-      JLabel help = getLinkLabel("Click here for more information", "For more information, see", JAVAFX_LINK);
+      JLabel help = getLinkLabel("Click here for more information", "For more information, see", HELP_LINK);
 
       JOptionPane.showMessageDialog(null, new Object[] {
         error, setup, help

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
@@ -43,6 +43,7 @@ import java.util.zip.ZipInputStream;
 public class JavaFxInstaller {
 
   private static final String HELP_LINK = "https://chunky.lemaik.de/java11";
+  private static final String JAVAFX_LINK = "https://gluonhq.com/products/javafx/";
   private static final String JAVAFX_JSON = "javafx.json";
 
   private final JavaFxDownloads.Os[] downloads;
@@ -279,8 +280,12 @@ public class JavaFxInstaller {
     // JavaFX Licensing
     JLabel licenseText = new JLabel("JavaFX is licensed under GPLv2+CE.");
     licenseText.setFont(new Font(licenseText.getFont().getFontName(), Font.PLAIN, 12));
-    textPanel.add(licenseText);
-    textPanel.add(getLinkLabel());
+    textPanel.add(getLinkLabel("JavaFX is licensed under GPLv2+CE.", "JavaFX is licensed under GPLv2+CE", JAVAFX_LINK));
+
+    // Spacer
+    textPanel.add(new JLabel(" "));
+
+    textPanel.add(getLinkLabel("Click here for more information.", "For more information see", HELP_LINK));
 
     // Spacer
     textPanel.add(new JLabel(" "));
@@ -337,10 +342,10 @@ public class JavaFxInstaller {
     }
   }
 
-  private static JLabel getLinkLabel() {
+  private static JLabel getLinkLabel(String linkText, String altText, String url) {
     JLabel faqLabel;
-    if(Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-      faqLabel = new JLabel("Click here for more information.");
+    if (Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+      faqLabel = new JLabel(linkText);
       Font font = faqLabel.getFont();
       Map attributes = font.getAttributes();
       attributes.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
@@ -351,14 +356,14 @@ public class JavaFxInstaller {
         @Override
         public void mouseClicked(MouseEvent e) {
           try {
-            Desktop.getDesktop().browse(new URI(HELP_LINK));
+            Desktop.getDesktop().browse(new URI(url));
           } catch(IOException | URISyntaxException ex) {
             throw new RuntimeException(ex);
           }
         }
       });
     } else {
-      faqLabel = new JLabel(String.format("For more information see: %s", HELP_LINK));
+      faqLabel = new JLabel(String.format("%s: %s", altText, url));
       faqLabel.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
     }
     return faqLabel;
@@ -382,7 +387,7 @@ public class JavaFxInstaller {
       setup.setBorder(null);
       setup.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
 
-      JLabel help = getLinkLabel();
+      JLabel help = getLinkLabel("Click here for more information", "For more information, see", JAVAFX_LINK);
 
       JOptionPane.showMessageDialog(null, new Object[] {
         error, setup, help

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
@@ -277,7 +277,7 @@ public class JavaFxInstaller {
     textPanel.add(new JLabel(" "));
 
     // JavaFX Licensing
-    JLabel licenseText = new JLabel("JavaFX is licensed under GPLv2+LE.");
+    JLabel licenseText = new JLabel("JavaFX is licensed under GPLv2+CE.");
     licenseText.setFont(new Font(licenseText.getFont().getFontName(), Font.PLAIN, 12));
     textPanel.add(licenseText);
     textPanel.add(getLinkLabel());

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxInstaller.java
@@ -372,10 +372,20 @@ public class JavaFxInstaller {
       error.setBorder(null);
       error.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
 
+      JTextField setup = new JTextField(String.format(
+        "Detected computer configuration: %s %s",
+        System.getProperty("os.name"),
+        System.getProperty("os.arch")
+      ));
+      setup.setEditable(false);
+      setup.setBackground(null);
+      setup.setBorder(null);
+      setup.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+
       JLabel help = getLinkLabel();
 
       JOptionPane.showMessageDialog(null, new Object[] {
-        error, help
+        error, setup, help
       }, "Cannot find JavaFX", JOptionPane.ERROR_MESSAGE);
     }
     System.err.println(e.getMessage());

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxLocator.java
@@ -51,6 +51,7 @@ public class JavaFxLocator {
     Path userHomePath = getJavaFXPathBySystemProperty("user.home");
     if(userHomePath != null) {
       addJavaFXPathIfValid(userHomePath.resolve(".chunky"), true);
+      addJavaFXPathIfValid(userHomePath.resolve(".chunky").resolve("javafx"), true);
     }
 
     // java home


### PR DESCRIPTION
When JavaFX is not detected, the following installer will open:
![image](https://user-images.githubusercontent.com/42661490/172085915-1af2047d-9872-43e9-b36f-1a8f073e7168.png)
The fields will attempt to auto-populate, however the user can change the fields if they are incorrect. Clicking on the `Download and Install` button will download the JavaFX sdk and extract it to `~/.chunky/javafx/`. The JavaFX finder has been modified to also look for this path.

This requires the update site to have a `javafx.json` file such as:
```json
[
  {
    "name": "Windows",
    "regex": "Windows.*",
    "archs": [
      {
        "name": "x64",
        "regex": "amd64",
        "url": "https://download2.gluonhq.com/openjfx/17.0.2/openjfx-17.0.2_windows-x64_bin-sdk.zip"
      }
    ]
  }
]
```
