### PR TITLE
Add freely adjustable layered fog

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Fog.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Fog.java
@@ -183,6 +183,7 @@ public final class Fog {
   public void importFromJson(JsonObject json, Scene scene) {
     mode = FogMode.get(json.get("mode").stringValue(mode.name()));
     uniformDensity = json.get("uniformDensity").doubleValue(uniformDensity);
+    skyFogDensity = json.get("skyFogDensity").doubleValue(skyFogDensity);
     layers = json.get("layers").array().elements.stream().map(JsonValue::object).map(o -> new FogLayer(
         o.get("y").doubleValue(0),
         o.get("breadth").doubleValue(0),

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Fog.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Fog.java
@@ -1,0 +1,217 @@
+package se.llbit.chunky.renderer.scene;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import se.llbit.chunky.PersistentSettings;
+import se.llbit.json.JsonArray;
+import se.llbit.json.JsonObject;
+import se.llbit.json.JsonValue;
+import se.llbit.math.QuickMath;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+public final class Fog {
+  protected FogMode mode = FogMode.NONE;
+  protected boolean fastFog = true;
+  protected double uniformDensity = Scene.DEFAULT_FOG_DENSITY;
+  protected double skyFogDensity = 1;
+  protected FogLayer[] layers = new FogLayer[0];
+  protected Vector3 fogColor = new Vector3(PersistentSettings.getFogColorRed(), PersistentSettings.getFogColorGreen(), PersistentSettings.getFogColorBlue());
+
+  private static final double EXTINCTION_FACTOR = 0.04;
+  public static final double FOG_LIMIT = 30000;
+  public static final Vector4 SKY_SCATTER = new Vector4(1, 1, 1, 1);
+
+  public boolean fogEnabled() {
+    return mode != FogMode.NONE;
+  }
+
+  public Vector3 getFogColor() {
+    return fogColor;
+  }
+
+  public double getUniformDensity() {
+    return uniformDensity;
+  }
+
+  public double getSkyFogDensity() {
+    return skyFogDensity;
+  }
+
+  public boolean fastFog() {
+    return fastFog;
+  }
+
+  private static double clampDy(double dy) {
+    // This method prevents numerical errors or division by 0 when dy is close to 0.
+    final double epsilon = 0.00001;
+    if (dy > 0) {
+      if (dy < epsilon) {
+        return epsilon;
+      }
+    } else if (dy > -epsilon) {
+      return -epsilon;
+    }
+    return dy;
+  }
+
+  public void addSkyFog(Ray ray, Vector4 scatterLight) {
+    if (mode == FogMode.UNIFORM) {
+      double fog;
+      if (ray.d.y > 0) {
+        fog = 1 - ray.d.y;
+        fog *= fog;
+      } else {
+        fog = 1;
+      }
+      fog *= skyFogDensity;
+      ray.color.x = (1 - fog) * ray.color.x + fog * fogColor.x;
+      ray.color.y = (1 - fog) * ray.color.y + fog * fogColor.y;
+      ray.color.z = (1 - fog) * ray.color.z + fog * fogColor.z;
+    } else if (mode == FogMode.LAYERED) {
+      double dy = ray.d.y;
+      double y1 = ray.o.y;
+      double y2 = y1 + dy * FOG_LIMIT;
+      addLayeredFog(ray.color, dy, y1, y2, scatterLight);
+    }
+  }
+
+  public void addGroundFog(Ray ray, Vector3 ox, double airDistance, Vector4 scatterLight, double scatterOffset) {
+    Vector4 color = ray.color;
+    if (mode == FogMode.UNIFORM) {
+      double fogDensity = uniformDensity * EXTINCTION_FACTOR;
+      double extinction = Math.exp(-airDistance * fogDensity);
+      color.scale(extinction);
+      if (scatterLight.w > Ray.EPSILON) {
+        double inscatter = scatterLight.w;
+        if (fastFog) {
+          inscatter *= (1 - extinction);
+        } else {
+          inscatter *= airDistance * fogDensity * Math.exp(-scatterOffset * fogDensity);
+        }
+        color.x += scatterLight.x * fogColor.x * inscatter;
+        color.y += scatterLight.y * fogColor.y * inscatter;
+        color.z += scatterLight.z * fogColor.z * inscatter;
+      }
+    } else if (mode == FogMode.LAYERED) {
+      addLayeredFog(color, ray.d.y, ox.y, ray.o.y, scatterLight);
+    }
+  }
+
+  public void addLayeredFog(Vector4 color, double dy, double y1, double y2, Vector4 scatterLight) {
+    double total = 0;
+    for (FogLayer layer : layers) {
+      // Logistic distribution CDF. It is the integral of the PDF, which is a nice bell shaped sigmoid function
+      // used to express the fog density at a given y coordinate.
+      total += layer.density * (1 / (1 + Math.exp((layer.yWithOrigin - y1) * layer.breadthInv)) - 1 / (1 + Math.exp((layer.yWithOrigin - y2) * layer.breadthInv)));
+    }
+    double extinction = Math.exp(total / clampDy(dy));
+    color.scale(extinction);
+    if (scatterLight.w > Ray.EPSILON) {
+      double inscatter = (1 - extinction) * scatterLight.w;
+      color.x += inscatter * scatterLight.x * fogColor.x;
+      color.y += inscatter * scatterLight.y * fogColor.y;
+      color.z += inscatter * scatterLight.z * fogColor.z;
+    }
+  }
+
+  public double sampleGroundScatterOffset(Ray ray, Vector3 ox, Random random) {
+    double airDistance = ray.distance;
+    if (mode == FogMode.UNIFORM) {
+      return QuickMath.clamp(airDistance * random.nextFloat(), Ray.EPSILON, airDistance - Ray.EPSILON);
+    } else if (mode == FogMode.LAYERED) {
+      double dy = ray.d.y;
+      double y1 = ox.y;
+      double y2 = ray.o.y;
+      return sampleLayeredScatterOffset(random, y1, y2, dy);
+    } else {
+      throw new IllegalStateException("Tried to sample ground fog scatter offset even though fog is off.");
+    }
+  }
+
+  public double sampleSkyScatterOffset(Scene scene, Ray ray, Random random) {
+    if (mode == FogMode.LAYERED) {
+      double dy = ray.d.y;
+      double y1 = ray.o.y;
+      double y2 = dy > 0 ? scene.yMax : scene.yMin;
+      return sampleLayeredScatterOffset(random, y1, y2, dy);
+    } else {
+      throw new IllegalStateException("Tried to sample sky fog scatter offset even though fog is not layered.");
+    }
+  }
+
+  private double sampleLayeredScatterOffset(Random random, double y1, double y2, double dy) {
+    if (layers.length == 0) {
+      return Ray.EPSILON;
+    }
+    // This works only for one fog layer yet.
+    FogLayer layer = layers[0];
+    // Logistic distribution CDF.
+    double y1v = 1 / (1 + Math.exp((layer.yWithOrigin - y1) * layer.breadthInv));
+    double y2v = 1 / (1 + Math.exp((layer.yWithOrigin - y2) * layer.breadthInv));
+    double middle = y1v + random.nextDouble() * (y2v - y1v);
+    // Logistic distribution Quantile function.
+    double offsetY = Math.log(middle / (1 - middle)) * layer.breadth + layer.yWithOrigin;
+    return (offsetY - y1) / clampDy(dy);
+  }
+
+  public JsonObject toJson() {
+    JsonObject fogObj = new JsonObject();
+    fogObj.add("mode", mode.name());
+    fogObj.add("uniformDensity", uniformDensity);
+    fogObj.add("skyFogDensity", skyFogDensity);
+    JsonArray jsonLayers = new JsonArray();
+    for (FogLayer layer : layers) {
+      JsonObject jsonLayer = new JsonObject();
+      jsonLayer.add("y", layer.y);
+      jsonLayer.add("breadth", layer.breadth);
+      jsonLayer.add("density", layer.density);
+      jsonLayers.add(jsonLayer);
+    }
+    fogObj.add("layers", jsonLayers);
+    JsonObject colorObj = new JsonObject();
+    colorObj.add("red", fogColor.x);
+    colorObj.add("green", fogColor.y);
+    colorObj.add("blue", fogColor.z);
+    fogObj.add("color", colorObj);
+    fogObj.add("fastFog", fastFog);
+    return fogObj;
+  }
+
+  public void importFromJson(JsonObject json, Scene scene) {
+    mode = FogMode.get(json.get("mode").stringValue(mode.name()));
+    uniformDensity = json.get("uniformDensity").doubleValue(uniformDensity);
+    layers = json.get("layers").array().elements.stream().map(JsonValue::object).map(o -> new FogLayer(
+        o.get("y").doubleValue(0),
+        o.get("breadth").doubleValue(0),
+        o.get("density").doubleValue(0),
+        scene)).toArray(FogLayer[]::new);
+    JsonObject colorObj = json.get("color").object();
+    fogColor.x = colorObj.get("red").doubleValue(fogColor.x);
+    fogColor.y = colorObj.get("green").doubleValue(fogColor.y);
+    fogColor.z = colorObj.get("blue").doubleValue(fogColor.z);
+    fastFog = json.get("fastFog").boolValue(fastFog);
+  }
+
+  public void importFromLegacy(JsonObject json) {
+    mode = json.get("fogEnabled").boolValue(mode != FogMode.NONE) ? FogMode.NONE : FogMode.UNIFORM;
+    uniformDensity = json.get("fogDensity").doubleValue(uniformDensity);
+    skyFogDensity = json.get("skyFogDensity").doubleValue(skyFogDensity);
+    layers = new FogLayer[0];
+    JsonObject colorObj = json.get("fogColor").object();
+    fogColor.x = colorObj.get("red").doubleValue(fogColor.x);
+    fogColor.y = colorObj.get("green").doubleValue(fogColor.y);
+    fogColor.z = colorObj.get("blue").doubleValue(fogColor.z);
+    fastFog = json.get("fastFog").boolValue(fastFog);
+  }
+
+  public void set(Fog other) {
+    mode = other.mode;
+    uniformDensity = other.uniformDensity;
+    skyFogDensity = other.skyFogDensity;
+    layers = Arrays.stream(other.layers).map(FogLayer::clone).toArray(FogLayer[]::new);
+    fogColor.set(other.fogColor);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogLayer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogLayer.java
@@ -1,0 +1,34 @@
+package se.llbit.chunky.renderer.scene;
+
+public final class FogLayer {
+  public double yMin, y, yWithOrigin, breadth, breadthInv, density;
+
+  public FogLayer(double y, double breadth, double density, Scene scene) {
+    this(y, breadth, density, scene.yMin);
+  }
+
+  private FogLayer(double y, double breadth, double density, double yMin) {
+    this.yMin = yMin;
+    setY(y);
+    setBreadth(breadth);
+    setDensity(density);
+  }
+
+  public void setY(double y) {
+    this.y = y;
+    this.yWithOrigin = y - yMin;
+  }
+
+  public void setBreadth(double breadth) {
+    this.breadth = breadth;
+    this.breadthInv = 1 / breadth;
+  }
+
+  public void setDensity(double density) {
+    this.density = density;
+  }
+
+  public FogLayer clone() {
+    return new FogLayer(y, breadth, density, yMin);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogMode.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogMode.java
@@ -1,0 +1,13 @@
+package se.llbit.chunky.renderer.scene;
+
+public enum FogMode {
+  NONE, UNIFORM, LAYERED;
+
+  public static FogMode get(String name) {
+    try {
+      return valueOf(name);
+    } catch (IllegalArgumentException e) {
+      return NONE;
+    }
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -275,7 +275,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @Override
   public void update(Scene scene) {
     outputMode.getSelectionModel().select(scene.getOutputMode());
-    fastFog.setSelected(scene.fastFog());
+    fastFog.setSelected(scene.fog.fastFog());
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
@@ -216,10 +216,10 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudX.set(scene.sky().cloudXOffset());
     cloudY.set(scene.sky().cloudYOffset());
     cloudZ.set(scene.sky().cloudZOffset());
-    fogDensity.set(scene.getFogDensity());
-    skyFogDensity.set(scene.getSkyFogDensity());
+    fogDensity.set(scene.fog.getUniformDensity());
+    skyFogDensity.set(scene.fog.getSkyFogDensity());
     fogColor.colorProperty().removeListener(fogColorListener);
-    fogColor.setColor(ColorUtil.toFx(scene.getFogColor()));
+    fogColor.setColor(ColorUtil.toFx(scene.fog.getFogColor()));
     fogColor.colorProperty().addListener(fogColorListener);
     horizonOffset.set(scene.sky().getHorizonOffset());
     simulatedSky.setValue(scene.sky().getSimulatedSky());


### PR DESCRIPTION
Completely rewrote the code for the fog so that fog can e.g. concentrate at the bottom, allowing for a wider range of effects. Fog density is modelled as a function of y. It is a sum of bell shaped sigmoid functions. Each fog layer has a center y coordinate, a density and a breadth value. Scattering works only for one layer so far. The scene JSON structure has been altered so that all fog data is stored in one JsonObject. The previous fog behavior is still supported and old scenes will be saved in the new format.

Import the following settings to test the new features:
`{"fog":{"mode":"LAYERED","layers":[{"y":62,"breadth":10,"density":1}]}}`
`{"fog":{"mode":"UNIFORM","uniformDensity":0.05}}`
`{"fog":{"mode":"NONE"}}`

A GUI implementation is still missing. So far the GUI still works the same except that the mode must be set to UNIFORM via JSON. I'd like to leave the GUI part to someone else.