### PR TITLE
Fix icon size of the delete selected chunks icon for larget resource packs.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -185,7 +185,10 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     exportPng.setOnAction(e -> controller.exportMapView());
 
     MenuItem deleteChunks = new MenuItem("Delete selected chunks");
-    deleteChunks.setGraphic(new ImageView(Icon.tntSide.fxImage()));
+    ImageView deleteChunksIcon = new ImageView(Icon.tntSide.fxImage());
+    deleteChunksIcon.setFitHeight(16);
+    deleteChunksIcon.setPreserveRatio(true);
+    deleteChunks.setGraphic(deleteChunksIcon);
     deleteChunks.setOnAction(e -> controller.promptDeleteSelectedChunks());
     deleteChunks.setDisable(chunkSelection.size() == 0);
 


### PR DESCRIPTION
Fixes #1294. It's the only icon that uses a texture from the resource pack. Since we're going to remove this functionality from Chunky (at move it into a plugin), I don't think it's necessary to change the icon at this point.