### PR TITLE
Update singleColorBtn name.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFxController.java
@@ -631,7 +631,8 @@ public class ChunkyFxController
       launcherSettings.save();
     });
 
-    singleColorBtn.setSelected(PersistentSettings.getSingleColorTextures());
+    singleColorBtn.setTooltip(new Tooltip("Set block textures to a single color which is the average of all color values of its current texture."))
+	singleColorBtn.setSelected(PersistentSettings.getSingleColorTextures());
     singleColorBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
       PersistentSettings.setSingleColorTextures(newValue);
     });

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -165,7 +165,7 @@
           </padding>
           <Button fx:id="editResourcePacks" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Edit resource packs"/>
           <CheckBox fx:id="disableDefaultTexturesBtn" mnemonicParsing="false" text="Disable default textures (needs restart)"/>
-          <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures (needs restart)"/>
+          <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures"/>
           <CheckBox fx:id="showLauncherBtn" mnemonicParsing="false" text="Show launcher when starting Chunky"/>
           <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open Scenes Directory"/>
           <Button fx:id="changeSceneDirBtn" mnemonicParsing="false" text="Change Scenes Directory"/>


### PR DESCRIPTION
The name was inaccurate, as using this option does not actually require a restart.

Added a tooltip to the control.