### PR TITLE
Separate Lectern and Book to match enchantment tables and its book

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -13,6 +13,7 @@ import se.llbit.math.Vector3;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
 
+import java.util.Collection;
 import java.util.Random;
 
 public abstract class Block extends Material {
@@ -121,7 +122,7 @@ public abstract class Block extends Material {
     return false;
   }
 
-  public Entity toEntity(Vector3 position) {
+  public Collection<Entity> toEntity(Vector3 position) {
     throw new Error("This block type can not be converted to an entity: "
       + getClass().getSimpleName());
   }

--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -105,7 +105,7 @@ public abstract class Block extends Material {
   }
 
   public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
-    throw new Error("This block type can not be converted to a block entity: "
+    throw new UnsupportedOperationException("This block type can not be converted to a block entity: "
       + getClass().getSimpleName());
   }
 
@@ -123,7 +123,7 @@ public abstract class Block extends Material {
   }
 
   public Collection<Entity> toEntity(Vector3 position) {
-    throw new Error("This block type can not be converted to an entity: "
+    throw new UnsupportedOperationException("This block type can not be converted to an entity: "
       + getClass().getSimpleName());
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -100,31 +100,66 @@ public abstract class Block extends Material {
     return name;
   }
 
+  /**
+   * Check if this block is a block entity, i.e. {@link #createBlockEntity(Vector3, CompoundTag)} should be invoked to
+   * create an entity from this block and its entity data tag. This is used for blocks that need to create a new entity
+   * that needs the block entity data, e.g. signs.
+   * <p>
+   * This is mutually exclusive with {@link #hasEntities()}, use that one if you don't need block entity data.
+   *
+   * @return True if this block is a block entity, false otherwise
+   */
   public boolean isBlockEntity() {
     return false;
   }
 
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  /**
+   * Create a block entity from this block and the given block entity tag at the specified position.
+   *
+   * @param position  Position
+   * @param entityTag Block entity tag
+   * @return The block entity created from this block's data and the entity tag
+   * @throws UnsupportedOperationException If this block is not a block entity (i.e. {@link #isBlockEntity()} returns false
+   */
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     throw new UnsupportedOperationException("This block type can not be converted to a block entity: "
       + getClass().getSimpleName());
   }
 
-  public boolean isEntity() {
+  /**
+   * Check if this block has entities, i.e. {@link #createEntities(Vector3)} should be invoked to create entities from this
+   * block. A block can create multiple entities (e.g. the lectern may create a lectern and a book entity).
+   * <p>
+   * This is mutually exclusive with {@link #isBlockEntity()}, use that one if you need block entity data.
+   *
+   * @return True if this block has entities, false otherwise
+   */
+  public boolean hasEntities() {
     return false;
   }
 
   /**
-   * If this returns true, the block won't be removed from the octree even if this is an entity
-   * (i.e. {@link #isEntity()} returns true). This can be used for blocks that also contain
-   * entities, e.g. candle (where the candle flame is an entity).
+   * Create entities from this block at the specified position.
+   * <p>
+   * This may return multiple entities, e.g. the lectern has a lectern entity and an optional book entity.
+   *
+   * @param position Position
+   * @return The entities created from this block's data
+   * @throws UnsupportedOperationException If this block is not a block entity (i.e. {@link #hasEntities()} returns false
    */
-  public boolean isBlockWithEntity() {
-    return false;
+  public Collection<Entity> createEntities(Vector3 position) {
+    throw new UnsupportedOperationException("This block type can not be converted to entities: "
+      + getClass().getSimpleName());
   }
 
-  public Collection<Entity> toEntity(Vector3 position) {
-    throw new UnsupportedOperationException("This block type can not be converted to an entity: "
-      + getClass().getSimpleName());
+  /**
+   * Whether to remove this block from the octree if it contains entities (i.e. {@link #hasEntities()} returns true).
+   * <p>
+   * Most blocks are replaced by their entities (eg. signs create a sign entity that does the rendering and the block itself
+   * does nothing, but some blocks use block model and entities, e.g. candle (where the candle flame is an entity but the candle is a block).
+   */
+  public boolean isReplacedByEntities() {
+    return true;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyBanner.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyBanner.java
@@ -56,7 +56,7 @@ public class LegacyBanner extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new StandingBanner(position, rotation, parseDesign(entityTag));
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySkull.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacySkull.java
@@ -39,7 +39,7 @@ public class LegacySkull extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     Kind kind = getSkullKind(entityTag.get("SkullType").byteValue(0));
     int rotation = entityTag.get("Rot").byteValue(0);
     if (kind == Kind.PLAYER) {

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyWallBanner.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyWallBanner.java
@@ -32,7 +32,7 @@ public class LegacyWallBanner extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new WallBanner(position, facing, LegacyBanner.parseDesign(entityTag));
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Banner.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Banner.java
@@ -54,7 +54,7 @@ public class Banner extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  @Override public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     JsonObject design = StandingBanner.parseDesign(entityTag);
     design.set("base", Json.of(color.id)); // Base color is not included in the entity tag in Minecraft 1.13+.
     return new StandingBanner(position, rotation, design);

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Beacon.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Beacon.java
@@ -36,8 +36,8 @@ public class Beacon extends AbstractModelBlock {
   }
 
   @Override
-  public boolean isBlockWithEntity() {
-    return true;
+  public boolean isReplacedByEntities() {
+    return false;
   }
 
   @Override
@@ -46,7 +46,7 @@ public class Beacon extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     if (entityTag.get("Levels").intValue(0) > 0) {
       return new BeaconBeam(position);
     }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
@@ -53,17 +53,17 @@ public class CakeWithCandle extends AbstractModelBlock {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return isLit();
   }
 
   @Override
-  public boolean isBlockWithEntity() {
-    return true;
+  public boolean isReplacedByEntities() {
+    return false;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new FlameParticles(position, entity));
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
@@ -64,7 +64,7 @@ public class CakeWithCandle extends AbstractModelBlock {
 
   @Override
   public Collection<Entity> toEntity(Vector3 position) {
-    return Collections.singletonList(new FlameParticles(position, entity));
+    return Collections.singleton(new FlameParticles(position, entity));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CakeWithCandle.java
@@ -25,6 +25,8 @@ import se.llbit.chunky.model.minecraft.CakeWithCandleModel;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Random;
 
 public class CakeWithCandle extends AbstractModelBlock {
@@ -61,8 +63,8 @@ public class CakeWithCandle extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
-    return new FlameParticles(position, entity);
+  public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singletonList(new FlameParticles(position, entity));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CalibratedSculkSensor.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CalibratedSculkSensor.java
@@ -49,17 +49,17 @@ public class CalibratedSculkSensor extends AbstractModelBlock {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return true;
   }
 
   @Override
-  public boolean isBlockWithEntity() {
-    return true;
+  public boolean isReplacedByEntities() {
+    return false;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new CalibratedSculkSensorAmethyst(position, this.facing, isActive(), this));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CalibratedSculkSensor.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CalibratedSculkSensor.java
@@ -25,6 +25,9 @@ import se.llbit.chunky.model.minecraft.CalibratedSculkSensorModel;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class CalibratedSculkSensor extends AbstractModelBlock {
   private final String phase;
   private final String facing;
@@ -56,7 +59,7 @@ public class CalibratedSculkSensor extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
-    return new CalibratedSculkSensorAmethyst(position, this.facing, isActive(), this);
+  public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singleton(new CalibratedSculkSensorAmethyst(position, this.facing, isActive(), this));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Campfire.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Campfire.java
@@ -54,7 +54,7 @@ public class Campfire extends MinecraftBlockTranslucent {
     }
 
     @Override
-    public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+    public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
         return new se.llbit.chunky.entity.Campfire(this.kind, position, this.facing, this.isLit, this);
     }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
@@ -81,17 +81,17 @@ public class Candle extends AbstractModelBlock {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return isLit();
   }
 
   @Override
-  public boolean isBlockWithEntity() {
-    return true;
+  public boolean isReplacedByEntities() {
+    return false;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     if (entity != null) {
       return Collections.singleton(new FlameParticles(position, entity));
     } else {

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
@@ -93,9 +93,9 @@ public class Candle extends AbstractModelBlock {
   @Override
   public Collection<Entity> toEntity(Vector3 position) {
     if (entity != null) {
-      return Collections.singletonList(new FlameParticles(position, entity));
+      return Collections.singleton(new FlameParticles(position, entity));
     } else {
-      return Collections.singletonList(new FlameParticles(position, this, new Vector3[0]));
+      return Collections.singleton(new FlameParticles(position, this, new Vector3[0]));
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Candle.java
@@ -27,6 +27,8 @@ import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.material.TextureMaterial;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Random;
 
 public class Candle extends AbstractModelBlock {
@@ -89,11 +91,11 @@ public class Candle extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
+  public Collection<Entity> toEntity(Vector3 position) {
     if (entity != null) {
-      return new FlameParticles(position, entity);
+      return Collections.singletonList(new FlameParticles(position, entity));
     } else {
-      return new FlameParticles(position, this, new Vector3[0]);
+      return Collections.singletonList(new FlameParticles(position, this, new Vector3[0]));
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CopperGolemStatue.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CopperGolemStatue.java
@@ -9,6 +9,9 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class CopperGolemStatue extends MinecraftBlockTranslucent {
   private final String facing;
   private final String pose;
@@ -36,14 +39,14 @@ public class CopperGolemStatue extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return true;
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     position = new Vector3(position);
     position.add(0.5, 0, 0.5);
-    return new CopperGolemStatueEntity(position, pose, facing, oxidation);
+    return Collections.singleton(new CopperGolemStatueEntity(position, pose, facing, oxidation));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
@@ -76,6 +76,6 @@ public class CoralFan extends MinecraftBlockTranslucent {
   }
 
   @Override public Collection<Entity> toEntity(Vector3 position) {
-    return Collections.singletonList(new CoralFanEntity(position, coralType));
+    return Collections.singleton(new CoralFanEntity(position, coralType));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
@@ -26,6 +26,9 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class CoralFan extends MinecraftBlockTranslucent {
 
   private final String coralType;
@@ -72,7 +75,7 @@ public class CoralFan extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toEntity(Vector3 position) {
-    return new CoralFanEntity(position, coralType);
+  @Override public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singletonList(new CoralFanEntity(position, coralType));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CoralFan.java
@@ -71,11 +71,11 @@ public class CoralFan extends MinecraftBlockTranslucent {
     return false;
   }
 
-  @Override public boolean isEntity() {
+  @Override public boolean hasEntities() {
     return true;
   }
 
-  @Override public Collection<Entity> toEntity(Vector3 position) {
+  @Override public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new CoralFanEntity(position, coralType));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/DecoratedPot.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/DecoratedPot.java
@@ -62,7 +62,7 @@ public class DecoratedPot extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new DecoratedPotModel.DecoratedPotSpoutEntity(position, facing);
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
@@ -58,6 +58,6 @@ public class EnchantingTable extends AbstractModelBlock {
         Math.toRadians(180 - 30));
     book.setPitch(Math.toRadians(80));
     book.setYaw(Math.toRadians(45));
-    return Collections.singletonList(book);
+    return Collections.singleton(book);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
@@ -25,6 +25,9 @@ import se.llbit.chunky.model.minecraft.EnchantmentTableModel;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class EnchantingTable extends AbstractModelBlock {
 
   public EnchantingTable() {
@@ -45,7 +48,7 @@ public class EnchantingTable extends AbstractModelBlock {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
+  public Collection<Entity> toEntity(Vector3 position) {
     Vector3 newPosition = new Vector3(position);
     newPosition.add(0, 0.35, 0);
     Book book = new Book(
@@ -55,6 +58,6 @@ public class EnchantingTable extends AbstractModelBlock {
         Math.toRadians(180 - 30));
     book.setPitch(Math.toRadians(80));
     book.setYaw(Math.toRadians(45));
-    return book;
+    return Collections.singletonList(book);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/EnchantingTable.java
@@ -38,17 +38,17 @@ public class EnchantingTable extends AbstractModelBlock {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return true;
   }
 
   @Override
-  public boolean isBlockWithEntity() {
-    return true;
+  public boolean isReplacedByEntities() {
+    return false;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     Vector3 newPosition = new Vector3(position);
     newPosition.add(0, 0.35, 0);
     Book book = new Book(

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/HangingSign.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/HangingSign.java
@@ -52,7 +52,7 @@ public class HangingSign extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new HangingSignEntity(position, entityTag, rotation, attached, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
@@ -34,6 +34,8 @@ import se.llbit.util.mojangapi.MinecraftSkin;
 import se.llbit.util.mojangapi.MojangApi;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 
 public class Head extends MinecraftBlockTranslucent {
@@ -67,8 +69,8 @@ public class Head extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
-    return new SkullEntity(position, type, rotation, 1);
+  public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singleton(new SkullEntity(position, type, rotation, 1));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
@@ -64,12 +64,12 @@ public class Head extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return type != Kind.PLAYER;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new SkullEntity(position, type, rotation, 1));
   }
 
@@ -79,7 +79,7 @@ public class Head extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     if (type == Kind.PLAYER) {
       try {
         String textureUrl = getTextureUrl(entityTag);

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Lectern.java
@@ -46,12 +46,12 @@ public class Lectern extends MinecraftBlockTranslucent {
     }
 
     @Override
-    public boolean isEntity() {
+    public boolean hasEntities() {
         return true;
     }
 
     @Override
-    public Collection<Entity> toEntity(Vector3 position) {
+    public Collection<Entity> createEntities(Vector3 position) {
       return se.llbit.chunky.entity.Lectern.create(position, this.facing, this.hasBook);
     }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Lectern.java
@@ -25,6 +25,8 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+
 public class Lectern extends MinecraftBlockTranslucent {
     private final String facing;
     private final boolean hasBook;
@@ -49,7 +51,7 @@ public class Lectern extends MinecraftBlockTranslucent {
     }
 
     @Override
-    public Entity toEntity(Vector3 position) {
-        return new se.llbit.chunky.entity.Lectern(position, this.facing, this.hasBook);
+    public Collection<Entity> toEntity(Vector3 position) {
+      return se.llbit.chunky.entity.Lectern.create(position, this.facing, this.hasBook);
     }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/LilyPad.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/LilyPad.java
@@ -26,6 +26,9 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class LilyPad extends MinecraftBlockTranslucent {
   public LilyPad() {
     super("lily_pad", Texture.lilyPad);
@@ -42,7 +45,7 @@ public class LilyPad extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toEntity(Vector3 position) {
-    return new LilyPadEntity(position);
+  @Override public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singleton(new LilyPadEntity(position));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/LilyPad.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/LilyPad.java
@@ -41,11 +41,11 @@ public class LilyPad extends MinecraftBlockTranslucent {
     return false;
   }
 
-  @Override public boolean isEntity() {
+  @Override public boolean hasEntities() {
     return true;
   }
 
-  @Override public Collection<Entity> toEntity(Vector3 position) {
+  @Override public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new LilyPadEntity(position));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Sign.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Sign.java
@@ -47,7 +47,7 @@ public class Sign extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  @Override public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new SignEntity(position, entityTag, rotation, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/SporeBlossom.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/SporeBlossom.java
@@ -43,12 +43,12 @@ public class SporeBlossom extends Block {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return true;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new se.llbit.chunky.entity.SporeBlossom(position));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/SporeBlossom.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/SporeBlossom.java
@@ -25,6 +25,9 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class SporeBlossom extends Block {
 
   public SporeBlossom() {
@@ -45,7 +48,7 @@ public class SporeBlossom extends Block {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
-    return new se.llbit.chunky.entity.SporeBlossom(position);
+  public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singleton(new se.llbit.chunky.entity.SporeBlossom(position));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallBanner.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallBanner.java
@@ -65,7 +65,7 @@ public class WallBanner extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  @Override public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     JsonObject design = StandingBanner.parseDesign(entityTag);
     design.set("base", Json.of(color.id)); // Base color is not included in the entity tag in Minecraft 1.13+.
     return new se.llbit.chunky.entity.WallBanner(position, facing, design);

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
@@ -51,6 +51,6 @@ public class WallCoralFan extends MinecraftBlockTranslucent {
   }
 
   @Override public Collection<Entity> toEntity(Vector3 position) {
-    return Collections.singletonList(new WallCoralFanEntity(position, coralType, facing));
+    return Collections.singleton(new WallCoralFanEntity(position, coralType, facing));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
@@ -25,6 +25,9 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 
+import java.util.Collection;
+import java.util.Collections;
+
 public class WallCoralFan extends MinecraftBlockTranslucent {
 
   private final String coralType;
@@ -47,7 +50,7 @@ public class WallCoralFan extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toEntity(Vector3 position) {
-    return new WallCoralFanEntity(position, coralType, facing);
+  @Override public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singletonList(new WallCoralFanEntity(position, coralType, facing));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallCoralFan.java
@@ -46,11 +46,11 @@ public class WallCoralFan extends MinecraftBlockTranslucent {
     return false;
   }
 
-  @Override public boolean isEntity() {
+  @Override public boolean hasEntities() {
     return true;
   }
 
-  @Override public Collection<Entity> toEntity(Vector3 position) {
+  @Override public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new WallCoralFanEntity(position, coralType, facing));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallHangingSign.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallHangingSign.java
@@ -51,7 +51,7 @@ public class WallHangingSign extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new WallHangingSignEntity(position, entityTag, facing, material);
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
@@ -73,12 +73,12 @@ public class WallHead extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public boolean isEntity() {
+  public boolean hasEntities() {
     return type != Kind.PLAYER;
   }
 
   @Override
-  public Collection<Entity> toEntity(Vector3 position) {
+  public Collection<Entity> createEntities(Vector3 position) {
     return Collections.singleton(new SkullEntity(position, type, 0, facing));
   }
 
@@ -88,7 +88,7 @@ public class WallHead extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     if (type == Kind.PLAYER) {
       try {
         String textureUrl = Head.getTextureUrl(entityTag);

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
@@ -31,9 +31,10 @@ import se.llbit.math.Vector3;
 import se.llbit.nbt.CompoundTag;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 public class WallHead extends MinecraftBlockTranslucent {
-
   private final String description;
   private final int facing;
   private final SkullEntity.Kind type;
@@ -77,8 +78,8 @@ public class WallHead extends MinecraftBlockTranslucent {
   }
 
   @Override
-  public Entity toEntity(Vector3 position) {
-    return new SkullEntity(position, type, 0, facing);
+  public Collection<Entity> toEntity(Vector3 position) {
+    return Collections.singletonList(new SkullEntity(position, type, 0, facing));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallHead.java
@@ -79,7 +79,7 @@ public class WallHead extends MinecraftBlockTranslucent {
 
   @Override
   public Collection<Entity> toEntity(Vector3 position) {
-    return Collections.singletonList(new SkullEntity(position, type, 0, facing));
+    return Collections.singleton(new SkullEntity(position, type, 0, facing));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallSign.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallSign.java
@@ -62,7 +62,7 @@ public class WallSign extends MinecraftBlockTranslucent {
     return true;
   }
 
-  @Override public Entity toBlockEntity(Vector3 position, CompoundTag entityTag) {
+  @Override public Entity createBlockEntity(Vector3 position, CompoundTag entityTag) {
     return new WallSignEntity(position, entityTag, facing, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
@@ -599,7 +599,7 @@ public class ArmorStand extends Entity implements Poseable, Geared {
    * @return deserialized entity, or {@code null} if it was not a valid entity
    */
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new ArmorStand(json));
+    return Collections.singleton(new ArmorStand(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
@@ -34,6 +34,7 @@ import se.llbit.nbt.Tag;
 import se.llbit.util.JsonUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 public class ArmorStand extends Entity implements Poseable, Geared {
@@ -597,8 +598,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
    *
    * @return deserialized entity, or {@code null} if it was not a valid entity
    */
-  public static Entity fromJson(JsonObject json) {
-    return new ArmorStand(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new ArmorStand(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ArmorStand.java
@@ -598,8 +598,8 @@ public class ArmorStand extends Entity implements Poseable, Geared {
    *
    * @return deserialized entity, or {@code null} if it was not a valid entity
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new ArmorStand(json));
+  public static Entity fromJson(JsonObject json) {
+    return new ArmorStand(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -228,7 +228,7 @@ public class BeaconBeam extends Entity implements Poseable {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new BeaconBeam(json));
+    return Collections.singleton(new BeaconBeam(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -22,6 +22,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -226,8 +227,8 @@ public class BeaconBeam extends Entity implements Poseable {
     return json;
   }
 
-  public static BeaconBeam fromJson(JsonObject json) {
-    return new BeaconBeam(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new BeaconBeam(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BeaconBeam.java
@@ -227,8 +227,8 @@ public class BeaconBeam extends Entity implements Poseable {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new BeaconBeam(json));
+  public static Entity fromJson(JsonObject json) {
+    return new BeaconBeam(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.entity;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 import se.llbit.chunky.PersistentSettings;
@@ -295,8 +296,8 @@ public class Book extends Entity implements Poseable {
     return json;
   }
 
-  public static Book fromJson(JsonObject json) {
-    return new Book(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new Book(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -297,7 +297,7 @@ public class Book extends Entity implements Poseable {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new Book(json));
+    return Collections.singleton(new Book(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/Book.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Book.java
@@ -296,8 +296,8 @@ public class Book extends Entity implements Poseable {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new Book(json));
+  public static Entity fromJson(JsonObject json) {
+    return new Book(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/CalibratedSculkSensorAmethyst.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CalibratedSculkSensorAmethyst.java
@@ -13,6 +13,7 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.util.JsonUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 public class CalibratedSculkSensorAmethyst extends Entity {
@@ -112,8 +113,8 @@ public class CalibratedSculkSensorAmethyst extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
-    return new CalibratedSculkSensorAmethyst(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new CalibratedSculkSensorAmethyst(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/CalibratedSculkSensorAmethyst.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CalibratedSculkSensorAmethyst.java
@@ -113,8 +113,8 @@ public class CalibratedSculkSensorAmethyst extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new CalibratedSculkSensorAmethyst(json));
+  public static Entity fromJson(JsonObject json) {
+    return new CalibratedSculkSensorAmethyst(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/Campfire.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Campfire.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.entity;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Random;
 
@@ -328,8 +329,8 @@ public class Campfire extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
-    return new Campfire(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new Campfire(json));
   }
 
   private static int getOrientationIndex(String facing) {

--- a/chunky/src/java/se/llbit/chunky/entity/Campfire.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Campfire.java
@@ -330,7 +330,7 @@ public class Campfire extends Entity {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new Campfire(json));
+    return Collections.singleton(new Campfire(json));
   }
 
   private static int getOrientationIndex(String facing) {

--- a/chunky/src/java/se/llbit/chunky/entity/Campfire.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Campfire.java
@@ -329,8 +329,8 @@ public class Campfire extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new Campfire(json));
+  public static Entity fromJson(JsonObject json) {
+    return new Campfire(json);
   }
 
   private static int getOrientationIndex(String facing) {

--- a/chunky/src/java/se/llbit/chunky/entity/ChickenEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ChickenEntity.java
@@ -19,6 +19,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class ChickenEntity extends Entity implements Poseable, Variant {
 
@@ -238,8 +239,8 @@ public class ChickenEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static ChickenEntity fromJson(JsonObject json) {
-    return new ChickenEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new ChickenEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/ChickenEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/ChickenEntity.java
@@ -239,8 +239,8 @@ public class ChickenEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new ChickenEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new ChickenEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
@@ -30,6 +30,7 @@ import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Primitive;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -106,10 +107,10 @@ public class CoralFanEntity extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
-    return new CoralFanEntity(position, json.get("coral_type").stringValue("tube"));
+    return Collections.singletonList(new CoralFanEntity(position, json.get("coral_type").stringValue("tube")));
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
@@ -110,7 +110,7 @@ public class CoralFanEntity extends Entity {
   public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
-    return Collections.singletonList(new CoralFanEntity(position, json.get("coral_type").stringValue("tube")));
+    return Collections.singleton(new CoralFanEntity(position, json.get("coral_type").stringValue("tube")));
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CoralFanEntity.java
@@ -107,10 +107,10 @@ public class CoralFanEntity extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
-    return Collections.singleton(new CoralFanEntity(position, json.get("coral_type").stringValue("tube")));
+    return new CoralFanEntity(position, json.get("coral_type").stringValue("tube"));
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/CowEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CowEntity.java
@@ -17,6 +17,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class CowEntity extends Entity implements Poseable, Variant {
 
@@ -273,8 +274,8 @@ public class CowEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static CowEntity fromJson(JsonObject json) {
-    return new CowEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new CowEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/CowEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/CowEntity.java
@@ -274,8 +274,8 @@ public class CowEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new CowEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new CowEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -71,7 +71,7 @@ abstract public class Entity {
    * @param json json data.
    * @return unmarshalled entity, or {@code null} if it was not a valid entity.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     String kind = json.get("kind").stringValue("");
     switch (kind) {
       case "painting":

--- a/chunky/src/java/se/llbit/chunky/entity/Entity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Entity.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.model.minecraft.DecoratedPotModel;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonValue;
+import se.llbit.log.Log;
 import se.llbit.math.Grid;
 import se.llbit.math.Octree;
 import se.llbit.math.Vector3;
@@ -28,6 +29,7 @@ import se.llbit.math.Vector3i;
 import se.llbit.math.primitive.Primitive;
 
 import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Represents Minecraft entities that are not stored in the octree.
@@ -68,72 +70,52 @@ abstract public class Entity {
   /**
    * Unmarshalls an entity object from JSON data.
    *
+   * <p>This method only returns a {@link Collection} to support legacy scenes.</p>
+   *
    * @param json json data.
-   * @return unmarshalled entity, or {@code null} if it was not a valid entity.
+   * @return The entities, or an empty collection if no entity was found.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Collection<Entity> entitiesFromJson(JsonObject json) {
     String kind = json.get("kind").stringValue("");
+    Collection<Entity> entities = new LinkedList<>();
     switch (kind) {
-      case "painting":
-        return PaintingEntity.fromJson(json);
-      case "sign":
-        return SignEntity.fromJson(json);
-      case "wallsign":
-        return WallSignEntity.fromJson(json);
-      case "skull":
-        return SkullEntity.fromJson(json);
-      case "head":
-        return HeadEntity.fromJson(json);
-      case "player":
-        return PlayerEntity.fromJson(json);
-      case "standing_banner":
-        return StandingBanner.fromJson(json);
-      case "wall_banner":
-        return WallBanner.fromJson(json);
-      case "armor_stand":
-        return ArmorStand.fromJson(json);
-      case "lily_pad":
-        return LilyPadEntity.fromJson(json);
-      case "coral_fan":
-        return CoralFanEntity.fromJson(json);
-      case "wall_coral_fan":
-        return WallCoralFanEntity.fromJson(json);
-      case "lectern":
-        return Lectern.fromJson(json);
-      case "campfire":
-        return Campfire.fromJson(json);
-      case "book":
-        return Book.fromJson(json);
-      case "flameParticles":
-        return FlameParticles.fromJson(json);
-      case "beaconBeam":
-        return BeaconBeam.fromJson(json);
-      case "sporeBlossom":
-        return SporeBlossom.fromJson(json);
-      case "decoratedPotSpout":
-        return DecoratedPotModel.DecoratedPotSpoutEntity.fromJson(json);
-      case "calibratedSculkSensorAmethyst":
-        return CalibratedSculkSensorAmethyst.fromJson(json);
-      case "hangingSign":
-        return HangingSignEntity.fromJson(json);
-      case "wallHangingSign":
-        return WallHangingSignEntity.fromJson(json);
-      case "sheep":
-        return SheepEntity.fromJson(json);
-      case "cow":
-        return CowEntity.fromJson(json);
-      case "chicken":
-        return ChickenEntity.fromJson(json);
-      case "pig":
-        return PigEntity.fromJson(json);
-      case "mooshroom":
-        return MooshroomEntity.fromJson(json);
-      case "squid":
-        return SquidEntity.fromJson(json);
-      case "copperGolemStatue":
-        return CopperGolemStatueEntity.fromJson(json);
+      case "painting" -> entities.add(PaintingEntity.fromJson(json));
+      case "sign" -> entities.add(SignEntity.fromJson(json));
+      case "wallsign" -> entities.add(WallSignEntity.fromJson(json));
+      case "skull" -> entities.add(SkullEntity.fromJson(json));
+      case "head" -> entities.add(HeadEntity.fromJson(json));
+      case "player" -> entities.add(PlayerEntity.fromJson(json));
+      case "standing_banner" -> entities.add(StandingBanner.fromJson(json));
+      case "wall_banner" -> entities.add(WallBanner.fromJson(json));
+      case "armor_stand" -> entities.add(ArmorStand.fromJson(json));
+      case "lily_pad" -> entities.add(LilyPadEntity.fromJson(json));
+      case "coral_fan" -> entities.add(CoralFanEntity.fromJson(json));
+      case "wall_coral_fan" -> entities.add(WallCoralFanEntity.fromJson(json));
+      case "lectern" -> {
+        if (json.get("book").isObject()) { // we still get the book from the lectern json to be compatible with the old format
+          entities.add(Book.fromJson(json.get("book").object()));
+        }
+        entities.add(Lectern.fromJson(json));
+      }
+      case "campfire" -> entities.add(Campfire.fromJson(json));
+      case "book" -> entities.add(Book.fromJson(json));
+      case "flameParticles" -> entities.add(FlameParticles.fromJson(json));
+      case "beaconBeam" -> entities.add(BeaconBeam.fromJson(json));
+      case "sporeBlossom" -> entities.add(SporeBlossom.fromJson(json));
+      case "decoratedPotSpout" -> entities.add(DecoratedPotModel.DecoratedPotSpoutEntity.fromJson(json));
+      case "calibratedSculkSensorAmethyst" -> entities.add(CalibratedSculkSensorAmethyst.fromJson(json));
+      case "hangingSign" -> entities.add(HangingSignEntity.fromJson(json));
+      case "wallHangingSign" -> entities.add(WallHangingSignEntity.fromJson(json));
+      case "sheep" -> entities.add(SheepEntity.fromJson(json));
+      case "cow" -> entities.add(CowEntity.fromJson(json));
+      case "chicken" -> entities.add(ChickenEntity.fromJson(json));
+      case "pig" -> entities.add(PigEntity.fromJson(json));
+      case "mooshroom" -> entities.add(MooshroomEntity.fromJson(json));
+      case "squid" -> entities.add(SquidEntity.fromJson(json));
+      case "copperGolemStatue" -> entities.add(CopperGolemStatueEntity.fromJson(json));
+      default -> Log.errorf("Found unknown entity %s when loading from scene.", kind);
     }
-    return null;
+    return entities;
   }
 
   public Vector3 getPosition() {

--- a/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
+++ b/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.entity;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Random;
 import java.util.stream.StreamSupport;
@@ -119,8 +120,8 @@ public class FlameParticles extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
-    return new FlameParticles(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new FlameParticles(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
+++ b/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
@@ -121,7 +121,7 @@ public class FlameParticles extends Entity {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new FlameParticles(json));
+    return Collections.singleton(new FlameParticles(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
+++ b/chunky/src/java/se/llbit/chunky/entity/FlameParticles.java
@@ -120,8 +120,8 @@ public class FlameParticles extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new FlameParticles(json));
+  public static Entity fromJson(JsonObject json) {
+    return new FlameParticles(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
@@ -289,7 +289,7 @@ public class HangingSignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -307,7 +307,7 @@ public class HangingSignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return Collections.singleton(new HangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, attached, material));
+    return new HangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, attached, material);
   }
 
   public static Texture textureFromMaterial(String material) {

--- a/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
@@ -15,6 +15,7 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 public class HangingSignEntity extends Entity {
@@ -288,7 +289,7 @@ public class HangingSignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -306,7 +307,7 @@ public class HangingSignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return new HangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, attached, material);
+    return Collections.singleton(new HangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, attached, material));
   }
 
   public static Texture textureFromMaterial(String material) {

--- a/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
@@ -193,14 +193,14 @@ public class HeadEntity extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     //int type = json.get("type").intValue(0);
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
     String skin = json.get("skin").stringValue("");
-    return new HeadEntity(position, skin, rotation, placement);
+    return Collections.singletonList(new HeadEntity(position, skin, rotation, placement));
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
@@ -200,7 +200,7 @@ public class HeadEntity extends Entity {
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
     String skin = json.get("skin").stringValue("");
-    return Collections.singletonList(new HeadEntity(position, skin, rotation, placement));
+    return Collections.singleton(new HeadEntity(position, skin, rotation, placement));
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HeadEntity.java
@@ -193,14 +193,14 @@ public class HeadEntity extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     //int type = json.get("type").intValue(0);
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
     String skin = json.get("skin").stringValue("");
-    return Collections.singleton(new HeadEntity(position, skin, rotation, placement));
+    return new HeadEntity(position, skin, rotation, placement);
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/entity/Lectern.java
+++ b/chunky/src/java/se/llbit/chunky/entity/Lectern.java
@@ -196,18 +196,8 @@ public class Lectern extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    Lectern lectern = new Lectern(json);
-
-    Collection<Entity> entities = new ArrayList<>();
-    entities.add(lectern);
-    if (json.get("book").isObject()) { // we still get the book from the lectern json to be compatible with the old format
-      entities.addAll(Book.fromJson(json.get("book").object()));
-    } else if (json.get("hasBook").asBoolean(false)) {
-      entities.add(createBookEntity(lectern.getPosition(), lectern.facing));
-    }
-
-    return entities;
+  public static Entity fromJson(JsonObject json) {
+    return new Lectern(json);
   }
 
   private static int getOrientationIndex(String facing) {

--- a/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
@@ -27,6 +27,7 @@ import se.llbit.math.primitive.TexturedTriangle;
 import se.llbit.util.MinecraftPRNG;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 public class LilyPadEntity extends Entity {
@@ -89,11 +90,11 @@ public class LilyPadEntity extends Entity {
   /**
    * Unmarshall a lily pad entity from JSON data.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return new LilyPadEntity(position, rotation);
+    return Collections.singletonList(new LilyPadEntity(position, rotation));
   }
 
 }

--- a/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
@@ -94,7 +94,7 @@ public class LilyPadEntity extends Entity {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return Collections.singletonList(new LilyPadEntity(position, rotation));
+    return Collections.singleton(new LilyPadEntity(position, rotation));
   }
 
 }

--- a/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/LilyPadEntity.java
@@ -90,11 +90,11 @@ public class LilyPadEntity extends Entity {
   /**
    * Unmarshall a lily pad entity from JSON data.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return Collections.singleton(new LilyPadEntity(position, rotation));
+    return new LilyPadEntity(position, rotation);
   }
 
 }

--- a/chunky/src/java/se/llbit/chunky/entity/MooshroomEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/MooshroomEntity.java
@@ -19,6 +19,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class MooshroomEntity extends Entity implements Poseable, Variant {
 
@@ -249,8 +250,8 @@ public class MooshroomEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static MooshroomEntity fromJson(JsonObject json) {
-    return new MooshroomEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new MooshroomEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/MooshroomEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/MooshroomEntity.java
@@ -250,8 +250,8 @@ public class MooshroomEntity extends Entity implements Poseable, Variant {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new MooshroomEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new MooshroomEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
@@ -27,6 +27,7 @@ import se.llbit.math.*;
 import se.llbit.math.primitive.Primitive;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -146,12 +147,12 @@ public class PaintingEntity extends Entity {
    *
    * @return deserialized entity, or {@code null} if it was not a valid entity
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     String art = json.get("art").stringValue("");
     double angle = json.get("angle").doubleValue(0.0);
-    return new PaintingEntity(position, art, angle);
+    return Collections.singletonList(new PaintingEntity(position, art, angle));
   }
 
   public static void resetPaintings() {

--- a/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
@@ -152,7 +152,7 @@ public class PaintingEntity extends Entity {
     position.fromJson(json.get("position").object());
     String art = json.get("art").stringValue("");
     double angle = json.get("angle").doubleValue(0.0);
-    return Collections.singletonList(new PaintingEntity(position, art, angle));
+    return Collections.singleton(new PaintingEntity(position, art, angle));
   }
 
   public static void resetPaintings() {

--- a/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PaintingEntity.java
@@ -147,12 +147,12 @@ public class PaintingEntity extends Entity {
    *
    * @return deserialized entity, or {@code null} if it was not a valid entity
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     String art = json.get("art").stringValue("");
     double angle = json.get("angle").doubleValue(0.0);
-    return Collections.singleton(new PaintingEntity(position, art, angle));
+    return new PaintingEntity(position, art, angle);
   }
 
   public static void resetPaintings() {

--- a/chunky/src/java/se/llbit/chunky/entity/PigEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PigEntity.java
@@ -17,6 +17,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class PigEntity extends Entity implements Poseable, Variant, Saddleable {
 
@@ -217,8 +218,8 @@ public class PigEntity extends Entity implements Poseable, Variant, Saddleable {
     return json;
   }
 
-  public static PigEntity fromJson(JsonObject json) {
-    return new PigEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new PigEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PigEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PigEntity.java
@@ -218,8 +218,8 @@ public class PigEntity extends Entity implements Poseable, Variant, Saddleable {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new PigEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new PigEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -958,7 +958,7 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new PlayerEntity(json));
+    return Collections.singleton(new PlayerEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -957,8 +957,8 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       new ColoredTexture(textureName, color, texture));
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new PlayerEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new PlayerEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -957,8 +957,8 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       new ColoredTexture(textureName, color, texture));
   }
 
-  public static PlayerEntity fromJson(JsonObject json) {
-    return new PlayerEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new PlayerEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/SheepEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SheepEntity.java
@@ -20,6 +20,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class SheepEntity extends Entity implements Poseable, Dyeable {
 
@@ -361,8 +362,8 @@ public class SheepEntity extends Entity implements Poseable, Dyeable {
     return json;
   }
 
-  public static SheepEntity fromJson(JsonObject json) {
-    return new SheepEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new SheepEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/SheepEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SheepEntity.java
@@ -362,8 +362,8 @@ public class SheepEntity extends Entity implements Poseable, Dyeable {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new SheepEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new SheepEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -33,10 +33,7 @@ import se.llbit.nbt.Tag;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.Map;
+import java.util.*;
 
 public class SignEntity extends Entity {
 
@@ -589,7 +586,7 @@ public class SignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -606,7 +603,7 @@ public class SignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     Color backDye = Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
+    return Collections.singletonList(new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -603,7 +603,7 @@ public class SignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     Color backDye = Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return Collections.singletonList(new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
+    return Collections.singleton(new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -586,7 +586,7 @@ public class SignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -603,7 +603,7 @@ public class SignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     Color backDye = Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return Collections.singleton(new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
+    return new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
@@ -33,6 +33,7 @@ import se.llbit.math.primitive.Box;
 import se.llbit.math.primitive.Primitive;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -296,12 +297,12 @@ public class SkullEntity extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     Kind type = Kind.values()[json.get("type").intValue(0)];
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
-    return new SkullEntity(position, type, rotation, placement);
+    return Collections.singletonList(new SkullEntity(position, type, rotation, placement));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
@@ -297,12 +297,12 @@ public class SkullEntity extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     Kind type = Kind.values()[json.get("type").intValue(0)];
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
-    return Collections.singleton(new SkullEntity(position, type, rotation, placement));
+    return new SkullEntity(position, type, rotation, placement);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SkullEntity.java
@@ -303,6 +303,6 @@ public class SkullEntity extends Entity {
     Kind type = Kind.values()[json.get("type").intValue(0)];
     int rotation = json.get("rotation").intValue(0);
     int placement = json.get("placement").intValue(0);
-    return Collections.singletonList(new SkullEntity(position, type, rotation, placement));
+    return Collections.singleton(new SkullEntity(position, type, rotation, placement));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
@@ -5,6 +5,8 @@ import se.llbit.chunky.model.minecraft.SporeBlossomModel;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.material.TextureMaterial;
+import java.util.Collections;
+
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonValue;
 import se.llbit.math.Transform;
@@ -37,7 +39,7 @@ public class SporeBlossom extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
-    return new SporeBlossom(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singletonList(new SporeBlossom(json));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
@@ -40,6 +40,6 @@ public class SporeBlossom extends Entity {
   }
 
   public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singletonList(new SporeBlossom(json));
+    return Collections.singleton(new SporeBlossom(json));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SporeBlossom.java
@@ -39,7 +39,7 @@ public class SporeBlossom extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new SporeBlossom(json));
+  public static Entity fromJson(JsonObject json) {
+    return new SporeBlossom(json);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/SquidEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SquidEntity.java
@@ -18,6 +18,7 @@ import se.llbit.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 public class SquidEntity extends Entity implements Poseable {
 
@@ -187,8 +188,8 @@ public class SquidEntity extends Entity implements Poseable {
     return json;
   }
 
-  public static SquidEntity fromJson(JsonObject json) {
-    return new SquidEntity(json);
+  public static Collection<Entity> fromJson(JsonObject json) {
+    return Collections.singleton(new SquidEntity(json));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/SquidEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SquidEntity.java
@@ -188,8 +188,8 @@ public class SquidEntity extends Entity implements Poseable {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
-    return Collections.singleton(new SquidEntity(json));
+  public static Entity fromJson(JsonObject json) {
+    return new SquidEntity(json);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
@@ -35,6 +35,7 @@ import se.llbit.nbt.SpecificTag;
 import se.llbit.util.NbtUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -211,11 +212,11 @@ public class StandingBanner extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return new StandingBanner(position, rotation, json.get("design").object());
+    return Collections.singleton(new StandingBanner(position, rotation, json.get("design").object()));
   }
 
   public static Material getBannerTexture(JsonObject design) {

--- a/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
@@ -212,11 +212,11 @@ public class StandingBanner extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return Collections.singleton(new StandingBanner(position, rotation, json.get("design").object()));
+    return new StandingBanner(position, rotation, json.get("design").object());
   }
 
   public static Material getBannerTexture(JsonObject design) {

--- a/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
@@ -148,6 +148,6 @@ public class WallBanner extends Entity {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return Collections.singletonList(new WallBanner(position, rotation, json.get("design").object()));
+    return Collections.singleton(new WallBanner(position, rotation, json.get("design").object()));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
@@ -29,6 +29,7 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -143,10 +144,10 @@ public class WallBanner extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return new WallBanner(position, rotation, json.get("design").object());
+    return Collections.singletonList(new WallBanner(position, rotation, json.get("design").object()));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallBanner.java
@@ -144,10 +144,10 @@ public class WallBanner extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     int rotation = json.get("rotation").intValue(0);
-    return Collections.singleton(new WallBanner(position, rotation, json.get("design").object()));
+    return new WallBanner(position, rotation, json.get("design").object());
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
@@ -110,6 +110,6 @@ public class WallCoralFanEntity extends Entity {
     position.fromJson(json.get("position").object());
     String coralType = json.get("coral_type").stringValue("tube");
     String facing = json.get("facing").stringValue("north");
-    return Collections.singletonList(new WallCoralFanEntity(position, coralType, facing));
+    return Collections.singleton(new WallCoralFanEntity(position, coralType, facing));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
@@ -31,6 +31,7 @@ import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Primitive;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -104,11 +105,11 @@ public class WallCoralFanEntity extends Entity {
     return json;
   }
 
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     String coralType = json.get("coral_type").stringValue("tube");
     String facing = json.get("facing").stringValue("north");
-    return new WallCoralFanEntity(position, coralType, facing);
+    return Collections.singletonList(new WallCoralFanEntity(position, coralType, facing));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallCoralFanEntity.java
@@ -105,11 +105,11 @@ public class WallCoralFanEntity extends Entity {
     return json;
   }
 
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     String coralType = json.get("coral_type").stringValue("tube");
     String facing = json.get("facing").stringValue("north");
-    return Collections.singleton(new WallCoralFanEntity(position, coralType, facing));
+    return new WallCoralFanEntity(position, coralType, facing);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
@@ -273,7 +273,7 @@ public class WallHangingSignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -290,6 +290,6 @@ public class WallHangingSignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return Collections.singleton(new WallHangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
+    return new WallHangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
@@ -16,6 +16,7 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 
 public class WallHangingSignEntity extends Entity {
@@ -272,7 +273,7 @@ public class WallHangingSignEntity extends Entity {
   /**
    * Unmarshalls a sign entity from JSON data.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] frontText = null;
@@ -289,6 +290,6 @@ public class WallHangingSignEntity extends Entity {
     boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     boolean backGlowing = json.get("backGlowing").boolValue(false);
-    return new WallHangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
+    return Collections.singleton(new WallHangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -33,6 +33,7 @@ import se.llbit.nbt.CompoundTag;
 
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Collections;
 
 public class WallSignEntity extends Entity {
 
@@ -166,7 +167,7 @@ public class WallSignEntity extends Entity {
   /**
    * Unmarshalls a wall sign entity from JSON data.
    */
-  public static Entity fromJson(JsonObject json) {
+  public static Collection<Entity> fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] text = null;
@@ -177,6 +178,6 @@ public class WallSignEntity extends Entity {
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
     boolean glowing = json.get("glowing").boolValue(false);
-    return new WallSignEntity(position, text, dye, glowing, direction, material);
+    return Collections.singletonList(new WallSignEntity(position, text, dye, glowing, direction, material));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -167,7 +167,7 @@ public class WallSignEntity extends Entity {
   /**
    * Unmarshalls a wall sign entity from JSON data.
    */
-  public static Collection<Entity> fromJson(JsonObject json) {
+  public static Entity fromJson(JsonObject json) {
     Vector3 position = new Vector3();
     position.fromJson(json.get("position").object());
     JsonArray[] text = null;
@@ -178,6 +178,6 @@ public class WallSignEntity extends Entity {
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
     boolean glowing = json.get("glowing").boolValue(false);
-    return Collections.singleton(new WallSignEntity(position, text, dye, glowing, direction, material));
+    return new WallSignEntity(position, text, dye, glowing, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -178,6 +178,6 @@ public class WallSignEntity extends Entity {
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
     boolean glowing = json.get("glowing").boolValue(false);
-    return Collections.singletonList(new WallSignEntity(position, text, dye, glowing, direction, material));
+    return Collections.singleton(new WallSignEntity(position, text, dye, glowing, direction, material));
   }
 }

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/DecoratedPotModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/DecoratedPotModel.java
@@ -34,6 +34,7 @@ import se.llbit.math.primitive.Primitive;
 import se.llbit.util.JsonUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 
 public class DecoratedPotModel extends TopBottomOrientedTexturedBlockModel {
@@ -156,11 +157,11 @@ public class DecoratedPotModel extends TopBottomOrientedTexturedBlockModel {
       return primitives;
     }
 
-    public static Entity fromJson(JsonObject json) {
-      return new DecoratedPotSpoutEntity(
+    public static Collection<Entity> fromJson(JsonObject json) {
+      return Collections.singleton(new DecoratedPotSpoutEntity(
         JsonUtil.vec3FromJsonObject(json.get("position")),
         json.get("facing").stringValue("north")
-      );
+      ));
     }
 
     @Override

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/DecoratedPotModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/DecoratedPotModel.java
@@ -157,11 +157,11 @@ public class DecoratedPotModel extends TopBottomOrientedTexturedBlockModel {
       return primitives;
     }
 
-    public static Collection<Entity> fromJson(JsonObject json) {
-      return Collections.singleton(new DecoratedPotSpoutEntity(
+    public static Entity fromJson(JsonObject json) {
+      return new DecoratedPotSpoutEntity(
         JsonUtil.vec3FromJsonObject(json.get("position")),
         json.get("facing").stringValue("north")
-      ));
+      );
     }
 
     @Override

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1004,22 +1004,25 @@ public class Scene implements JsonSerializable {
 
                     if (block.isEntity()) {
                       Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
-                      Entity entity = block.toEntity(position);
+                      Collection<Entity> entitiesFromBlock = block.toEntity(position);
 
-                      if (entities.shouldLoad(entity)) {
-                        if (entity instanceof Poseable && !(entity instanceof Lectern && !((Lectern) entity).hasBook())) {
-                          entities.addActor(entity);
-                        } else {
-                          entities.addEntity(entity);
-                          if (emitterGrid != null) {
-                            for (Grid.EmitterPosition emitterPos : entity.getEmitterPosition()) {
-                              emitterPos.x -= origin.x;
-                              emitterPos.y -= origin.y;
-                              emitterPos.z -= origin.z;
-                              emitterGrid.addEmitter(emitterPos);
+                      for (Entity entity : entitiesFromBlock) {
+                        if (entities.shouldLoad(entity)) {
+                          if (entity instanceof Poseable) {
+                            entities.addActor(entity);
+                          } else {
+                            entities.addEntity(entity);
+                            if (emitterGrid != null) {
+                              for (Grid.EmitterPosition emitterPos : entity.getEmitterPosition()) {
+                                emitterPos.x -= origin.x;
+                                emitterPos.y -= origin.y;
+                                emitterPos.z -= origin.z;
+                                emitterGrid.addEmitter(emitterPos);
+                              }
                             }
                           }
                         }
+                      }
 
                         if (!block.isBlockWithEntity()) {
                           if (block.isWaterlogged()) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1002,9 +1002,9 @@ public class Scene implements JsonSerializable {
                       chunkBiomeHelper.makeBiomeRelevant(y);
                     }
 
-                    if (block.isEntity()) {
+                    if (block.hasEntities()) {
                       Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
-                      Collection<Entity> entitiesFromBlock = block.toEntity(position);
+                      Collection<Entity> entitiesFromBlock = block.createEntities(position);
 
                       for (Entity entity : entitiesFromBlock) {
                         if (entities.shouldLoad(entity)) {
@@ -1024,14 +1024,13 @@ public class Scene implements JsonSerializable {
                         }
                       }
 
-                        if (!block.isBlockWithEntity()) {
-                          if (block.isWaterlogged()) {
-                            block = palette.water;
-                            octNode = palette.waterId;
-                          } else {
-                            block = Air.INSTANCE;
-                            octNode = palette.airId;
-                          }
+                      if (!block.isReplacedByEntities()) {
+                        if (block.isWaterlogged()) {
+                          block = palette.water;
+                          octNode = palette.waterId;
+                        } else {
+                          block = Air.INSTANCE;
+                          octNode = palette.airId;
                         }
                       }
                     }
@@ -1203,7 +1202,7 @@ public class Scene implements JsonSerializable {
                 }
               }
               if (block.isBlockEntity()) {
-                Entity blockEntity = block.toBlockEntity(position, entityTag);
+                Entity blockEntity = block.createBlockEntity(position, entityTag);
                 if (blockEntity == null) {
                   continue;
                 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneEntities.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneEntities.java
@@ -321,18 +321,18 @@ public class SceneEntities {
       // rather than the actors array. In future versions only the actors
       // array should contain poseable entities.
       for (JsonValue element : json.get("entities").array()) {
-        Entity entity = Entity.fromJson(element.object());
+        Collection<Entity> entity = Entity.fromJson(element.object());
         if (entity != null) {
           if (entity instanceof PlayerEntity) {
-            actors.add(entity);
+            actors.addAll(entity);
           } else {
-            entities.add(entity);
+            entities.addAll(entity);
           }
         }
       }
       for (JsonValue element : json.get("actors").array()) {
-        Entity entity = Entity.fromJson(element.object());
-        actors.add(entity);
+        Collection<Entity> entity = Entity.fromJson(element.object());
+        actors.addAll(entity);
       }
     }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneEntities.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneEntities.java
@@ -321,7 +321,7 @@ public class SceneEntities {
       // rather than the actors array. In future versions only the actors
       // array should contain poseable entities.
       for (JsonValue element : json.get("entities").array()) {
-        Collection<Entity> entity = Entity.fromJson(element.object());
+        Collection<Entity> entity = Entity.entitiesFromJson(element.object());
         if (entity != null) {
           if (entity instanceof PlayerEntity) {
             actors.addAll(entity);
@@ -331,7 +331,7 @@ public class SceneEntities {
         }
       }
       for (JsonValue element : json.get("actors").array()) {
-        Collection<Entity> entity = Entity.fromJson(element.object());
+        Collection<Entity> entity = Entity.entitiesFromJson(element.object());
         actors.addAll(entity);
       }
     }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
@@ -72,7 +72,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
       return player;
     });
     entityTypes.put("Armor stand", (position, scene) -> new ArmorStand(position, new CompoundTag()));
-    entityTypes.put("Lectern", (position, scene) -> new Lectern(position, "north", true));
+    entityTypes.put("Lectern", (position, scene) -> new Lectern(position, "north"));
     entityTypes.put("Book", (position, scene) -> new Book(position, Math.PI - Math.PI / 16, Math.toRadians(30), Math.toRadians(180 - 30)));
     entityTypes.put("Beacon beam", (position, scene) -> new BeaconBeam(position));
     entityTypes.put("Sheep", (position, scene) -> new SheepEntity(position, new CompoundTag()));
@@ -281,15 +281,9 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
 
         controls.getChildren().addAll(modelBox, skinBox, layerBox);
       }
-      else if (entity instanceof Book || entity instanceof Lectern) {
-        Book book;
-        if (entity instanceof Lectern) {
-          book = ((Lectern) entity).getBook();
-        } else {
-          book = (Book) entity;
-        }
+      else if (entity instanceof Book) {
+        Book book = (Book) entity;
 
-        if (book != null) {
           DoubleAdjuster openingAngle = new DoubleAdjuster();
           openingAngle.setName("Opening angle");
           openingAngle.setTooltip("Modifies the book's opening angle.");
@@ -322,7 +316,6 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
             scene.rebuildActorBvh();
           });
           controls.getChildren().add(page2Angle);
-        }
       }
       else if (entity instanceof BeaconBeam) {
         BeaconBeam beam = (BeaconBeam) entity;


### PR DESCRIPTION
Previously a lectern redirected all pose information to its child book, which is different to the enchantment table. Likely because both lectern and book are entities

Main changes in this PR:
 - blocks and entities can return multiple entities on `toEntity` and `fromJson` respectively
 - lecterns are no longer poseable entities
 - lecterns now return both the lectern and its book as entities

As a result, lecterns don't show up in the entities list (as they shouldn't), and lectern books show up in the entities list