### PR TITLE
Add Loading scenes list title to inform user

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -87,6 +87,7 @@ import se.llbit.log.Log;
 import se.llbit.math.Vector3;
 import se.llbit.util.ProgressListener;
 import se.llbit.util.TaskTracker;
+import se.llbit.util.annotation.Nullable;
 
 /**
  * Controller for the main Chunky window.
@@ -100,6 +101,8 @@ public class ChunkyFxController
   private ChunkMap map;
   private MapView mapView;
   protected ChunkSelectionTracker chunkSelection = new ChunkSelectionTracker();
+
+  @Nullable private SceneChooser sceneChooser;
 
   @FXML private Canvas mapCanvas;
   @FXML private Canvas mapOverlay;
@@ -718,11 +721,19 @@ public class ChunkyFxController
 
   public void openSceneChooser() {
     try {
-      SceneChooser chooser = new SceneChooser(this);
-      chooser.show();
+      if (this.sceneChooser == null) {
+        this.sceneChooser = new SceneChooser(this);
+        this.sceneChooser.show();
+      } else {
+        this.sceneChooser.toFront();
+      }
     } catch (IOException e1) {
       Log.error("Failed to create scene chooser window.", e1);
     }
+  }
+
+  public void sceneChooserClosed() {
+    this.sceneChooser = null;
   }
 
   public void saveCurrentFrame() {

--- a/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
@@ -210,6 +210,9 @@ public class SceneChooserController implements Initializable {
   }
 
   private void populateSceneTable(File sceneDir) {
+    String previousTitle = this.stage.getTitle();
+    this.stage.setTitle("Loading scenes list...");
+
     List<SceneListItem> scenes = new ArrayList<>();
     List<File> fileList = SceneHelper.getAvailableSceneFiles(sceneDir);
     fileList.sort(Comparator.comparing(File::length));
@@ -235,6 +238,8 @@ public class SceneChooserController implements Initializable {
     } catch(Exception ignore) {
     }
     sceneTbl.sort();
+
+    this.stage.setTitle(previousTitle);
 
     sceneTbl.setOnSort(e -> {
       PersistentSettings.setTableSortConfig("scenes", TableSortConfigSerializer.getSortConfig(sceneTbl));

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/SceneChooser.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/SceneChooser.java
@@ -39,13 +39,16 @@ public class SceneChooser extends Stage {
     setTitle("Load Chunky Scene");
     getIcons().add(Icons.CHUNKY_ICON);
     setScene(new Scene(root));
-    controller.setController(chunkyFxController);
     controller.setStage(this);
+    controller.setController(chunkyFxController);
     addEventFilter(KeyEvent.ANY, e -> {
       if (e.getCode() == KeyCode.ESCAPE) {
         e.consume();
         close();
+        chunkyFxController.sceneChooserClosed();
       }
     });
+
+    this.setOnCloseRequest(windowEvent -> chunkyFxController.sceneChooserClosed());
   }
 }


### PR DESCRIPTION
Also fix being able to open multiple scene chooser windows at once.

I'm not entirely sure we're closing them correctly, `close()` actually just calls `hide()` internally. We might be slowly stacking up popup windows internally, not sure