### PR TITLE
Use the new number entry for the map coordinates

### DIFF
--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -64,7 +64,7 @@
             <Canvas fx:id="mapCanvas" />
             <Canvas fx:id="mapOverlay" />
           </StackPane>
-          <VBox maxWidth="500" minWidth="0" spacing="5.0">
+          <VBox maxWidth="500" minWidth="0" spacing="10.0">
             <padding>
               <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
             </padding>
@@ -78,33 +78,22 @@
               <Button fx:id="reloadWorldBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Reload"
                       HBox.hgrow="ALWAYS"/>
             </HBox>
-            <HBox prefHeight="100.0" spacing="20.0">
-              <VBox prefHeight="200.0" spacing="5.0">
-                <Label text="Dimension:"/>
-                <ToggleButton fx:id="overworldBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                              selected="true" text="Overworld">
-                  <toggleGroup>
-                    <ToggleGroup fx:id="dimension"/>
-                  </toggleGroup>
-                </ToggleButton>
-                <ToggleButton fx:id="netherBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
-                              text="Nether" toggleGroup="$dimension"/>
-                <ToggleButton fx:id="endBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="The End"
-                              toggleGroup="$dimension"/>
-              </VBox>
+            <HBox spacing="10.0">
+              <Label text="Dimension:"/>
+              <ToggleButton fx:id="overworldBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                            selected="true" text="Overworld">
+                <toggleGroup>
+                  <ToggleGroup fx:id="dimension"/>
+                </toggleGroup>
+              </ToggleButton>
+              <ToggleButton fx:id="netherBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
+                            text="Nether" toggleGroup="$dimension"/>
+              <ToggleButton fx:id="endBtn" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="The End"
+                            toggleGroup="$dimension"/>
             </HBox>
             <Separator/>
-            <VBox alignment="CENTER_LEFT">
-              <PositiveIntegerAdjuster fx:id="scale" name="Scale"/>
-            </VBox>
-            <VBox alignment="CENTER_LEFT">
-              <IntegerAdjuster fx:id="yMin" name="Min Y level"/>
-            </VBox>
-            <VBox alignment="CENTER_LEFT">
-              <IntegerAdjuster fx:id="yMax" name="Max Y level"/>
-            </VBox>
-            <Label text="Coordinates"/>
             <HBox alignment="CENTER_LEFT" spacing="10.0">
+              <Label text="Coordinates:"/>
               <TextFieldLabelWrapper labelText="x:">
                 <DoubleTextField prefWidth="100.0" fx:id="xPosition">
                   <tooltip>
@@ -120,13 +109,22 @@
                 </DoubleTextField>
               </TextFieldLabelWrapper>
             </HBox>
+            <VBox alignment="CENTER_LEFT">
+              <PositiveIntegerAdjuster fx:id="scale" name="Scale"/>
+            </VBox>
+            <VBox alignment="CENTER_LEFT">
+              <IntegerAdjuster fx:id="yMin" name="Min Y level"/>
+            </VBox>
+            <VBox alignment="CENTER_LEFT">
+              <IntegerAdjuster fx:id="yMax" name="Max Y level"/>
+            </VBox>
             <HBox spacing="10.0">
-              <ToggleButton prefWidth="100.0" fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">
+              <ToggleButton fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">
                 <toggleGroup>
                   <ToggleGroup fx:id="tracking"/>
                 </toggleGroup>
               </ToggleButton>
-              <ToggleButton prefWidth="100.0" fx:id="trackCameraBtn" mnemonicParsing="false" text="track camera"
+              <ToggleButton fx:id="trackCameraBtn" mnemonicParsing="false" text="track camera"
                             toggleGroup="$tracking"/>
             </HBox>
           </VBox>

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.layout.*?>
 <?import se.llbit.chunky.ui.*?>
 <?import se.llbit.fx.ToolPane?>
+<?import se.llbit.chunky.ui.elements.TextFieldLabelWrapper?>
 <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" xmlns="http://javafx.com/javafx/8.0.65"
       xmlns:fx="http://javafx.com/fxml/1">
   <MenuBar>
@@ -104,18 +105,28 @@
             </VBox>
             <Label text="Coordinates"/>
             <HBox alignment="CENTER_LEFT" spacing="10.0">
-              <Label text="X="/>
-              <DoubleTextField prefWidth="80.0" fx:id="xPosition"/>
-              <Label text="Z="/>
-              <DoubleTextField fx:id="zPosition" prefWidth="80.0"/>
+              <TextFieldLabelWrapper labelText="x:">
+                <DoubleTextField prefWidth="100.0" fx:id="xPosition">
+                  <tooltip>
+                    <Tooltip text="Map x (east/west) coordinate" />
+                  </tooltip>
+                </DoubleTextField>
+              </TextFieldLabelWrapper>
+              <TextFieldLabelWrapper labelText="z:">
+                <DoubleTextField prefWidth="100.0" fx:id="zPosition">
+                  <tooltip>
+                    <Tooltip text="Map z (north/south) coordinate" />
+                  </tooltip>
+                </DoubleTextField>
+              </TextFieldLabelWrapper>
             </HBox>
             <HBox spacing="10.0">
-              <ToggleButton fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">
+              <ToggleButton prefWidth="100.0" fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">
                 <toggleGroup>
                   <ToggleGroup fx:id="tracking"/>
                 </toggleGroup>
               </ToggleButton>
-              <ToggleButton fx:id="trackCameraBtn" mnemonicParsing="false" text="track camera"
+              <ToggleButton prefWidth="100.0" fx:id="trackCameraBtn" mnemonicParsing="false" text="track camera"
                             toggleGroup="$tracking"/>
             </HBox>
           </VBox>

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -119,12 +119,12 @@
               <IntegerAdjuster fx:id="yMax" name="Max Y level"/>
             </VBox>
             <HBox spacing="10.0">
-              <ToggleButton fx:id="trackPlayerBtn" mnemonicParsing="false" text="track player">
+              <ToggleButton fx:id="trackPlayerBtn" mnemonicParsing="false" text="Track player">
                 <toggleGroup>
                   <ToggleGroup fx:id="tracking"/>
                 </toggleGroup>
               </ToggleButton>
-              <ToggleButton fx:id="trackCameraBtn" mnemonicParsing="false" text="track camera"
+              <ToggleButton fx:id="trackCameraBtn" mnemonicParsing="false" text="Track camera"
                             toggleGroup="$tracking"/>
             </HBox>
           </VBox>


### PR DESCRIPTION
I also made it match the size of the buttons below because that looks nice

old:
![image](https://user-images.githubusercontent.com/16853282/183298895-c996f998-59a1-407f-94f5-0e95c1d71bbb.png)

new:
![image](https://user-images.githubusercontent.com/16853282/183298992-1d96ebb8-20da-4e35-a43e-0ae7105102ab.png)