### PR TITLE
Fix pom publish regression from #1110

### DIFF
--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -110,6 +110,7 @@ publishing {
                 packaging = "jar"
                 description = "Minecraft mapping and rendering tool"
                 url = "http://chunky.llbit.se"
+                artifactId = archivesBaseName
 
                 licenses {
                     license {


### PR DESCRIPTION
As of #1110 we changed from publishing to `chunky-core` to `chunky`, which is possibly a change in default behaviour in the publish plugin.

It could've been defaulting to `archivesBaseName`, where it now defaults to the top level project `archivesBaseName`?