### PR TITLE
Throw exception when failing to load a chunk, allowing it to be safely skipped

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/ChunkLoadingException.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/ChunkLoadingException.java
@@ -1,6 +1,6 @@
 package se.llbit.chunky.chunk;
 
-public class ChunkLoadingException extends RuntimeException {
+public class ChunkLoadingException extends Exception {
   public ChunkLoadingException(String message) {
     super(message);
   }

--- a/chunky/src/java/se/llbit/chunky/chunk/ChunkLoadingException.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/ChunkLoadingException.java
@@ -1,0 +1,10 @@
+package se.llbit.chunky.chunk;
+
+public class ChunkLoadingException extends RuntimeException {
+  public ChunkLoadingException(String message) {
+    super(message);
+  }
+  public ChunkLoadingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -959,6 +959,7 @@ public class Scene implements JsonSerializable, Refreshable {
       ExecutorService executor = Executors.newSingleThreadExecutor();
       Future<?> nextChunkDataTask = executor.submit(() -> { //Initialise first chunk data for the for loop
         world.getChunk(chunkPositions[0]).getChunkData(loadingChunkData, palette, biomePalette, yMin, yMax);
+        return null; // runnable can't throw non-RuntimeExceptions, so we use a callable instead and have to return something
       });
       for (int i = 0; i < chunkPositions.length; i++) {
         ChunkPosition cp = chunkPositions[i];
@@ -990,6 +991,7 @@ public class Scene implements JsonSerializable, Refreshable {
             final int finalI = i;
             nextChunkDataTask = executor.submit(() -> { //request chunk data for the next iteration of the loop
               world.getChunk(chunkPositions[finalI + 1]).getChunkData(loadingChunkData, palette, biomePalette, yMin, yMax);
+              return null; // runnable can't throw non-RuntimeExceptions, so we use a callable instead and have to return something
             });
           }
         }

--- a/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
+import se.llbit.chunky.chunk.ChunkLoadingException;
 import se.llbit.chunky.world.*;
 import se.llbit.log.Log;
 import se.llbit.nbt.ErrorTag;
@@ -130,7 +131,7 @@ public class MCRegion implements Region {
     try (RandomAccessFile file = new RandomAccessFile(regionFile, "r")) {
       long length = file.length();
       if (length < 2 * SECTOR_SIZE) {
-        Log.warn("Missing header in region file!");
+        Log.warnf("Missing header in region file %s!", this.position);
         return;
       }
 
@@ -183,7 +184,7 @@ public class MCRegion implements Region {
     return String.format("r.%d.%d.mca", pos.x, pos.z);
   }
 
-  public Map<String, Tag> getChunkTags(ChunkPosition position, Set<String> request, Mutable<Integer> dataTimestamp) {
+  public Map<String, Tag> getChunkTags(ChunkPosition position, Set<String> request, Mutable<Integer> dataTimestamp) throws ChunkLoadingException {
     ChunkDataSource data = this.getChunkData(position);
     dataTimestamp.set(data.timestamp);
     if (data.inputStream != null) {
@@ -196,7 +197,7 @@ public class MCRegion implements Region {
         }
         return result;
       } catch (IOException e) {
-        // Ignored.
+        throw new ChunkLoadingException(String.format("Failed to read chunk %s from region file!", position), e);
       }
     }
     return null;


### PR DESCRIPTION
The user is also warned about chunks being skipped in both map view loading, and in octree loading.