### PR TITLE
Make Chunky open the parent folder of the selected resource pack

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -215,7 +215,7 @@ public class ResourcePackChooserController implements Initializable {
               Desktop.getDesktop().open(
                 getItem().isDefaultPack()
                   ? getItem().file.getParentFile()
-                  : getItem().file
+                  : getItem().file.getParentFile()
               );
             } catch (IOException ex) {
               Log.warn("Failed to open resource pack file in system file browser.", ex);


### PR DESCRIPTION
Previously, Chunky would attempt to open the resource pack itself in the file explorer, which would fail if the file format of the resource pack were not supported by the system file explorer. This fix makes Chunky attempt to open the parent folder of the selected resource pack. Fixes #1381 