### PR TITLE
Update Disable default textures control

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -325,7 +325,7 @@ public class ResourcePackChooserController implements Initializable {
 
     Icons.buildIcon(Icons.HEAVY_PLUS).withSize(14).setAsGraphicOn(addNewTargetPackBtn);
     addNewTargetPackBtn.setOnAction(evt -> browseForUnlistedPack());
-    disableDefaultTexturesBtn.setTooltip(new Tooltip("Disable loading of textures from Minecraft and revert to internal textures and any loaded resource packs. \nRequires restart for changes to take effect."));
+    disableDefaultTexturesBtn.setTooltip(new Tooltip("Disable loading of textures from Minecraft and revert to internal textures and any loaded resource packs.\nRequires restart for changes to take effect."));
     disableDefaultTexturesBtn.setSelected(PersistentSettings.getDisableDefaultTextures());
     disableDefaultTexturesBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
       PersistentSettings.setDisableDefaultTextures(newValue);

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -29,16 +29,10 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.geometry.HPos;
 import javafx.scene.Node;
+import javafx.scene.control.*;
 import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
@@ -331,6 +325,7 @@ public class ResourcePackChooserController implements Initializable {
 
     Icons.buildIcon(Icons.HEAVY_PLUS).withSize(14).setAsGraphicOn(addNewTargetPackBtn);
     addNewTargetPackBtn.setOnAction(evt -> browseForUnlistedPack());
+    disableDefaultTexturesBtn.setTooltip(new Tooltip("Disable loading of textures from Minecraft and revert to internal textures and any loaded resource packs. \nRequires restart for changes to take effect."));
     disableDefaultTexturesBtn.setSelected(PersistentSettings.getDisableDefaultTextures());
     disableDefaultTexturesBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
       PersistentSettings.setDisableDefaultTextures(newValue);

--- a/chunky/src/res/se/llbit/chunky/ui/dialogs/ResourcePackChooser.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/dialogs/ResourcePackChooser.fxml
@@ -58,7 +58,7 @@
         <Tooltip text="Browse for a resource pack from outside the default resource pack folder and add it to the selected resource packs list" />
       </tooltip>
     </Button>
-    <CheckBox fx:id="disableDefaultTexturesBtn" mnemonicParsing="false" text="Disable default textures"/>
+    <CheckBox fx:id="disableDefaultTexturesBtn" mnemonicParsing="false" text="Disable default textures (requires restart)"/>
     <Pane HBox.hgrow="ALWAYS" />
     <Button fx:id="cancelBtn" cancelButton="true" mnemonicParsing="false" text="Cancel" />
     <Button fx:id="applyAsDefaultBtn" defaultButton="true" mnemonicParsing="false" text="Apply as default" />


### PR DESCRIPTION
The control had no indication of a required restart, and provided no further information of what its functionality is.

- Updated the control name to indicate a required restart.
- Added a tooltip to the control to indicate its functionality.