### PR TITLE
Fix preview render grid not being aligned to chunks.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -168,8 +168,8 @@ public class PreviewRayTracer implements RayTracer {
         boolean insideOctree = scene.isInsideOctree(vec);
         ray.t = t;
         ray.o.set(vec);
-        double xm = ((ray.o.x) % 16.0 + 16.0) % 16.0;
-        double zm = ((ray.o.z) % 16.0 + 16.0) % 16.0;
+        double xm = ((ray.o.x) % 16.0 + 8.0) % 16.0;
+        double zm = ((ray.o.z) % 16.0 + 8.0) % 16.0;
         if (
           (xm < chunkPatternLinePosition || xm > chunkPatternLinePosition + chunkPatternLineWidth) &&
             (zm < chunkPatternLinePosition || zm > chunkPatternLinePosition + chunkPatternLineWidth)


### PR DESCRIPTION
Just realized that the grid is supposed to be aligned to the chunks, like this:
![image](https://user-images.githubusercontent.com/5544859/183301880-dab45961-6f2a-4a0a-b123-fbbd8c4433b9.png)
