### PR TITLE
Fix sky mode settings not being shown after loading a scene.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
@@ -229,6 +229,7 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     colorPicker.setColor(ColorUtil.toFx(scene.sky().getColor()));
     colorPicker.colorProperty().addListener(skyColorListener);
     skyboxSettings.update(scene);
+    skymapSettings.update(scene);
   }
 
   @Override public String getTabTitle() {


### PR DESCRIPTION
Fixes #1296 