### PR TITLE
Refactor octree finalization, make water level independent of block solid property, fix water level below submerged blocks.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/BlockFace.java
+++ b/chunky/src/java/se/llbit/chunky/block/BlockFace.java
@@ -1,40 +1,64 @@
 package se.llbit.chunky.block;
 
 public enum BlockFace {
+  SELF("self", 0, 0, 0),
   /**
    * Facing north, i.e. towards negative Z.
    */
-  NORTH("north"),
+  NORTH("north", 0, 0, -1),
+  /**
+   * Facing north east, i.e. towards positive X, negative Z.
+   */
+  NORTH_EAST("north_east", 1, 0, -1),
   /**
    * Facing east, i.e. towards positive X.
    */
-  EAST("east"),
+  EAST("east", 1, 0, 0),
+  /**
+   * Facing south east, i.e. towards positive X, positive Z.
+   */
+  SOUTH_EAST("south_east", 1, 0, 1),
   /**
    * Facing south, i.e. towards positive Z.
    */
-  SOUTH("south", NORTH),
+  SOUTH("south", NORTH, 0, 0, 1),
+  /**
+   * Facing south west, i.e. towards negative X, positive Z.
+   */
+  SOUTH_WEST("south_west", NORTH_EAST, -1, 0, 1),
   /**
    * Facing west, i.e. towards negative X.
    */
-  WEST("west", EAST),
+  WEST("west", EAST, -1, 0, 0),
+  /**
+   * Facing north west, i.e. towards negative X, negative Z.
+   */
+  NORTH_WEST("north_west", SOUTH_EAST, -1, 0, -1),
   /**
    * Facing up, i.e. towards positive Y.
    */
-  UP("up"),
+  UP("up", 0, 1, 0),
   /**
    * Facing down, i.e. towards negative Y.
    */
-  DOWN("down", UP);
+  DOWN("down", UP, 0, -1, 0);
 
   private final String name;
   private BlockFace oppositeFace;
+  public final int rx;
+  public final int ry;
+  public final int rz;
 
-  BlockFace(String name) {
+  BlockFace(String name, int rx, int ry, int rz) {
     this.name = name;
+    this.rx = rx;
+    this.ry = ry;
+    this.rz = rz;
+    this.oppositeFace = this; // to make the opposite of SELF be SELF
   }
 
-  BlockFace(String name, BlockFace oppositeFace) {
-    this.name = name;
+  BlockFace(String name, BlockFace oppositeFace, int rx, int ry, int rz) {
+    this(name, rx, ry, rz);
     this.oppositeFace = oppositeFace;
     oppositeFace.oppositeFace = this;
   }
@@ -56,16 +80,26 @@ public enum BlockFace {
     switch (name) {
       case "north":
         return NORTH;
+      case "north_east":
+        return NORTH_EAST;
       case "east":
         return EAST;
+      case "south_east":
+        return SOUTH_EAST;
       case "south":
         return SOUTH;
+      case "south_west":
+        return SOUTH_WEST;
       case "west":
         return WEST;
+      case "north_west":
+        return NORTH_WEST;
       case "up":
         return UP;
       case "down":
         return DOWN;
+      case "self":
+        return SELF;
       default:
         throw new IllegalArgumentException("Unknown BlockFace name: " + name);
     }

--- a/chunky/src/java/se/llbit/chunky/block/ChunkDataFinalizationState.java
+++ b/chunky/src/java/se/llbit/chunky/block/ChunkDataFinalizationState.java
@@ -1,0 +1,84 @@
+package se.llbit.chunky.block;
+
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.chunk.ChunkData;
+import se.llbit.chunky.world.Material;
+
+public abstract class ChunkDataFinalizationState extends FinalizationState {
+  private  ChunkData chunkData;
+  private final int yMin;
+  private final int yMax;
+  protected int x;
+  protected int y;
+  protected int z;
+
+  public ChunkDataFinalizationState(ChunkData chunkData, BlockPalette palette, int yMin, int yMax) {
+    super(palette);
+    this.chunkData = chunkData;
+    this.yMin = yMin;
+    this.yMax = yMax;
+  }
+
+  public void setChunkData(ChunkData chunkData) {
+    this.chunkData = chunkData;
+  }
+
+  @Override
+  public Material getMaterial() {
+    return getPalette().get(chunkData.getBlockAt(x, y, z));
+  }
+
+  @Override
+  public Material getMaterial(int rx, int ry, int rz) {
+    return getPalette().get(chunkData.getBlockAt(x + rx, y + ry, z + rz));
+  }
+
+  @Override
+  public Material getWaterMaterial() {
+    Material material = getMaterial();
+    if (material.isWater()) {
+      return material;
+    }
+    return getPalette().get(getPalette().airId);
+  }
+
+  @Override
+  public Material getWaterMaterial(int rx, int ry, int rz) {
+    Material material = getMaterial(rx, ry, rz);
+    if (material.isWater()) {
+      return material;
+    }
+    return getPalette().get(getPalette().airId);
+  }
+
+  @Override
+  public int getX() {
+    return x;
+  }
+
+  @Override
+  public int getY() {
+    return y;
+  }
+
+  @Override
+  public int getZ() {
+    return z;
+  }
+
+  @Override
+  public int getYMin() {
+    return yMin;
+  }
+
+  @Override
+  public int getYMax() {
+    return yMax;
+  }
+
+  public void setPosition(int x, int y, int z) {
+    this.x = x;
+    this.y = y;
+    this.z = z;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/block/FinalizationState.java
+++ b/chunky/src/java/se/llbit/chunky/block/FinalizationState.java
@@ -12,27 +12,67 @@ public abstract class FinalizationState {
     this.palette = palette;
   }
 
+  /**
+   * Get the material at the current position. This may or may not return materials replaced by
+   * {@link #replaceCurrentBlock(int)} or {@link #replaceCurrentBlock(Tag)}.
+   *
+   * @return Material at the current location
+   */
   public abstract Material getMaterial();
 
+  /**
+   * Get the material at the current position. If rx = ry = rz = 0, this may or may not return materials replaced by
+   * {@link #replaceCurrentBlock(int)} or {@link #replaceCurrentBlock(Tag)}.
+   *
+   * @return Material at the current location
+   */
   public abstract Material getMaterial(int rx, int ry, int rz);
 
+  /**
+   * Get the material at given direction from the current positon. If direction is SELF, this may or may not return
+   * materials replaced by {@link #replaceCurrentBlock(int)} or {@link #replaceCurrentBlock(Tag)}.
+   *
+   * @return Material at the current location
+   */
   public Material getMaterial(BlockFace direction) {
-    switch (direction) {
-      case NORTH:
-        return getMaterial(0, 0, -1);
-      case EAST:
-        return getMaterial(1, 0, 0);
-      case SOUTH:
-        return getMaterial(0, 0, 1);
-      case WEST:
-        return getMaterial(-1, 0, 0);
-      case UP:
-        return getMaterial(0, 1, 0);
-      case DOWN:
-        return getMaterial(0, -1, 0);
-      default:
-        throw new IllegalArgumentException("Invalid direction: " + direction);
-    }
+    return getMaterial(direction.rx, direction.ry, direction.rz);
+  }
+
+  /**
+   * Check if the block at the current position is visible (ie. has any non-opaque blocks surrounding it).
+   *
+   * @return True if the block is visible, false otherwise
+   */
+  public boolean isCurrentBlockVisible() {
+    return !(getMaterial(BlockFace.NORTH).opaque && getMaterial(BlockFace.SOUTH).opaque &&
+      getMaterial(BlockFace.WEST).opaque && getMaterial(BlockFace.EAST).opaque &&
+      getMaterial(BlockFace.UP).opaque && getMaterial(BlockFace.DOWN).opaque);
+  }
+
+  /**
+   * Get the water material at the current position. This may or may not return materials replaced
+   * by {@link #replaceCurrentWaterBlock(int)}.
+   *
+   * @return Water material at the current location
+   */
+  public abstract Material getWaterMaterial();
+
+  /**
+   * Get the water material at the current position. If rx = ry = rz = 0, this may or may not return materials
+   * replaced by {@link #replaceCurrentWaterBlock(int)}.
+   *
+   * @return Water material at the current location
+   */
+  public abstract Material getWaterMaterial(int rx, int ry, int rz);
+
+  /**
+   * Get the material at given direction from the current positon. If direction is SELF, this may or may not return
+   * materials replaced by {@link #replaceCurrentWaterBlock(int)}.
+   *
+   * @return Material at the current location
+   */
+  public Material getWaterMaterial(BlockFace direction) {
+    return getWaterMaterial(direction.rx, direction.ry, direction.rz);
   }
 
   public abstract void replaceCurrentBlock(int newBlock);
@@ -40,6 +80,8 @@ public abstract class FinalizationState {
   public void replaceCurrentBlock(Tag tag) {
     replaceCurrentBlock(getPalette().put(tag));
   }
+
+  public abstract void replaceCurrentWaterBlock(int newPaletteId);
 
   public BlockPalette getPalette() {
     return palette;

--- a/chunky/src/java/se/llbit/chunky/block/OctreeFinalizationState.java
+++ b/chunky/src/java/se/llbit/chunky/block/OctreeFinalizationState.java
@@ -3,6 +3,7 @@ package se.llbit.chunky.block;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.world.Material;
 import se.llbit.math.Octree;
+import se.llbit.math.Vector3i;
 
 public class OctreeFinalizationState extends FinalizationState {
 
@@ -10,33 +11,54 @@ public class OctreeFinalizationState extends FinalizationState {
   private final Octree waterTree;
   private final int yMin;
   private final int yMax;
+  private final Vector3i origin;
   private int x;
   private int y;
   private int z;
+  private int ox;
+  private int oy;
+  private int oz;
 
   public OctreeFinalizationState(Octree worldTree, Octree waterTree,
-      BlockPalette palette, int yMin, int yMax) {
+                                 BlockPalette palette, int yMin, int yMax, Vector3i origin) {
     super(palette);
     this.worldTree = worldTree;
     this.waterTree = waterTree;
     this.yMin = yMin;
     this.yMax = yMax;
+    this.origin = origin;
   }
 
   @Override
   public Material getMaterial() {
-    return worldTree.getMaterial(x, y, z, getPalette());
+    return worldTree.getMaterial(ox, oy, oz, getPalette());
   }
 
   @Override
   public Material getMaterial(int rx, int ry, int rz) {
     return worldTree
-        .getMaterial(x + rx, y + ry, z + rz, getPalette());
+      .getMaterial(ox + rx, oy + ry, oz + rz, getPalette());
+  }
+
+  @Override
+  public Material getWaterMaterial() {
+    return waterTree.getMaterial(ox, oy, oz, getPalette());
+  }
+
+  @Override
+  public Material getWaterMaterial(int rx, int ry, int rz) {
+    return waterTree
+      .getMaterial(ox + rx, oy + ry, oz + rz, getPalette());
   }
 
   @Override
   public void replaceCurrentBlock(int newPaletteId) {
-    worldTree.set(newPaletteId, x, y, z);
+    worldTree.set(newPaletteId, ox, oy, oz);
+  }
+
+  @Override
+  public void replaceCurrentWaterBlock(int newPaletteId) {
+    waterTree.set(newPaletteId, ox, oy, oz);
   }
 
   @Override
@@ -68,5 +90,8 @@ public class OctreeFinalizationState extends FinalizationState {
     this.x = x;
     this.y = y;
     this.z = z;
+    ox = x - origin.x;
+    oy = y - origin.y;
+    oz = z - origin.z;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlockUtils.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlockUtils.java
@@ -48,16 +48,18 @@ public class LegacyBlockUtils {
   public static class FinalizationStateCache extends FinalizationState {
 
     private final Material[] cache;
+    private final Material[] waterCache;
     private final FinalizationState state;
 
     public FinalizationStateCache(FinalizationState state) {
-      this(state, new Material[27]);
+      this(state, new Material[27], new Material[27]);
     }
 
-    public FinalizationStateCache(FinalizationState state, Material[] cache) {
+    public FinalizationStateCache(FinalizationState state, Material[] cache, Material[] waterCache) {
       super(state.getPalette());
       this.state = state;
       this.cache = cache;
+      this.waterCache = waterCache;
     }
 
     private static int getCacheIndex(int rx, int ry, int rz) {
@@ -81,8 +83,29 @@ public class LegacyBlockUtils {
     }
 
     @Override
+    public Material getWaterMaterial() {
+      return state.getWaterMaterial();
+    }
+
+    @Override
+    public Material getWaterMaterial(int rx, int ry, int rz) {
+      int index = getCacheIndex(rx, ry, rz);
+
+      if (waterCache[index] != null) {
+        return waterCache[index];
+      }
+      waterCache[index] = state.getWaterMaterial(rx, ry, rz);
+      return waterCache[index];
+    }
+
+    @Override
     public void replaceCurrentBlock(int newBlock) {
       state.replaceCurrentBlock(newBlock);
+    }
+
+    @Override
+    public void replaceCurrentWaterBlock(int newPaletteId) {
+      state.replaceCurrentWaterBlock(newPaletteId);
     }
 
     @Override

--- a/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocksFinalizer.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/LegacyBlocksFinalizer.java
@@ -26,15 +26,14 @@ public class LegacyBlocksFinalizer {
   public static void finalizeChunk(Octree worldTree, Octree waterTree, BlockPalette palette,
       Vector3i origin, ChunkPosition cp, int yMin, int yMax) {
     OctreeFinalizationState finalizerState = new OctreeFinalizationState(worldTree, waterTree,
-        palette, yMin, yMax);
+        palette, yMin, yMax, origin);
     for (int cy = yMin; cy < yMax; ++cy) {
-      int y = cy - origin.y;
       for (int cz = 0; cz < 16; ++cz) {
-        int z = cz + cp.z * 16 - origin.z;
+        int z = cz + cp.z * 16;
         for (int cx = 0; cx < 16; ++cx) {
-          int x = cx + cp.x * 16 - origin.x;
+          int x = cx + cp.x * 16;
           // TODO as in 1.13+ finalization we could finalize non-edge blocks during chunk loading
-          finalizerState.setPosition(x, y, z);
+          finalizerState.setPosition(x, cy, z);
           Material mat = finalizerState.getMaterial();
           if (mat instanceof UnfinalizedLegacyBlock) {
             ((UnfinalizedLegacyBlock) mat).finalizeBlock(finalizerState);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -116,15 +116,21 @@ public class Scene implements JsonSerializable, Refreshable {
   public static final int DEFAULT_DUMP_FREQUENCY = 500;
   public static final String EXTENSION = ".json";
 
-  /** The current Scene Description Format (SDF) version. */
+  /**
+   * The current Scene Description Format (SDF) version.
+   */
   public static final int SDF_VERSION = 9;
 
   protected static final double fSubSurface = 0.3;
 
-  /** Minimum canvas width. */
+  /**
+   * Minimum canvas width.
+   */
   public static final int MIN_CANVAS_WIDTH = 20;
 
-  /** Minimum canvas height. */
+  /**
+   * Minimum canvas height.
+   */
   public static final int MIN_CANVAS_HEIGHT = 20;
 
   /**
@@ -173,7 +179,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Default post processing filter.
    */
   public static final PostProcessingFilter DEFAULT_POSTPROCESSING_FILTER = PostProcessingFilters
-      .getPostProcessingFilterFromId("GAMMA").orElse(PostProcessingFilters.NONE);
+    .getPostProcessingFilterFromId("GAMMA").orElse(PostProcessingFilters.NONE);
 
   private static boolean invalidWarn = false;
 
@@ -181,11 +187,11 @@ public class Scene implements JsonSerializable, Refreshable {
   protected final Camera camera = new Camera(this);
   protected final Sun sun = new Sun(this);
   protected final Vector3 waterColor =
-      new Vector3(PersistentSettings.getWaterColorRed(), PersistentSettings.getWaterColorGreen(),
-          PersistentSettings.getWaterColorBlue());
+    new Vector3(PersistentSettings.getWaterColorRed(), PersistentSettings.getWaterColorGreen(),
+      PersistentSettings.getWaterColorBlue());
   protected final Vector3 fogColor =
-      new Vector3(PersistentSettings.getFogColorRed(), PersistentSettings.getFogColorGreen(),
-          PersistentSettings.getFogColorBlue());
+    new Vector3(PersistentSettings.getFogColorRed(), PersistentSettings.getFogColorGreen(),
+      PersistentSettings.getFogColorBlue());
   public int sdfVersion = -1;
   public String name = "default_" + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
 
@@ -244,10 +250,14 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   protected boolean fastFog = true;
 
-  /** Fog thickness. */
+  /**
+   * Fog thickness.
+   */
   protected double fogDensity = DEFAULT_FOG_DENSITY;
 
-  /** Controls how much the fog color is blended over the sky/skymap. */
+  /**
+   * Controls how much the fog color is blended over the sky/skymap.
+   */
   protected double skyFogDensity = 1;
 
   protected boolean biomeColors = true;
@@ -264,7 +274,8 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * World reference.
    */
-  @NotNull private World loadedWorld = EmptyWorld.INSTANCE;
+  @NotNull
+  private World loadedWorld = EmptyWorld.INSTANCE;
 
   /**
    * Octree origin.
@@ -296,16 +307,24 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   private ArrayList<Entity> actors = new ArrayList<>();
 
-  /** Poseable entities in the scene. */
+  /**
+   * Poseable entities in the scene.
+   */
   private Map<PlayerEntity, JsonObject> profiles = new HashMap<>();
 
-  /** Material properties for this scene. */
+  /**
+   * Material properties for this scene.
+   */
   public Map<String, JsonValue> materials = new HashMap<>();
 
-  /** Lower Y clip plane. */
+  /**
+   * Lower Y clip plane.
+   */
   public int yClipMin = PersistentSettings.getYClipMin();
 
-  /** Upper Y clip plane. */
+  /**
+   * Upper Y clip plane.
+   */
   public int yClipMax = PersistentSettings.getYClipMax();
 
   private BVH bvh = BVH.EMPTY;
@@ -320,7 +339,9 @@ public class Scene implements JsonSerializable, Refreshable {
   private BiomeStructure foliageTexture;
   private BiomeStructure waterTexture;
 
-  /** This is the 8-bit channel frame buffer. */
+  /**
+   * This is the 8-bit channel frame buffer.
+   */
   protected BitmapImage frontBuffer;
 
   private BitmapImage backBuffer;
@@ -402,7 +423,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public static void delete(String name, File sceneDir) {
     String[] extensions = {
-        ".json", ".dump", ".octree2", ".emittergrid", ".foliage", ".grass", ".json.backup", ".dump.backup",
+      ".json", ".dump", ".octree2", ".emittergrid", ".foliage", ".grass", ".json.backup", ".dump.backup",
     };
     for (String extension : extensions) {
       File file = new File(sceneDir, name + extension);
@@ -417,7 +438,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Export the scene to a zip file.
    */
   public static void exportToZip(File sceneDirectory, String name, File targetFile) {
-    String[] extensions = { ".json", ".dump", ".octree2", ".foliage", ".grass", ".emittergrid", };
+    String[] extensions = {".json", ".dump", ".octree2", ".foliage", ".grass", ".emittergrid",};
     ZipExport.zip(targetFile, new File(sceneDirectory, name), name, extensions);
   }
 
@@ -551,7 +572,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * @throws InterruptedException
    */
   public synchronized void saveScene(SceneIOProvider context, TaskTracker taskTracker)
-      throws IOException {
+    throws IOException {
     try (TaskTracker.Task task = taskTracker.task("Saving scene", 2)) {
       task.update(1);
 
@@ -571,7 +592,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * @param sceneName file name of the scene to load
    */
   public synchronized void loadScene(RenderContext context, String sceneName, TaskTracker taskTracker)
-      throws IOException {
+    throws IOException {
     isLoading = true;
     try {
       try {
@@ -694,7 +715,9 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * @return The <code>BlockPallete</code> for the scene
    */
-  public BlockPalette getPalette() { return palette; }
+  public BlockPalette getPalette() {
+    return palette;
+  }
 
   /**
    * Trace a ray in this scene. This offsets the ray origin to
@@ -705,7 +728,7 @@ public class Scene implements JsonSerializable, Refreshable {
     state.ray.o.y -= origin.y;
     state.ray.o.z -= origin.z;
 
-    if(camera.getProjectionMode() == ProjectionMode.PARALLEL) {
+    if (camera.getProjectionMode() == ProjectionMode.PARALLEL) {
       // When in parallel projection, push the ray origin back so the
       // ray start outside the octree to prevent ray spawning inside some blocks
       int limit = (1 << worldOctree.getDepth());
@@ -713,15 +736,15 @@ public class Scene implements JsonSerializable, Refreshable {
       Vector3 d = state.ray.d;
       double t = 0;
       // simplified intersection test with the 6 planes that form the bounding box of the octree
-      if(Math.abs(d.x) > Ray.EPSILON) {
+      if (Math.abs(d.x) > Ray.EPSILON) {
         t = Math.min(t, -o.x / d.x);
         t = Math.min(t, (limit - o.x) / d.x);
       }
-      if(Math.abs(d.y) > Ray.EPSILON) {
+      if (Math.abs(d.y) > Ray.EPSILON) {
         t = Math.min(t, -o.y / d.y);
         t = Math.min(t, (limit - o.y) / d.y);
       }
-      if(Math.abs(d.z) > Ray.EPSILON) {
+      if (Math.abs(d.z) > Ray.EPSILON) {
         t = Math.min(t, -o.z / d.z);
         t = Math.min(t, (limit - o.z) / d.z);
       }
@@ -746,12 +769,12 @@ public class Scene implements JsonSerializable, Refreshable {
     boolean hit = false;
 
     if (Double.isNaN(ray.d.x) || Double.isNaN(ray.d.y) || Double.isNaN(ray.d.z) ||
-        (ray.d.x == 0 && ray.d.y == 0 && ray.d.z == 0)) {
+      (ray.d.x == 0 && ray.d.y == 0 && ray.d.z == 0)) {
       if (!invalidWarn) {
         Log.warnf("Invalid ray with direction (%f, %f, %f).\n" +
             "This is a bug! Please report it at:\n" +
             "    https://github.com/chunky-dev/chunky/issues/",
-            ray.d.x, ray.d.y, ray.d.z);
+          ray.d.x, ray.d.y, ray.d.z);
         invalidWarn = true;
       }
       ray.d.set(0, 1, 0);
@@ -780,7 +803,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Test whether the ray intersects any voxel before exiting the Octree.
    *
-   * @param ray   the ray
+   * @param ray the ray
    * @return {@code true} if the ray intersects a voxel
    */
   private boolean worldIntersection(Ray ray) {
@@ -800,14 +823,14 @@ public class Scene implements JsonSerializable, Refreshable {
     if (start.getCurrentMaterial().isWater()) {
       r = new Ray(start);
       r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
-      if(waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
+      if (waterOctree.exitWater(this, r, palette) && r.distance < ray.t - Ray.EPSILON) {
         ray.t = r.distance;
         ray.setNormal(r.getNormal());
         ray.color.set(r.color);
         ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
         ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
         hit = true;
-      } else if(ray.getPrevMaterial() == Air.INSTANCE) {
+      } else if (ray.getPrevMaterial() == Air.INSTANCE) {
         ray.setPrevMaterial(Water.INSTANCE, 1 << Water.FULL_BLOCK);
       }
     } else {
@@ -827,7 +850,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public void updateOpacity(Ray ray) {
     if (ray.getCurrentMaterial().isWater() || (ray.getCurrentMaterial() == Air.INSTANCE
-        && ray.getPrevMaterial().isWater())) {
+      && ray.getPrevMaterial().isWater())) {
       if (useCustomWaterColor) {
         ray.color.x = waterColor.x;
         ray.color.y = waterColor.y;
@@ -907,7 +930,7 @@ public class Scene implements JsonSerializable, Refreshable {
       foliageTexture = biomeStructureFactory.create();
       waterTexture = biomeStructureFactory.create();
 
-      if(emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
+      if (emitterSamplingStrategy != EmitterSamplingStrategy.NONE)
         emitterGrid = new Grid(gridSize);
 
       // Parse the regions first - force chunk lists to be populated!
@@ -978,8 +1001,8 @@ public class Scene implements JsonSerializable, Refreshable {
 
       ChunkPosition[] chunkPositions = chunksToLoad.toArray(new ChunkPosition[0]);
 
-      int[] cubeWorldBlocks = new int[16*16*16];
-      int[] cubeWaterBlocks = new int[16*16*16];
+      int[] cubeWorldBlocks = new int[16 * 16 * 16];
+      int[] cubeWaterBlocks = new int[16 * 16 * 16];
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
       Future<?> nextChunkDataTask = executor.submit(() -> { //Initialise first chunk data for the for loop
@@ -999,10 +1022,10 @@ public class Scene implements JsonSerializable, Refreshable {
 
         try {
           nextChunkDataTask.get();
-        } catch(InterruptedException logged) { // If except, load the chunk synchronously
+        } catch (InterruptedException logged) { // If except, load the chunk synchronously
           Log.warn("Chunky loading interrupted.", logged);
           return;
-        } catch(ExecutionException e) {
+        } catch (ExecutionException e) {
           throw new RuntimeException(e.getCause());
         }
 
@@ -1061,7 +1084,7 @@ public class Scene implements JsonSerializable, Refreshable {
                 // After 1.12 paintings had id=minecraft:painting.
                 float yaw = tag.get("Rotation").get(0).floatValue();
                 entities.add(
-                        new PaintingEntity(new Vector3(x, y, z), tag.get("Motive").stringValue(), yaw));
+                  new PaintingEntity(new Vector3(x, y, z), tag.get("Motive").stringValue(), yaw));
               } else if (id.equals("minecraft:armor_stand") && entityLoadingPreferences.shouldLoadClass(ArmorStand.class)) {
                 actors.add(new ArmorStand(new Vector3(x, y, z), tag));
               }
@@ -1069,49 +1092,79 @@ public class Scene implements JsonSerializable, Refreshable {
           }
         }
 
+        ChunkDataFinalizationState finalizerState = new ChunkDataFinalizationState(chunkData, palette, yMin, yMax) {
+          @Override
+          public void setPosition(int x, int y, int z) {
+            super.setPosition(x, y, z);
+          }
+
+          @Override
+          public void replaceCurrentBlock(int newBlock) {
+            int cy = y % 16;
+            int cubeIndex = (z * 16 + cy) * 16 + x;
+            cubeWorldBlocks[cubeIndex] = newBlock;
+          }
+
+          @Override
+          public void replaceCurrentWaterBlock(int newBlock) {
+            int cy = y % 16;
+            int cubeIndex = (z * 16 + cy) * 16 + x;
+            cubeWaterBlocks[cubeIndex] = newBlock;
+          }
+        };
+
         int yCubeMin = yMin / 16;
-        int yCubeMax = (yMax+15) / 16;
-        for(int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
+        int yCubeMax = (yMax + 15) / 16;
+        for (int yCube = yCubeMin; yCube < yCubeMax; ++yCube) {
           // Reset the cubes
           Arrays.fill(cubeWorldBlocks, 0);
           Arrays.fill(cubeWaterBlocks, 0);
-          for(int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
+          for (int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
             int y = yCube * 16 + cy;
-            if(y < yMin || y >= yMax)
+            if (y < yMin || y >= yMax)
               continue;
-            for(int cz = 0; cz < 16; ++cz) {
+            for (int cz = 0; cz < 16; ++cz) {
+              for (int cx = 0; cx < 16; ++cx) {
+                int cubeIndex = (cz * 16 + cy) * 16 + cx;
+                int block = chunkData.getBlockAt(cx, y, cz);
+                cubeWorldBlocks[cubeIndex] = block;
+                if (palette.get(block).isWater()) {
+                  cubeWaterBlocks[cubeIndex] = block;
+                }
+              }
+            }
+          }
+          for (int cy = 0; cy < 16; ++cy) { //Uses chunk min and max, rather than global - minor optimisation for pre1.13 worlds
+            int y = yCube * 16 + cy;
+            if (y < yMin || y >= yMax)
+              continue;
+            for (int cz = 0; cz < 16; ++cz) {
               int z = cz + cp.z * 16 - origin.z;
-              for(int cx = 0; cx < 16; ++cx) {
+              for (int cx = 0; cx < 16; ++cx) {
                 int x = cx + cp.x * 16 - origin.x;
+                finalizerState.setPosition(cx, y, cz);
 
                 int cubeIndex = (cz * 16 + cy) * 16 + cx;
 
                 // Change the type of hidden blocks to ANY_TYPE
                 boolean onEdge = y <= yMin || y >= yMax - 1 || chunkData.isBlockOnEdge(cx, y, cz);
-                boolean isHidden = !onEdge
-                        && palette.get(chunkData.getBlockAt(cx + 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx - 1, y, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y + 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y - 1, cz)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz + 1)).opaque
-                        && palette.get(chunkData.getBlockAt(cx, y, cz - 1)).opaque;
+                boolean isHidden = !onEdge && !finalizerState.isCurrentBlockVisible();
 
-                if(isHidden) {
+                if (isHidden) {
                   cubeWorldBlocks[cubeIndex] = Octree.ANY_TYPE;
                 } else {
-                  int currentBlock = chunkData.getBlockAt(cx, y, cz);
-                  int octNode = currentBlock;
+                  final int currentBlock = chunkData.getBlockAt(cx, y, cz);
                   Block block = palette.get(currentBlock);
 
-                  if(block.isEntity()) {
+                  if (block.isEntity()) {
                     Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
                     Entity entity = block.toEntity(position);
 
                     if (entityLoadingPreferences.shouldLoad(entity)) {
-                      if(entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
+                      if (entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
                         // don't add the actor again if it was already loaded from json
-                        if(actors.stream().noneMatch(actor -> {
-                          if(actor.getClass().equals(entity.getClass())) {
+                        if (actors.stream().noneMatch(actor -> {
+                          if (actor.getClass().equals(entity.getClass())) {
                             Vector3 distance = new Vector3(actor.position);
                             distance.sub(entity.position);
                             return distance.lengthSquared() < Ray.EPSILON;
@@ -1132,146 +1185,57 @@ public class Scene implements JsonSerializable, Refreshable {
                         }
                       }
 
-                      if(!block.isBlockWithEntity()) {
-                        if(block.waterlogged) {
+                      if (!block.isBlockWithEntity()) {
+                        if (block.waterlogged) {
                           block = palette.water;
-                          octNode = palette.waterId;
                         } else {
                           block = Air.INSTANCE;
-                          octNode = palette.airId;
                         }
                       }
                     }
                   }
 
-                  if(block.isWaterFilled()) {
+                  if (block.isWaterFilled()) {
                     int waterNode = palette.waterId;
-                    if(y + 1 < yMax) {
-                      if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)).isWaterFilled()) {
+                    if (y + 1 < yMax) {
+                      if (palette.get(chunkData.getBlockAt(cx, y + 1, cz)).isWaterFilled()) {
                         waterNode = palette.getWaterId(0, 1 << Water.FULL_BLOCK);
                       }
                     }
-                    if(block.isWater()) {
+                    finalizerState.replaceCurrentWaterBlock(waterNode);
+                    if (block.isWater()) {
                       // Move plain water blocks to the water octree.
-                      octNode = palette.airId;
+                      finalizerState.replaceCurrentBlock(palette.airId);
 
-                      if(!onEdge) {
+                      if (!onEdge) {
                         // Perform water computation now for water blocks that are not on th edge of the chunk
                         // Test if the block has not already be marked as full
-                        if(((Water) palette.get(waterNode)).data == 0) {
-                          int level0 = 8 - ((Water) block).level;
-                          int corner0 = level0;
-                          int corner1 = level0;
-                          int corner2 = level0;
-                          int corner3 = level0;
-
-                          int level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                          corner3 += level;
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                          corner0 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                          corner0 += level;
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                          corner1 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                          corner1 += level;
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                          corner2 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                          corner2 += level;
-                          corner3 += level;
-
-                          level = Chunk.waterLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                          corner3 += level;
-
-                          corner0 = Math.min(7, 8 - (corner0 / 4));
-                          corner1 = Math.min(7, 8 - (corner1 / 4));
-                          corner2 = Math.min(7, 8 - (corner2 / 4));
-                          corner3 = Math.min(7, 8 - (corner3 / 4));
-                          waterNode = palette.getWaterId(((Water) block).level, (corner0 << Water.CORNER_0)
-                                          | (corner1 << Water.CORNER_1)
-                                          | (corner2 << Water.CORNER_2)
-                                          | (corner3 << Water.CORNER_3));
+                        if (((Water) palette.get(waterNode)).data == 0) {
+                          OctreeFinalizer.processWater(finalizerState);
                         }
                       } else {
                         // Water computation for water blocks on the edge of a chunk is done by the OctreeFinalizer but we need the water level information
-                        waterNode = palette.getWaterId(((Water) block).level, 0);
+                        finalizerState.replaceCurrentWaterBlock(palette.getWaterId(((Water) block).level, 0));
                       }
                     }
-                    cubeWaterBlocks[cubeIndex] = waterNode;
-                  } else if(y + 1 < yMax && block instanceof Lava) {
-                    if(palette.get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
-                      octNode = palette.getLavaId(0, 1 << Water.FULL_BLOCK);
-                    } else if(!onEdge) {
+                  } else if (y + 1 < yMax && block instanceof Lava) {
+                    if (palette.get(chunkData.getBlockAt(cx, y + 1, cz)) instanceof Lava) {
+                      cubeWorldBlocks[cubeIndex] = palette.getLavaId(0, 1 << Water.FULL_BLOCK);
+                    } else if (!onEdge) {
                       // Compute lava level for blocks not on edge
-                      Lava lava = (Lava) block;
-                      int level0 = 8 - lava.level;
-                      int corner0 = level0;
-                      int corner1 = level0;
-                      int corner2 = level0;
-                      int corner3 = level0;
-
-                      int level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz, level0);
-                      corner3 += level;
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz + 1, level0);
-                      corner0 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz + 1, level0);
-                      corner0 += level;
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz + 1, level0);
-                      corner1 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz, level0);
-                      corner1 += level;
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx + 1, y, cz - 1, level0);
-                      corner2 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx, y, cz - 1, level0);
-                      corner2 += level;
-                      corner3 += level;
-
-                      level = Chunk.lavaLevelAt(chunkData, palette, cx - 1, y, cz - 1, level0);
-                      corner3 += level;
-
-                      corner0 = Math.min(7, 8 - (corner0 / 4));
-                      corner1 = Math.min(7, 8 - (corner1 / 4));
-                      corner2 = Math.min(7, 8 - (corner2 / 4));
-                      corner3 = Math.min(7, 8 - (corner3 / 4));
-                      octNode = palette.getLavaId(
-                              lava.level,
-                              (corner0 << Water.CORNER_0)
-                                      | (corner1 << Water.CORNER_1)
-                                      | (corner2 << Water.CORNER_2)
-                                      | (corner3 << Water.CORNER_3)
-                      );
+                      OctreeFinalizer.processLava(finalizerState);
                     }
                   }
-                  cubeWorldBlocks[cubeIndex] = octNode;
 
-                  if(emitterGrid != null && block.emittance > 1e-4) {
+                  if (emitterGrid != null && block.emittance > 1e-4) {
                     emitterGrid.addEmitter(new Grid.EmitterPosition(x + 0.5f, y - origin.y + 0.5f, z + 0.5f));
                   }
                 }
               }
             }
           }
-          worldOctree.setCube(4, cubeWorldBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
-          waterOctree.setCube(4, cubeWaterBlocks, cp.x*16 - origin.x, yCube*16 - origin.y, cp.z*16 - origin.z);
+          worldOctree.setCube(4, cubeWorldBlocks, cp.x * 16 - origin.x, yCube * 16 - origin.y, cp.z * 16 - origin.z);
+          waterOctree.setCube(4, cubeWaterBlocks, cp.x * 16 - origin.x, yCube * 16 - origin.y, cp.z * 16 - origin.z);
         }
 
         // Block entities are also called "tile entities". These are extra bits of metadata
@@ -1344,7 +1308,7 @@ public class Scene implements JsonSerializable, Refreshable {
           }
         }
 
-        if (!chunkData.isEmpty()){
+        if (!chunkData.isEmpty()) {
           nonEmptyChunks.add(cp);
           if (world.getChunk(cp).getVersion().equals("1.12")) {
             legacyChunks.add(cp);
@@ -1493,7 +1457,7 @@ public class Scene implements JsonSerializable, Refreshable {
                     if (id == null) {
                       continue;
                     }
-                    if(id != 0) {
+                    if (id != 0) {
                       int asd = 0;
                     }
 
@@ -1526,7 +1490,7 @@ public class Scene implements JsonSerializable, Refreshable {
         OctreeFinalizer.finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
         if (legacyChunks.contains(cp)) {
           LegacyBlocksFinalizer
-              .finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
+            .finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
         }
       }
 
@@ -1619,7 +1583,7 @@ public class Scene implements JsonSerializable, Refreshable {
     int maxDimension = Math.max(yMax - yMin, Math.max(xmax - xmin, zmax - zmin));
     int requiredDepth = QuickMath.log2(QuickMath.nextPow2(maxDimension));
 
-    if(centerOctree) {
+    if (centerOctree) {
       int xroom = (1 << requiredDepth) - (xmax - xmin);
       int yroom = (1 << requiredDepth) - (yMax - yMin);
       int zroom = (1 << requiredDepth) - (zmax - zmin);
@@ -1676,9 +1640,9 @@ public class Scene implements JsonSerializable, Refreshable {
     int xcenter = (xmax + xmin) / 2;
     int zcenter = (zmax + zmin) / 2;
     int ycenter = (yMax + yMin) / 2;
-    for (int y = Math.min(ycenter+127, yMax); y >= Math.max(ycenter-128, yMin); --y) {
+    for (int y = Math.min(ycenter + 127, yMax); y >= Math.max(ycenter - 128, yMin); --y) {
       Material block = worldOctree.getMaterial(xcenter - origin.x, y - origin.y, zcenter - origin.z,
-          palette);
+        palette);
       if (!(block instanceof Air)) {
         return new Vector3(xcenter, y + 5, zcenter);
       }
@@ -1979,11 +1943,12 @@ public class Scene implements JsonSerializable, Refreshable {
   public double getWaterPlaneHeight() {
     return waterPlaneHeight;
   }
+
   /**
    * @return The effective water world mode ocean height influenced by waterPlaneOffsetEnabled
    */
   public double getEffectiveWaterPlaneHeight() {
-    if(waterPlaneOffsetEnabled) {
+    if (waterPlaneOffsetEnabled) {
       return waterPlaneHeight - Water.TOP_BLOCK_GAP;
     } else {
       return waterPlaneHeight;
@@ -2017,6 +1982,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Check if water plane chunk clipping is enabled. If so, the water plane is hidden in loaded
    * chunks (i.e. it is ignored inside of loaded chunks).
+   *
    * @return {@code true} if the water plane chunk clipping is enabled
    */
   public boolean getWaterPlaneChunkClip() {
@@ -2160,7 +2126,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Save the current frame into the given output stream, using the given format.
    */
   public synchronized void writeFrame(OutputStream out, PictureExportFormat mode, TaskTracker taskTracker, int threadCount)
-      throws IOException {
+    throws IOException {
     if (mode.isTransparencySupported()) {
       computeAlpha(taskTracker);
     }
@@ -2176,7 +2142,7 @@ public class Scene implements JsonSerializable, Refreshable {
   private void computeAlpha(TaskTracker taskTracker) {
     if (transparentSky) {
       if (!this.getOutputMode().isTransparencySupported()) {
-        Log.warn("Can not use transparent sky with " + this.getOutputMode().getName() +  " output mode. Use PNG instead.");
+        Log.warn("Can not use transparent sky with " + this.getOutputMode().getName() + " output mode. Use PNG instead.");
       } else {
         try (TaskTracker.Task task = taskTracker.task("Computing alpha channel")) {
           AtomicInteger done = new AtomicInteger(0);
@@ -2211,7 +2177,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public void postProcessFrame(TaskTracker.Task task) {
     PostProcessingFilter filter = postProcessingFilter;
-    if(mode == RenderMode.PREVIEW) {
+    if (mode == RenderMode.PREVIEW) {
       filter = PreviewFilter.INSTANCE;
     }
     filter.processFrame(width, height, samples, backBuffer, exposure, task);
@@ -2262,7 +2228,7 @@ public class Scene implements JsonSerializable, Refreshable {
       boolean saved = false;
       try (DataOutputStream out = new DataOutputStream(new FastBufferedOutputStream(new GZIPOutputStream(context.getSceneFileOutputStream(fileName))))) {
         OctreeFileFormat.store(out, worldOctree, waterOctree, palette,
-            grassTexture, foliageTexture, waterTexture);
+          grassTexture, foliageTexture, waterTexture);
         saved = true;
 
         task.update(2);
@@ -2407,7 +2373,7 @@ public class Scene implements JsonSerializable, Refreshable {
     // Rotated grid supersampling.
 
     camera
-        .calcViewRay(ray, -halfWidth + (x - 3 / 8.0) * invHeight, -.5 + (y + 1 / 8.0) * invHeight);
+      .calcViewRay(ray, -halfWidth + (x - 3 / 8.0) * invHeight, -.5 + (y + 1 / 8.0) * invHeight);
     ray.o.x -= origin.x;
     ray.o.y -= origin.y;
     ray.o.z -= origin.z;
@@ -2415,7 +2381,7 @@ public class Scene implements JsonSerializable, Refreshable {
     double occlusion = PreviewRayTracer.skyOcclusion(this, state);
 
     camera
-        .calcViewRay(ray, -halfWidth + (x + 1 / 8.0) * invHeight, -.5 + (y + 3 / 8.0) * invHeight);
+      .calcViewRay(ray, -halfWidth + (x + 1 / 8.0) * invHeight, -.5 + (y + 3 / 8.0) * invHeight);
     ray.o.x -= origin.x;
     ray.o.y -= origin.y;
     ray.o.z -= origin.z;
@@ -2423,7 +2389,7 @@ public class Scene implements JsonSerializable, Refreshable {
     occlusion += PreviewRayTracer.skyOcclusion(this, state);
 
     camera
-        .calcViewRay(ray, -halfWidth + (x - 1 / 8.0) * invHeight, -.5 + (y - 3 / 8.0) * invHeight);
+      .calcViewRay(ray, -halfWidth + (x - 1 / 8.0) * invHeight, -.5 + (y - 3 / 8.0) * invHeight);
     ray.o.x -= origin.x;
     ray.o.y -= origin.y;
     ray.o.z -= origin.z;
@@ -2431,7 +2397,7 @@ public class Scene implements JsonSerializable, Refreshable {
     occlusion += PreviewRayTracer.skyOcclusion(this, state);
 
     camera
-        .calcViewRay(ray, -halfWidth + (x + 3 / 8.0) * invHeight, -.5 + (y - 1 / 8.0) * invHeight);
+      .calcViewRay(ray, -halfWidth + (x + 3 / 8.0) * invHeight, -.5 + (y - 1 / 8.0) * invHeight);
     ray.o.x -= origin.x;
     ray.o.y -= origin.y;
     ray.o.z -= origin.z;
@@ -2473,10 +2439,10 @@ public class Scene implements JsonSerializable, Refreshable {
 
         buf.append("facing: ");
         double yaw = camera.getYaw();
-        yaw = (yaw + Math.PI*2) % (Math.PI*2);
-        int index = (int)Math.floor((yaw + Math.PI/8) / (Math.PI/4)) % 8;
+        yaw = (yaw + Math.PI * 2) % (Math.PI * 2);
+        int index = (int) Math.floor((yaw + Math.PI / 8) / (Math.PI / 4)) % 8;
         buf.append(new String[]{"west", "southwest", "south", "southeast", "east", "northeast", "north", "northwest"}[index]);
-        index = (int)Math.floor((yaw + Math.PI/4) / (Math.PI/2)) % 4;
+        index = (int) Math.floor((yaw + Math.PI / 4) / (Math.PI / 2)) % 4;
         buf.append(" (towards ");
         buf.append(new String[]{"negative X", "positive Z", "positive X", "negative Z"}[index]);
         buf.append(")");
@@ -2520,6 +2486,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
   /**
    * Get the back buffer of the current frame (in ARGB format).
+   *
    * @return Back buffer
    */
   public BitmapImage getBackBuffer() {
@@ -2528,6 +2495,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
   /**
    * Get the alpha channel of the current frame.
+   *
    * @return Alpha channel of the current frame
    */
   public byte[] getAlphaChannel() {
@@ -2603,7 +2571,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public void mergeDump(File dumpFile, TaskTracker taskTracker) {
     Log.info("Merging render dump: " + dumpFile);
-    try(FileInputStream inputStream = new FileInputStream(dumpFile)) {
+    try (FileInputStream inputStream = new FileInputStream(dumpFile)) {
       RenderDump.merge(inputStream, this, taskTracker);
       postProcessFrame(taskTracker);
       Log.info("Render dump merged: " + dumpFile);
@@ -2623,7 +2591,7 @@ public class Scene implements JsonSerializable, Refreshable {
   public boolean isInWater(Ray ray) {
     if (isWaterPlaneEnabled() && ray.o.y + origin.y < getEffectiveWaterPlaneHeight()) {
       if (getWaterPlaneChunkClip()) {
-        if (!isChunkLoaded((int)Math.floor(ray.o.x), (int)Math.floor(ray.o.y), (int)Math.floor(ray.o.z))) {
+        if (!isChunkLoaded((int) Math.floor(ray.o.x), (int) Math.floor(ray.o.y), (int) Math.floor(ray.o.z))) {
           return true;
         }
       } else {
@@ -2636,7 +2604,7 @@ public class Scene implements JsonSerializable, Refreshable {
       int z = (int) QuickMath.floor(ray.o.z);
       Material block = waterOctree.getMaterial(x, y, z, palette);
       return block.isWater()
-          && ((ray.o.y - y) < 0.875 || ((Water) block).isFullBlock());
+        && ((ray.o.y - y) < 0.875 || ((Water) block).isFullBlock());
     }
     return false;
   }
@@ -2696,7 +2664,8 @@ public class Scene implements JsonSerializable, Refreshable {
     }
   }
 
-  @Override public synchronized JsonObject toJson() {
+  @Override
+  public synchronized JsonObject toJson() {
     JsonObject json = new JsonObject();
     json.add("sdfVersion", SDF_VERSION);
     json.add("name", name);
@@ -2873,7 +2842,9 @@ public class Scene implements JsonSerializable, Refreshable {
     actors.clear();
   }
 
-  /** Create a backup of a scene file. */
+  /**
+   * Create a backup of a scene file.
+   */
   public void backupFile(File sceneDirectory, File file) {
     if (file.exists()) {
       // Try to create backup. It is not a problem if we fail this.
@@ -2932,7 +2903,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * <p>This initializes the sample buffers.
    *
    * @param in Input stream to read the JSON data from. The stream will
-   * be closed when done.
+   *           be closed when done.
    */
   public void loadDescription(InputStream in) throws IOException {
     try (JsonParser parser = new JsonParser(in)) {
@@ -2947,7 +2918,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Write the scene description as JSON.
    *
    * @param out Output stream to write the JSON data to.
-   * The stream will not be closed when done.
+   *            The stream will not be closed when done.
    */
   public void saveDescription(OutputStream out) throws IOException {
     PrettyPrinter pp = new PrettyPrinter("  ", new PrintStream(out));
@@ -2981,14 +2952,14 @@ public class Scene implements JsonSerializable, Refreshable {
 
     exposure = json.get("exposure").doubleValue(exposure);
     postProcessingFilter = PostProcessingFilters
-            .getPostProcessingFilterFromId(json.get("postprocess").stringValue(postProcessingFilter.getId()))
-            .orElseGet(() -> {
-              if (json.get("postprocess").stringValue(null) != null) {
-                Log.warn("The post processing filter " + json +
-                        " is unknown. Maybe you're missing a plugin that was used to create this scene?");
-              }
-              return DEFAULT_POSTPROCESSING_FILTER;
-            });
+      .getPostProcessingFilterFromId(json.get("postprocess").stringValue(postProcessingFilter.getId()))
+      .orElseGet(() -> {
+        if (json.get("postprocess").stringValue(null) != null) {
+          Log.warn("The post processing filter " + json +
+            " is unknown. Maybe you're missing a plugin that was used to create this scene?");
+        }
+        return DEFAULT_POSTPROCESSING_FILTER;
+      });
     outputMode = PictureExportFormats
       .getFormat(json.get("outputMode").stringValue(outputMode.getName()))
       .orElse(PictureExportFormats.PNG);
@@ -3018,9 +2989,9 @@ public class Scene implements JsonSerializable, Refreshable {
       waterColor.z = colorObj.get("blue").doubleValue(waterColor.z);
     }
     String waterShader = json.get("waterShader").stringValue("LEGACY");
-    if(waterShader.equals("LEGACY"))
+    if (waterShader.equals("LEGACY"))
       waterShading = new LegacyWaterShader();
-    else if(waterShader.equals("SIMPLEX"))
+    else if (waterShader.equals("SIMPLEX"))
       waterShading = new SimplexWaterShader();
     else {
       Log.infof("Unknown water shader %s, using LEGACY", waterShader);
@@ -3037,7 +3008,7 @@ public class Scene implements JsonSerializable, Refreshable {
     fogDensity = json.get("fogDensity").doubleValue(fogDensity);
     skyFogDensity = json.get("skyFogDensity").doubleValue(skyFogDensity);
 
-    if(!json.get("waterHeight").isUnknown()) {
+    if (!json.get("waterHeight").isUnknown()) {
       // fallback for older scene versions were waterPlane was enabled by using height = 0
       waterPlaneHeight = json.get("waterHeight").doubleValue(waterPlaneHeight);
       waterPlaneEnabled = waterPlaneHeight > 0;
@@ -3138,7 +3109,8 @@ public class Scene implements JsonSerializable, Refreshable {
    * Called when the scene description has been altered in a way that
    * forces the rendering to restart.
    */
-  @Override public synchronized void refresh() {
+  @Override
+  public synchronized void refresh() {
     refresh(ResetReason.SETTINGS_CHANGED);
   }
 
@@ -3224,6 +3196,7 @@ public class Scene implements JsonSerializable, Refreshable {
   public double getSkyFogDensity() {
     return skyFogDensity;
   }
+
   public void setFastFog(boolean value) {
     if (fastFog != value) {
       fastFog = value;
@@ -3260,6 +3233,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
   /**
    * Clears the reset reason and returns the previous reason.
+   *
    * @return the current reset reason
    */
   public synchronized ResetReason getResetReason() {
@@ -3287,11 +3261,12 @@ public class Scene implements JsonSerializable, Refreshable {
       JsonValue properties = materials.get(name);
       if (properties != null) {
         material.loadMaterialProperties(properties.asObject());
-      }});
+      }
+    });
   }
 
   private void importMaterial(Map<String, JsonValue> propertyMap, String name,
-      Collection<? extends Material> materials) {
+                              Collection<? extends Material> materials) {
     JsonValue value = propertyMap.get(name);
     if (value != null) {
       JsonObject properties = value.object();
@@ -3432,7 +3407,7 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   public void setEmitterSamplingStrategy(EmitterSamplingStrategy emitterSamplingStrategy) {
-    if(this.emitterSamplingStrategy != emitterSamplingStrategy) {
+    if (this.emitterSamplingStrategy != emitterSamplingStrategy) {
       this.emitterSamplingStrategy = emitterSamplingStrategy;
       refresh();
     }

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -371,34 +371,6 @@ public class Chunk {
     }
   }
 
-  public static int waterLevelAt(ChunkData chunkData, BlockPalette palette, int cx, int cy, int cz,
-                                 int baseLevel) {
-    Material corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
-    if (corner.isWater()) {
-      Material above = palette.get(chunkData.getBlockAt(cx, cy+1, cz));
-      boolean isFullBlock = above.isWaterFilled();
-      return isFullBlock ? 8 : 8 - ((Water) corner).level;
-    } else if (corner.waterlogged) {
-      return 8;
-    } else if (!corner.solid) {
-      return 0;
-    }
-    return baseLevel;
-  }
-
-  public static int lavaLevelAt(ChunkData chunkData, BlockPalette palette, int cx, int cy, int cz,
-                                int baseLevel) {
-    Material corner = palette.get(chunkData.getBlockAt(cx, cy, cz));
-    if (corner instanceof Lava) {
-      Material above = palette.get(chunkData.getBlockAt(cx, cy+1, cz));
-      boolean isFullBlock = above instanceof Lava;
-      return isFullBlock ? 8 : 8 - ((Lava) corner).level;
-    } else if (!corner.solid) {
-      return 0;
-    }
-    return baseLevel;
-  }
-
   /**
    * @return <code>true</code> if this is an empty (non-existing) chunk
    */


### PR DESCRIPTION
Fixes #1236 

TODO:

- [ ] Check lava
- [ ] Cleanup (maybe get rid of the water methods in `FinalizationState`?)
- [ ] Check if legacy block finalization still works
- [ ] Look into #1247 by figuring out whether we are at the edge of the selected chunks in `FinalizationState`