### PR TITLE
Add more labels to camera controls

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
+++ b/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
@@ -1,0 +1,110 @@
+/* Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.ui.elements;
+
+import javafx.beans.DefaultProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.AccessibleRole;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+
+@DefaultProperty("textField")
+public class TextFieldLabelWrapper extends StackPane {
+
+  private final StringProperty labelTextProperty = new SimpleStringProperty();
+  private final Label labelNode = new Label();
+
+  private final ObjectProperty<TextField> textFieldProperty = new SimpleObjectProperty<>();
+
+  private boolean requirePaddingUpdate = false;
+  private Insets defaultPadding = new Insets(4, 6, 4, 6);
+
+  protected TextField defaultTextField() {
+    return new TextField();
+  }
+
+  public TextFieldLabelWrapper() {
+    this.getStyleClass().add("text-field-label-wrapper");
+
+    labelNode.textProperty().bind(labelTextProperty);
+    labelTextProperty.addListener(unused -> requirePaddingUpdate = true);
+    labelNode.setTranslateX(5);
+    labelNode.setPadding(new Insets(0, 1, 0, 1));
+    labelNode.setMouseTransparent(true);
+    getChildren().add(labelNode);
+
+    setAlignment(Pos.BASELINE_LEFT);
+    setAccessibleRole(AccessibleRole.TEXT_FIELD);
+    setTextField(null);
+  }
+
+  public void setTextField(TextField textField) {
+    if (textField == null) {
+      textField = defaultTextField();
+    }
+    getChildren().remove(textFieldProperty.get());
+
+    textFieldProperty.set(textField);
+    labelNode.setLabelFor(textField);
+
+    getChildren().add(0, textField);
+  }
+
+  @Override
+  protected void layoutChildren() {
+    super.layoutChildren();
+    if (requirePaddingUpdate) {
+      updateTextFieldPadding();
+    }
+  }
+
+  private void updateTextFieldPadding() {
+    TextField textField = textFieldProperty.get();
+    if (defaultPadding == null) {
+      defaultPadding = textField.getPadding();
+    }
+    textField.setPadding(new Insets(
+      defaultPadding.getTop(),
+      defaultPadding.getRight(),
+      defaultPadding.getBottom(),
+      defaultPadding.getLeft() + labelNode.getLayoutBounds().getWidth()
+    ));
+    requirePaddingUpdate = false;
+  }
+
+  public TextField getTextField() {
+    return textFieldProperty.get();
+  }
+
+  public void setLabelText(String labelText) {
+    labelTextProperty.set(labelText);
+  }
+
+  public String getLabelText() {
+    return labelTextProperty.get();
+  }
+
+  public Label getLabelNode() {
+    return labelNode;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2016-2020 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2020-2022 Chunky contributors
  *
  * This file is part of Chunky.
  *

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
@@ -220,11 +220,8 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
       }
     };
     posX.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
-    posX.setTooltip(new Tooltip("Camera X (East/West) coordinate."));
     posY.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
-    posY.setTooltip(new Tooltip("Camera Y (Up/Down) coordinate."));
     posZ.addEventFilter(KeyEvent.KEY_PRESSED, positionHandler);
-    posZ.setTooltip(new Tooltip("Camera Z (South/North) coordinate."));
 
     EventHandler<KeyEvent> directionHandler = e -> {
       if (e.getCode() == KeyCode.ENTER) {
@@ -235,14 +232,10 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
                 QuickMath.degToRad(rollField.valueProperty().get()));
       }
     };
-    yawField.setTooltip(new Tooltip("Camera yaw."));
     yawField.addEventFilter(KeyEvent.KEY_PRESSED, directionHandler);
-    pitchField.setTooltip(new Tooltip("Camera pitch."));
     pitchField.addEventFilter(KeyEvent.KEY_PRESSED, directionHandler);
-    rollField.setTooltip(new Tooltip("Camera roll."));
     rollField.addEventFilter(KeyEvent.KEY_PRESSED, directionHandler);
 
-    centerCamera.setTooltip(new Tooltip("Center camera above loaded chunks."));
     centerCamera.setOnAction(e -> {
       scene.moveCameraToCenter();
       updateCameraPosition();
@@ -285,9 +278,6 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
       updateSubjectDistance();
     });
 
-    shiftX.setTooltip(new Tooltip("Horizontal lens shift (relative to the image height)."));
-    shiftY.setTooltip(new Tooltip("Vertical lens shift (relative to the image height)."));
-
     EventHandler<KeyEvent> shiftHandler = e -> {
       if (e.getCode() == KeyCode.ENTER) {
         scene.camera().setShift(shiftX.valueProperty().get(), shiftY.valueProperty().get());
@@ -295,7 +285,6 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     };
     shiftX.addEventFilter(KeyEvent.KEY_PRESSED, shiftHandler);
     shiftY.addEventFilter(KeyEvent.KEY_PRESSED, shiftHandler);
-
 
     apertureShape.setTooltip(new Tooltip("Change the shape of the aperture of the virtual camera."));
     apertureShape.getItems().addAll(ApertureShape.values());

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
@@ -18,6 +18,8 @@
 <?import se.llbit.chunky.ui.DoubleTextField?>
 
 <?import javafx.scene.control.Tooltip?>
+<?import se.llbit.chunky.ui.elements.TextFieldLabelWrapper?>
+<?import javafx.scene.control.TextField?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
@@ -41,55 +43,74 @@
           <RowConstraints vgrow="SOMETIMES" />
         </rowConstraints>
 
-        <Label text="x (East/West)" GridPane.rowIndex="0" GridPane.columnIndex="1" />
-        <Label text="y (Up/Down)" GridPane.rowIndex="0" GridPane.columnIndex="2" />
-        <Label text="z (South/North)" GridPane.rowIndex="0" GridPane.columnIndex="3" />
+        <Label text="Position:" GridPane.rowIndex="0" />
+        <TextFieldLabelWrapper labelText="x:" GridPane.rowIndex="0" GridPane.columnIndex="1">
+          <DoubleTextField fx:id="posX">
+            <tooltip>
+              <Tooltip text="Camera x (east/west) coordinate" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
+        <TextFieldLabelWrapper labelText="y:" GridPane.rowIndex="0" GridPane.columnIndex="2">
+          <DoubleTextField fx:id="posY">
+            <tooltip>
+              <Tooltip text="Camera y (up/down) coordinate" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
+        <TextFieldLabelWrapper labelText="z:" GridPane.rowIndex="0" GridPane.columnIndex="3">
+          <DoubleTextField fx:id="posZ">
+            <tooltip>
+              <Tooltip text="Camera z (south/north) coordinate" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
 
-        <Label text="Position:" GridPane.rowIndex="1" />
-        <DoubleTextField fx:id="posX" GridPane.rowIndex="1" GridPane.columnIndex="1" />
-        <DoubleTextField fx:id="posY" GridPane.rowIndex="1" GridPane.columnIndex="2" />
-        <DoubleTextField fx:id="posZ" GridPane.rowIndex="1" GridPane.columnIndex="3" />
+        <Button fx:id="centerCamera" mnemonicParsing="false" text="Center camera above loaded chunks"
+                GridPane.rowIndex="1" GridPane.columnIndex="1" GridPane.columnSpan="3" />
 
-        <Button fx:id="centerCamera" mnemonicParsing="false" text="Center camera above loaded chunks" GridPane.rowIndex="2" GridPane.columnIndex="1" GridPane.columnSpan="3"/>
-        <Separator GridPane.rowIndex="3" GridPane.columnSpan="4" />
+        <Separator GridPane.rowIndex="2" GridPane.columnSpan="4" />
 
-        <Label text="yaw" GridPane.rowIndex="4" GridPane.columnIndex="1" />
-        <Label text="pitch" GridPane.rowIndex="4" GridPane.columnIndex="2" />
-        <Label text="roll" GridPane.rowIndex="4" GridPane.columnIndex="3" />
+        <Label text="Orientation:" GridPane.rowIndex="3" />
+        <TextFieldLabelWrapper labelText="yaw:" GridPane.rowIndex="3" GridPane.columnIndex="1">
+          <DoubleTextField fx:id="yawField">
+            <tooltip>
+              <Tooltip text="Rotation around the camera's downwards facing axis" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
+        <TextFieldLabelWrapper labelText="pitch:" GridPane.rowIndex="3" GridPane.columnIndex="2">
+          <DoubleTextField fx:id="pitchField">
+            <tooltip>
+              <Tooltip text="Rotation around the camera's right facing axis" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
+        <TextFieldLabelWrapper labelText="roll:" GridPane.rowIndex="3" GridPane.columnIndex="3">
+          <DoubleTextField fx:id="rollField">
+            <tooltip>
+              <Tooltip text="Rotation around the camera's forward facing axis" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
 
-        <Label text="Orientation:" GridPane.rowIndex="5" />
-        <DoubleTextField fx:id="yawField" GridPane.rowIndex="5" GridPane.columnIndex="1">
-          <tooltip>
-            <Tooltip text="Rotation around the camera's downwards facing axis" />
-          </tooltip>
-        </DoubleTextField>
-        <DoubleTextField fx:id="pitchField" GridPane.rowIndex="5" GridPane.columnIndex="2">
-          <tooltip>
-            <Tooltip text="Rotation around the camera's right facing axis" />
-          </tooltip>
-        </DoubleTextField>
-        <DoubleTextField fx:id="rollField" GridPane.rowIndex="5" GridPane.columnIndex="3">
-          <tooltip>
-            <Tooltip text="Rotation around the camera's forward facing axis" />
-          </tooltip>
-        </DoubleTextField>
+        <Separator GridPane.rowIndex="4" GridPane.columnSpan="4" />
 
-        <Separator GridPane.rowIndex="6" GridPane.columnSpan="4" />
-        
-        <Label text="horizontal" GridPane.rowIndex="7" GridPane.columnIndex="1" />
-        <Label text="vertical" GridPane.rowIndex="7" GridPane.columnIndex="2" />
-
-        <Label text="Lens shift:" GridPane.rowIndex="8" />
-        <DoubleTextField fx:id="shiftX" GridPane.rowIndex="8" GridPane.columnIndex="1">
-          <tooltip>
-            <Tooltip text="Horizontal lens shift (relative to the image height)" />
-          </tooltip>
-        </DoubleTextField>
-        <DoubleTextField fx:id="shiftY" GridPane.rowIndex="8" GridPane.columnIndex="2">
-          <tooltip>
-            <Tooltip text="Vertical lens shift (relative to the image height)" />
-          </tooltip>
-        </DoubleTextField>
+        <Label text="Lens shift:" GridPane.rowIndex="5" />
+        <TextFieldLabelWrapper labelText="x:" GridPane.rowIndex="5" GridPane.columnIndex="1">
+          <DoubleTextField fx:id="shiftX">
+            <tooltip>
+              <Tooltip text="Horizontal lens shift (relative to the image height)" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
+        <TextFieldLabelWrapper labelText="y:" GridPane.rowIndex="5" GridPane.columnIndex="2">
+          <DoubleTextField fx:id="shiftY">
+            <tooltip>
+              <Tooltip text="Vertical lens shift (relative to the image height)" />
+            </tooltip>
+          </DoubleTextField>
+        </TextFieldLabelWrapper>
       </GridPane>
     </TitledPane>
     <Separator prefWidth="200.0" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
@@ -17,6 +17,7 @@
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
 <?import se.llbit.chunky.ui.DoubleTextField?>
 
+<?import javafx.scene.control.Tooltip?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
@@ -29,34 +30,68 @@
       <Button fx:id="removeCamera" mnemonicParsing="false" text="Remove" />
     </HBox>
     <TitledPane fx:id="positionOrientation" animated="false" expanded="false" text="Position &amp; Orientation">
-      <GridPane hgap="10.0" vgap="10.0">
+      <GridPane hgap="6.0" vgap="10.0">
         <columnConstraints>
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-          <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+          <ColumnConstraints hgrow="NEVER" prefWidth="70.0" />
+          <ColumnConstraints minWidth="20.0" prefWidth="90.0" />
+          <ColumnConstraints minWidth="20.0" prefWidth="90.0" />
+          <ColumnConstraints minWidth="20.0" prefWidth="90.0" />
         </columnConstraints>
         <rowConstraints>
           <RowConstraints vgrow="SOMETIMES" />
-          <RowConstraints vgrow="SOMETIMES" />
-          <RowConstraints vgrow="SOMETIMES" />
         </rowConstraints>
-        <Label text="Orientation:" GridPane.rowIndex="1" />
-        <DoubleTextField fx:id="yawField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-        <DoubleTextField fx:id="pitchField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="1" />
-        <DoubleTextField fx:id="rollField" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" GridPane.rowIndex="1" />
-        <Label text="Position:" />
-        <DoubleTextField fx:id="posX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" />
-        <DoubleTextField fx:id="posY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" />
-        <DoubleTextField fx:id="posZ" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="3" />
-        <Label text="Lens shift:" GridPane.rowIndex="2" />
-        <DoubleTextField fx:id="shiftX" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-        <DoubleTextField fx:id="shiftY" prefHeight="26.0" prefWidth="86.0" GridPane.columnIndex="2" GridPane.rowIndex="2" />
+
+        <Label text="x (East/West)" GridPane.rowIndex="0" GridPane.columnIndex="1" />
+        <Label text="y (Up/Down)" GridPane.rowIndex="0" GridPane.columnIndex="2" />
+        <Label text="z (South/North)" GridPane.rowIndex="0" GridPane.columnIndex="3" />
+
+        <Label text="Position:" GridPane.rowIndex="1" />
+        <DoubleTextField fx:id="posX" GridPane.rowIndex="1" GridPane.columnIndex="1" />
+        <DoubleTextField fx:id="posY" GridPane.rowIndex="1" GridPane.columnIndex="2" />
+        <DoubleTextField fx:id="posZ" GridPane.rowIndex="1" GridPane.columnIndex="3" />
+
+        <Button fx:id="centerCamera" mnemonicParsing="false" text="Center camera above loaded chunks" GridPane.rowIndex="2" GridPane.columnIndex="1" GridPane.columnSpan="3"/>
+        <Separator GridPane.rowIndex="3" GridPane.columnSpan="4" />
+
+        <Label text="yaw" GridPane.rowIndex="4" GridPane.columnIndex="1" />
+        <Label text="pitch" GridPane.rowIndex="4" GridPane.columnIndex="2" />
+        <Label text="roll" GridPane.rowIndex="4" GridPane.columnIndex="3" />
+
+        <Label text="Orientation:" GridPane.rowIndex="5" />
+        <DoubleTextField fx:id="yawField" GridPane.rowIndex="5" GridPane.columnIndex="1">
+          <tooltip>
+            <Tooltip text="Rotation around the camera's downwards facing axis" />
+          </tooltip>
+        </DoubleTextField>
+        <DoubleTextField fx:id="pitchField" GridPane.rowIndex="5" GridPane.columnIndex="2">
+          <tooltip>
+            <Tooltip text="Rotation around the camera's right facing axis" />
+          </tooltip>
+        </DoubleTextField>
+        <DoubleTextField fx:id="rollField" GridPane.rowIndex="5" GridPane.columnIndex="3">
+          <tooltip>
+            <Tooltip text="Rotation around the camera's forward facing axis" />
+          </tooltip>
+        </DoubleTextField>
+
+        <Separator GridPane.rowIndex="6" GridPane.columnSpan="4" />
+        
+        <Label text="horizontal" GridPane.rowIndex="7" GridPane.columnIndex="1" />
+        <Label text="vertical" GridPane.rowIndex="7" GridPane.columnIndex="2" />
+
+        <Label text="Lens shift:" GridPane.rowIndex="8" />
+        <DoubleTextField fx:id="shiftX" GridPane.rowIndex="8" GridPane.columnIndex="1">
+          <tooltip>
+            <Tooltip text="Horizontal lens shift (relative to the image height)" />
+          </tooltip>
+        </DoubleTextField>
+        <DoubleTextField fx:id="shiftY" GridPane.rowIndex="8" GridPane.columnIndex="2">
+          <tooltip>
+            <Tooltip text="Vertical lens shift (relative to the image height)" />
+          </tooltip>
+        </DoubleTextField>
       </GridPane>
     </TitledPane>
-    <HBox alignment="CENTER_LEFT" layoutX="20.0" layoutY="56.0" prefWidth="200.0" spacing="10.0">
-      <Button fx:id="centerCamera" mnemonicParsing="false" text="Center camera" />
-    </HBox>
     <Separator prefWidth="200.0" />
     <HBox alignment="CENTER_LEFT" layoutX="20.0" layoutY="20.0" prefWidth="200.0" spacing="10.0">
       <Label text="Projection mode:" />

--- a/chunky/src/res/style.css
+++ b/chunky/src/res/style.css
@@ -59,6 +59,13 @@ Hyperlink:hover {
     -fx-focus-color: #FF434A;
 }
 
+.text-field-label-wrapper > .label {
+    -fx-text-fill: gray;
+}
+.text-field-label-wrapper > .text-field {
+    -fx-alignment: baseline-right;
+}
+
 .menu-item:disabled:focused {
     -fx-background: unset;
     -fx-background-color: transparent;


### PR DESCRIPTION
- Have labels for each input field:
![image](https://user-images.githubusercontent.com/16897056/178125171-96a77edb-707d-4b47-97f6-9a004518c1a4.png)
  Previous:
![image](https://user-images.githubusercontent.com/16897056/178125181-038a5d66-f5f1-4315-804d-f58c2793cd47.png)

- Moved the "center camera" (above loaded chunks) button to the camera coordinate input.
- Also rewritten some of the tooltips and removed self-explanatory ones.

This PR is based on top of #1350 