### PR TITLE
Fix initial text overflow for labeled text fields by scrolling to the end

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
+++ b/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.ui.elements;
 
+import javafx.application.Platform;
 import javafx.beans.DefaultProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -62,12 +63,23 @@ public class TextFieldLabelWrapper extends StackPane {
     if (textField == null) {
       textField = defaultTextField();
     }
+    textField.textProperty().addListener(prop -> Platform.runLater(this::fixTextPositionOffset));
     getChildren().remove(textFieldProperty.get());
 
     textFieldProperty.set(textField);
     labelNode.setLabelFor(textField);
 
     getChildren().add(0, textField);
+  }
+
+  /**
+   * scrolls to the end of the text field
+   * _best effort_ fix for 1378 - long initial text overflows the text field (cut off)
+   */
+  private void fixTextPositionOffset() {
+    TextField textField = textFieldProperty.get();
+    if (!textField.isFocused())
+      textField.end();
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
+++ b/chunky/src/java/se/llbit/chunky/ui/elements/TextFieldLabelWrapper.java
@@ -78,8 +78,9 @@ public class TextFieldLabelWrapper extends StackPane {
    */
   private void fixTextPositionOffset() {
     TextField textField = textFieldProperty.get();
-    if (!textField.isFocused())
+    if (!textField.isFocused()) {
       textField.end();
+    }
   }
 
   @Override


### PR DESCRIPTION
fixes #1378 (best effort: is better now, but not perfect)