### PR TITLE
Update procedural water defaults

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SimplexWaterShader.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SimplexWaterShader.java
@@ -32,8 +32,8 @@ public class SimplexWaterShader implements WaterShader {
    */
 
   public int iterations = 4; /// Number of iteration of the fractal noise
-  public double baseFrequency = 0.1; /// frequency of the first iteration, doubles each iteration
-  public double baseAmplitude = 0.2; /// amplitude of the first iteration, halves each iteration
+  public double baseFrequency = 0.4; /// frequency of the first iteration, doubles each iteration
+  public double baseAmplitude = 0.025; /// amplitude of the first iteration, halves each iteration
   public double animationSpeed = 1; /// animation speed
   private final SimplexNoise noise = new SimplexNoise();
 


### PR DESCRIPTION
Not using procedural water makes water tiling evident over large distances. Enabling procedural water fixes that issue, but not many people may understand what the controls do and may leave them at their default values. Procedural water at its default values does not look very realistic, and on the example scene, also causes a large perfromance drop. The new defaults look much more like the old "Fast" water does, but without the tiling. Additionally, on the example scene, the new default values outperformed the "Fast" water.

**Default procedural water settings: 168190 SPS.**
![Default_procwater_values-32 (168190 SPS)](https://user-images.githubusercontent.com/92183530/177585135-722e7a6d-1d8f-40b7-844e-db47487479f4.png)

**New default procedural water settings: 436860 SPS.**
![New-32 (436860 SPS)](https://user-images.githubusercontent.com/92183530/177585223-5adea056-b61c-412b-8877-f807d3259133.png)

**"Fast" water: 432483 SPS.**
![Fast-32 (432483 SPS)](https://user-images.githubusercontent.com/92183530/177585032-b0f6b62b-0ec9-4203-91be-6b9e29b71780.png)
