### PR TITLE
Fix incorrect biomes in some worlds

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1010,13 +1010,25 @@ public class Scene implements JsonSerializable, Refreshable {
         int wx0 = cp.x * 16; // Start of this chunk in world coordinates.
         int wz0 = cp.z * 16;
         BiomeData biomeData = chunkData.getBiomeData();
-        for (int y = chunkData.minY(); y < chunkData.maxY(); y++) {
+
+        if (use3dBiomes) {
+          for (int y = chunkData.minY(); y < chunkData.maxY(); y++) {
+            for (int cz = 0; cz < 16; ++cz) {
+              int wz = cz + wz0;
+              for (int cx = 0; cx < 16; ++cx) {
+                int wx = cx + wx0;
+                int biomePaletteIdx = biomeData.getBiome(cx, y, cz);
+                biomePaletteIdxStructure.set(wx, y, wz, biomePaletteIdx);
+              }
+            }
+          }
+        } else {
           for (int cz = 0; cz < 16; ++cz) {
             int wz = cz + wz0;
             for (int cx = 0; cx < 16; ++cx) {
               int wx = cx + wx0;
-              int biomePaletteIdx = biomeData.getBiome(cx, y, cz);
-              biomePaletteIdxStructure.set(wx, y, wz, biomePaletteIdx);
+              int biomePaletteIdx = biomeData.getBiome(cx, chunkData.minY(), cz); // TODO: add an option to set the biome sample height?
+              biomePaletteIdxStructure.set(wx, chunkData.minY(), wz, biomePaletteIdx);
             }
           }
         }

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -428,6 +428,7 @@ public class Chunk {
     request.add(LEVEL_SECTIONS);
     request.add(SECTIONS_POST_21W39A);
     request.add(LEVEL_BIOMES);
+    request.add(BIOMES_POST_21W39A);
     request.add(LEVEL_ENTITIES);
     request.add(LEVEL_TILEENTITIES);
     request.add(BLOCK_ENTITIES_POST_21W43A);


### PR DESCRIPTION
Closes #1343 

We were previously assuming the biomeIdxStructure was always compatible with 3d coordinates, which isn't true

I'll make a PR to clean up the biome palette stuff soon (@leMaik suggested something which I've yet to implement), but wanted to get it fixed straight away