### PR TITLE
Hide unknown blocks

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/UnknownBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/UnknownBlock.java
@@ -1,11 +1,21 @@
 package se.llbit.chunky.block;
 
+import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Ray;
 
 public class UnknownBlock extends SpriteBlock {
   public static final UnknownBlock UNKNOWN = new UnknownBlock("?");
 
   public UnknownBlock(String name) {
     super(name, Texture.unknown);
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    if (scene.getHideUnknownBlocks()) {
+      return false;
+    }
+    return super.intersect(ray, scene);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -370,6 +370,11 @@ public class Scene implements JsonSerializable, Refreshable {
   private String biomeStructureImplementation = PersistentSettings.getBiomeStructureImplementation();
 
   /**
+   * Hide unknown blocks. This is done at intersection time, the unknown blocks are still in the octree.
+   */
+  private boolean hideUnknownBlocks = true;
+
+  /**
    * Additional data that is associated with a scene, this can be used by plugins
    */
   private JsonObject additionalData = new JsonObject();
@@ -509,6 +514,8 @@ public class Scene implements JsonSerializable, Refreshable {
     waterPlaneOffsetEnabled = other.waterPlaneOffsetEnabled;
     waterPlaneChunkClip = other.waterPlaneChunkClip;
     waterShading = other.waterShading.clone();
+
+    hideUnknownBlocks = other.hideUnknownBlocks;
 
     spp = other.spp;
     renderTime = other.renderTime;
@@ -2747,6 +2754,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("waterWorldHeightOffsetEnabled", waterPlaneOffsetEnabled);
     json.add("waterWorldClipEnabled", waterPlaneChunkClip);
     json.add("renderActors", renderActors);
+    json.add("hideUnknownBlocks", hideUnknownBlocks);
 
     if (!worldPath.isEmpty()) {
       // Save world info.
@@ -3074,6 +3082,7 @@ public class Scene implements JsonSerializable, Refreshable {
     }
 
     renderActors = json.get("renderActors").boolValue(renderActors);
+    hideUnknownBlocks = json.get("hideUnknownBlocks").boolValue(hideUnknownBlocks);
     materials = json.get("materials").object().copy().toMap();
 
     // Load world info.
@@ -3552,5 +3561,13 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public void setWaterShading(WaterShader waterShading) {
     this.waterShading = waterShading;
+  }
+
+  public boolean getHideUnknownBlocks() {
+    return this.hideUnknownBlocks;
+  }
+
+  public void setHideUnknownBlocks(boolean hideUnknownBlocks) {
+    this.hideUnknownBlocks = hideUnknownBlocks;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -355,6 +355,11 @@ public class Scene implements JsonSerializable, Refreshable {
   private boolean preventNormalEmitterWithSampling = PersistentSettings.getPreventNormalEmitterWithSampling();
 
   /**
+   * Hide unknown blocks. This is done at intersection time, the unknown blocks are still in the octree.
+   */
+  private boolean hideUnknownBlocks = false;
+
+  /**
    * The octree implementation to use
    */
   private String octreeImplementation = PersistentSettings.getOctreeImplementation();
@@ -368,11 +373,6 @@ public class Scene implements JsonSerializable, Refreshable {
    * The BiomeStructure implementation to use
    */
   private String biomeStructureImplementation = PersistentSettings.getBiomeStructureImplementation();
-
-  /**
-   * Hide unknown blocks. This is done at intersection time, the unknown blocks are still in the octree.
-   */
-  private boolean hideUnknownBlocks = true;
 
   /**
    * Additional data that is associated with a scene, this can be used by plugins

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -71,6 +71,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private ChoiceBox<String> biomeStructureImplementation;
   @FXML private IntegerAdjuster gridSize;
   @FXML private CheckBox preventNormalEmitterWithSampling;
+  @FXML private CheckBox hideUnknownBlocks;
   @FXML private ChoiceBox<String> rendererSelect;
   @FXML private ChoiceBox<String> previewSelect;
   @FXML private CheckBox showLauncher;
@@ -241,6 +242,11 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
       PersistentSettings.setPreventNormalEmitterWithSampling(newvalue);
     });
 
+    hideUnknownBlocks.setTooltip(new Tooltip("Hide unknown blocks instead of rendering them as question marks."));
+    hideUnknownBlocks.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      scene.setHideUnknownBlocks(newValue);
+    });
+
     rendererSelect.setTooltip(new Tooltip("The renderer to use for rendering."));
     rendererSelect.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) ->
         scene.setRenderer(newValue));
@@ -279,6 +285,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     gridSize.set(scene.getGridSize());
     preventNormalEmitterWithSampling.setSelected(scene.isPreventNormalEmitterWithSampling());
     animationTime.set(scene.getAnimationTime());
+    hideUnknownBlocks.setSelected((scene.getHideUnknownBlocks()));
     rendererSelect.getSelectionModel().select(scene.getRenderer());
     previewSelect.getSelectionModel().select(scene.getPreviewRenderer());
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -285,7 +285,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     gridSize.set(scene.getGridSize());
     preventNormalEmitterWithSampling.setSelected(scene.isPreventNormalEmitterWithSampling());
     animationTime.set(scene.getAnimationTime());
-    hideUnknownBlocks.setSelected((scene.getHideUnknownBlocks()));
+    hideUnknownBlocks.setSelected(scene.getHideUnknownBlocks());
     rendererSelect.getSelectionModel().select(scene.getRenderer());
     previewSelect.getSelectionModel().select(scene.getPreviewRenderer());
   }

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -29,6 +29,7 @@
       <Label text="Output mode:" />
       <ChoiceBox fx:id="outputMode" prefWidth="150.0" />
     </HBox>
+    <CheckBox fx:id="hideUnknownBlocks" mnemonicParsing="false" text="Hide unknown blocks" />
     <Separator prefWidth="200.0" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Octree implementation:" />


### PR DESCRIPTION
Closes #1302 

This PR hides unknown blocks at intersection time. We could also hide them while creating the octree (ie. in `BlockSpec.toBlock()` but that would require access to the scene, which we don't have there yet.