### PR TITLE
Fix always rounding to 3 decimal places

### DIFF
--- a/lib/src/se/llbit/chunky/ui/ValidatingNumberStringConverter.java
+++ b/lib/src/se/llbit/chunky/ui/ValidatingNumberStringConverter.java
@@ -21,7 +21,7 @@ public class ValidatingNumberStringConverter extends StringConverter<Number> {
   private boolean parseNonNegativeOnly = false;
   private boolean allowZero = true;
 
-  private final int maximumFractionDigits = decimalFormat.getMaximumFractionDigits();
+  private final int maximumFractionDigits = 9;
 
   public enum AllowedRange {
     FULL,


### PR DESCRIPTION
This is a quick fix to a weird issue where we often update the text field with the internally stored value. Closes #1268

Currently on any focus loss, or enter press to an input field we set the text to a locale formatted string version of the current value in chunky.

So the current logic is:
1. User sets text, internal value is updated
2. Set text field to locale formatted version of the internal value
3. Text field has changed (by ourselves in the previous step), set internal value to re-parsed text value

kind of insane.