### PR TITLE
Fix Export ZIP and Export PNG tooltips

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -556,7 +556,7 @@ public class ChunkyFxController
       }
     });
 
-    exportZipBtn.setTooltip(new Tooltip("Exports the current map view (not the selected chunks) as a PNG file."));
+    renderPngBtn.setTooltip(new Tooltip("Exports the current map view (not the selected chunks) as a PNG file."));
     renderPngBtn.setGraphic(new ImageView(Icon.save.fxImage()));
     renderPngBtn.setOnAction(e -> {
       FileChooser fileChooser = new FileChooser();


### PR DESCRIPTION
Fixed an issue where the Export ZIP had an incorrect tooltip and the Export PNG had no tooltip.