### PR TITLE
Add ability to switch octree implementations.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -246,7 +246,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         // Wait for a scene state change (e.g. user editing the scene)
         ResetReason reason = sceneProvider.awaitSceneStateChange();
 
-        if (reason == ResetReason.SETTINGS_CHANGED_SOFT) {
+        if (!reason.shouldRerender()) {
           // Settings sync reset. No need to re-render.
           continue;
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -246,6 +246,11 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         // Wait for a scene state change (e.g. user editing the scene)
         ResetReason reason = sceneProvider.awaitSceneStateChange();
 
+        if (reason == ResetReason.SETTINGS_CHANGED_SOFT) {
+          // Settings sync reset. No need to re-render.
+          continue;
+        }
+
         // Copy the new scene state to the bufferedScene
         synchronized (bufferedScene) {
           sceneProvider.withSceneProtected(scene -> {

--- a/chunky/src/java/se/llbit/chunky/renderer/ResetReason.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/ResetReason.java
@@ -21,26 +21,34 @@ package se.llbit.chunky.renderer;
  * Indicates the reason a render needs to be reset.
  */
 public enum ResetReason {
-  NONE(false),
-  MODE_CHANGE(false),
-  MATERIALS_CHANGED(true),
+  NONE(false, false),
+  MODE_CHANGE(false, true),
+  MATERIALS_CHANGED(true, true),
   /**
    * Settings changed, and we do want to trigger a rerender.
    */
-  SETTINGS_CHANGED(true),
+  SETTINGS_CHANGED(true, true),
   /**
    * Settings changed, but we do NOT want to trigger a rerender.
    */
-  SETTINGS_CHANGED_SOFT(true),
-  SCENE_LOADED(true);
+  SETTINGS_CHANGED_SOFT(true, false),
+  SCENE_LOADED(true, true);
 
   /** Determines if the non-transitive scene state needs to be modified. */
   private final boolean overwriteState;
 
-  ResetReason(boolean overwrite) {
+  /** Determines if the scene needs to be rerendered. **/
+  private final boolean shouldRerender;
+
+  ResetReason(boolean overwrite, boolean rerender) {
     overwriteState = overwrite;
+    shouldRerender = rerender;
   }
   public boolean overwriteState() {
     return overwriteState;
+  }
+
+  public boolean shouldRerender() {
+    return shouldRerender;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/ResetReason.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/ResetReason.java
@@ -24,7 +24,14 @@ public enum ResetReason {
   NONE(false),
   MODE_CHANGE(false),
   MATERIALS_CHANGED(true),
+  /**
+   * Settings changed, and we do want to trigger a rerender.
+   */
   SETTINGS_CHANGED(true),
+  /**
+   * Settings changed, but we do NOT want to trigger a rerender.
+   */
+  SETTINGS_CHANGED_SOFT(true),
   SCENE_LOADED(true);
 
   /** Determines if the non-transitive scene state needs to be modified. */

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3138,16 +3138,27 @@ public class Scene implements JsonSerializable, Refreshable {
    * Called when the scene description has been altered in a way that
    * forces the rendering to restart.
    */
-  @Override public synchronized void refresh() {
+  @Override
+  public synchronized void refresh() {
     refresh(ResetReason.SETTINGS_CHANGED);
+  }
+
+  /**
+   * Called when the scene description has been altered in a way that
+   * should be saved to disk.
+   */
+  public synchronized void softRefresh() {
+    refresh(ResetReason.SETTINGS_CHANGED_SOFT);
   }
 
   private synchronized void refresh(ResetReason reason) {
     if (mode == RenderMode.PAUSED) {
       mode = RenderMode.RENDERING;
     }
-    spp = 0;
-    renderTime = 0;
+    if (reason != ResetReason.NONE) {
+      spp = 0;
+      renderTime = 0;
+    }
     setResetReason(reason);
     notifyAll();
   }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -174,8 +174,9 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     octreeImplementation.getItems().addAll(octreeNames);
     octreeImplementation.getSelectionModel().selectedItemProperty()
             .addListener((observable, oldvalue, newvalue) -> {
-              scene.setOctreeImplementation(newvalue);
               PersistentSettings.setOctreeImplementation(newvalue);
+              scene.setOctreeImplementation(newvalue);
+              scene.softRefresh();
             });
     octreeImplementation.setTooltip(new Tooltip(tooltipTextBuilder.toString()));
 
@@ -209,6 +210,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
             .addListener(((observable, oldValue, newValue) -> {
               PersistentSettings.setBvhMethod(newValue);
               scene.setBvhImplementation(newValue);
+              scene.softRefresh();
             }));
     bvhMethod.setTooltip(new Tooltip(bvhMethodBuilder.toString()));
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -188,7 +188,6 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
         try (TaskTracker.Task task = tracker.task("(2/2) Converting water octree")) {
           scene.getWaterOctree().switchImplementation(octreeImplementation.getValue(), task);
         }
-        System.out.println("Done");
       } catch (IOException e) {
         Log.error("Switching octrees failed. Reload the scene.\n", e);
       }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -805,7 +805,9 @@ public class Octree {
       })))) {
         implementation.store(out);
       }
-      implementation = null; // Allow the GC to free memory during construction of the new octree
+      // Allow the GC to free memory during construction of the new octree
+      // Replace with an empty octree to prevent any NPE's
+      implementation = new PackedOctree(1);
 
       try (DataInputStream in = new DataInputStream(new FastBufferedInputStream(new PositionalInputStream(Files.newInputStream(tempFile.toPath()), position -> {
         task.updateInterval((int) (position * progressScaler) + 500, 1);

--- a/chunky/src/java/se/llbit/util/PositionalOutputStream.java
+++ b/chunky/src/java/se/llbit/util/PositionalOutputStream.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.util;
+
+import se.llbit.util.annotation.NotNull;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.function.LongConsumer;
+
+/**
+ * An output stream that keeps track of it's position and calls a callback whenever a write occurs.
+ */
+public class PositionalOutputStream extends FilterOutputStream {
+  private final LongConsumer update;
+  private long count = 0;
+
+  public PositionalOutputStream(OutputStream out, LongConsumer update) {
+    super(out);
+    this.update = update;
+  }
+
+  public long getPosition() {
+    return count;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    super.write(b);
+    count++;
+    update.accept(count);
+  }
+
+  @Override
+  public void write(@NotNull byte[] b) throws IOException {
+    super.write(b);
+    count += b.length;
+    update.accept(count);
+  }
+
+  @Override
+  public void write(@NotNull byte[] b, int off, int len) throws IOException {
+    super.write(b, off, len);
+    count += len;
+    update.accept(count);
+  }
+}

--- a/chunky/src/java/se/llbit/util/PositionalOutputStream.java
+++ b/chunky/src/java/se/llbit/util/PositionalOutputStream.java
@@ -20,7 +20,6 @@ package se.llbit.util;
 
 import se.llbit.util.annotation.NotNull;
 
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.LongConsumer;
@@ -28,13 +27,14 @@ import java.util.function.LongConsumer;
 /**
  * An output stream that keeps track of it's position and calls a callback whenever a write occurs.
  */
-public class PositionalOutputStream extends FilterOutputStream {
+public class PositionalOutputStream extends OutputStream {
   private final LongConsumer update;
+  private final OutputStream out;
   private long count = 0;
 
   public PositionalOutputStream(OutputStream out, LongConsumer update) {
-    super(out);
     this.update = update;
+    this.out = out;
   }
 
   public long getPosition() {
@@ -42,22 +42,32 @@ public class PositionalOutputStream extends FilterOutputStream {
   }
 
   @Override
+  public void close() throws IOException {
+    out.close();
+  }
+
+  @Override
+  public void flush() throws IOException {
+    out.flush();
+  }
+
+  @Override
   public void write(int b) throws IOException {
-    super.write(b);
+    out.write(b);
     count++;
     update.accept(count);
   }
 
   @Override
   public void write(@NotNull byte[] b) throws IOException {
-    super.write(b);
+    out.write(b);
     count += b.length;
     update.accept(count);
   }
 
   @Override
   public void write(@NotNull byte[] b, int off, int len) throws IOException {
-    super.write(b, off, len);
+    out.write(b, off, len);
     count += len;
     update.accept(count);
   }

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -34,6 +34,7 @@
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Octree implementation:" />
       <ChoiceBox fx:id="octreeImplementation" prefWidth="150.0" />
+      <Button fx:id="octreeSwitchImplementation" text="Switch Current Scene" />
     </HBox>
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="BVH build method:" />


### PR DESCRIPTION
When complete closes #1416

Complete:
- Switch octrees in an existing scene
- Progress bar while switching octrees

To do:
- [x] Check it saves the new octree setting
- [x] Block rendering when switching octrees (can cause NPE)