### PR TITLE
Fix pom version not matching actual version

### DIFF
--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -111,6 +111,7 @@ publishing {
                 description = "Minecraft mapping and rendering tool"
                 url = "http://chunky.llbit.se"
                 artifactId = archivesBaseName
+                version = "2.5.0-SNAPSHOT"
 
                 licenses {
                     license {


### PR DESCRIPTION
Causing inconsistent metadata errors in dependent projects

Would it be better to store the version somewhere? We don't actually store this anywhere at the moment, so I just hardcoded it

See this [chunky-editor build](https://github.com/chunky-dev/chunky-editor/runs/7527395032?check_suite_focus=true) as an example

```
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve se.llbit:chunky-core:2.5.0-SNAPSHOT.
     Required by:
         project :
      > Could not resolve se.llbit:chunky-core:2.5.0-SNAPSHOT.
         > inconsistent module metadata found. Descriptor: se.llbit:chunky-core:2.5.0-SNAPSHOT.162.g94748109 Errors: bad version: expected='2.5.0-SNAPSHOT' found='2.5.0-SNAPSHOT.162.g94748109'
```