### PR TITLE
Fix master snapshot build tag.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master, fix/snapshot-build-tag ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix/snapshot-build-tag ]
   pull_request:
     branches: [ master ]
 
@@ -35,11 +35,17 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-          ./gradlew buildReleaseJar
-        else
-          ./gradlew buildReleaseJar -PprereleaseTag="PR.${PR_NUMBER}"
-        fi
+        case "${GITHUB_EVENT_NAME}" in
+          "pull_request")
+            ./gradlew buildReleaseJar -PprereleaseTag="PR.${PR_NUMBER}"
+            ;;
+          "push")
+            ./gradlew buildReleaseJar -PprereleaseTag="SNAPSHOT"
+            ;;
+          *)
+            ./gradlew buildReleaseJar
+            ;;
+        esac
     - name: Upload build
       uses: actions/upload-artifact@v2.2.2
       with:


### PR DESCRIPTION
Previously the `master` build was not a special case and would create an artifact tagged with `-DEV`. Change it to be tagged with `-SNAPSHOT`.