### PR TITLE
Remove outdated "Move Camera to Player" button in CameraTab

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1759,17 +1759,6 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * Move the camera to the player position, if available.
-   */
-  public void moveCameraToPlayer() {
-    for (Entity entity : actors) {
-      if (entity instanceof PlayerEntity) {
-        camera.moveToPlayer((PlayerEntity) entity);
-      }
-    }
-  }
-
-  /**
    * @return <code>true</code> if still water is enabled
    */
   public boolean stillWaterEnabled() {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
@@ -70,7 +70,6 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
   @FXML private DoubleTextField yawField;
   @FXML private DoubleTextField pitchField;
   @FXML private DoubleTextField rollField;
-  @FXML private Button cameraToPlayer;
   @FXML private Button centerCamera;
   @FXML private ChoiceBox<ProjectionMode> projectionMode;
   @FXML private DoubleAdjuster fov;
@@ -243,13 +242,6 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     rollField.setTooltip(new Tooltip("Camera roll."));
     rollField.addEventFilter(KeyEvent.KEY_PRESSED, directionHandler);
 
-    cameraToPlayer.setTooltip(new Tooltip("Move camera to the player position."));
-    cameraToPlayer.setOnAction(e -> {
-      scene.moveCameraToPlayer();
-      updateCameraPosition();
-    });
-
-    centerCamera.setTooltip(new Tooltip("Center camera above loaded chunks."));
     centerCamera.setOnAction(e -> {
       scene.moveCameraToCenter();
       updateCameraPosition();

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
@@ -242,6 +242,7 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     rollField.setTooltip(new Tooltip("Camera roll."));
     rollField.addEventFilter(KeyEvent.KEY_PRESSED, directionHandler);
 
+    centerCamera.setTooltip(new Tooltip("Center camera above loaded chunks."));
     centerCamera.setOnAction(e -> {
       scene.moveCameraToCenter();
       updateCameraPosition();

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
@@ -55,7 +55,6 @@
       </GridPane>
     </TitledPane>
     <HBox alignment="CENTER_LEFT" layoutX="20.0" layoutY="56.0" prefWidth="200.0" spacing="10.0">
-      <Button fx:id="cameraToPlayer" mnemonicParsing="false" text="Camera to player" />
       <Button fx:id="centerCamera" mnemonicParsing="false" text="Center camera" />
     </HBox>
     <Separator prefWidth="200.0" />


### PR DESCRIPTION
The underlying feature does not work as expected* and can also be accessed in EntitiesTab via "Camera to Entity".

* Code assumes that only one player exists in the scene, otherwise it uses the last loaded one - since we are able to load all players in a world, this is not what the user wants to do in most cases.