### PR TITLE
Update entity and camera location controls

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
@@ -128,11 +128,11 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML
   private Button add;
   @FXML
-  private Button cameraToPlayer;
+  private Button cameraToEntity;
   @FXML
-  private Button playerToCamera;
+  private Button entityToCamera;
   @FXML
-  private Button playerToTarget;
+  private Button entityToTarget;
   @FXML
   private Button faceCamera;
   @FXML
@@ -583,15 +583,15 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       });
       return row;
     });*/
-    cameraToPlayer.setTooltip(new Tooltip("Move the camera to the selected player position."));
-    cameraToPlayer.setOnAction(e -> withEntity(player -> scene.camera().moveToPlayer(player)));
-    playerToCamera.setTooltip(new Tooltip("Move the selected player to the camera position."));
-    playerToCamera.setOnAction(e -> withEntity(entity -> {
+    cameraToEntity.setTooltip(new Tooltip("Move the camera to the location of the selected entity."));
+    cameraToEntity.setOnAction(e -> withEntity(player -> scene.camera().moveToPlayer(player)));
+    entityToCamera.setTooltip(new Tooltip("Move the selected entity to the location of the camera."));
+    entityToCamera.setOnAction(e -> withEntity(entity -> {
       entity.setPosition(scene.camera().getPosition());
       scene.rebuildActorBvh();
     }));
-    playerToTarget.setTooltip(new Tooltip("Move the selected player to the current target."));
-    playerToTarget.setOnAction(e -> withEntity(player -> {
+    entityToTarget.setTooltip(new Tooltip("Move the selected entity to the current target."));
+    entityToTarget.setOnAction(e -> withEntity(player -> {
       Vector3 target = scene.getTargetPosition();
       if (target != null) {
         player.position.set(target);

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/EntitiesTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/EntitiesTab.fxml
@@ -24,9 +24,9 @@
       <Button fx:id="add" mnemonicParsing="false" text="+" />
     </HBox>
     <HBox spacing="10.0">
-      <Button fx:id="cameraToPlayer" mnemonicParsing="false" text="Camera to entity" />
-      <Button fx:id="playerToCamera" mnemonicParsing="false" text="Player to camera" />
-      <Button fx:id="playerToTarget" mnemonicParsing="false" text="Entity to target" />
+      <Button fx:id="cameraToEntity" mnemonicParsing="false" text="Camera to entity" />
+      <Button fx:id="entityToCamera" mnemonicParsing="false" text="Entity to camera" />
+      <Button fx:id="entityToTarget" mnemonicParsing="false" text="Entity to target" />
     </HBox>
     <HBox spacing="10.0">
       <Button fx:id="faceCamera" mnemonicParsing="false" text="Face camera" />


### PR DESCRIPTION
Since the entity location controls in the `Entities` tab apply not only to players, but also to other entities, the names and tooltips of the pertaining controls have been updated to show this information.