### PR TITLE
Don't fail to open file browser when resourcepacks directory is missing

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -362,7 +362,10 @@ public class ResourcePackChooserController implements Initializable {
       "*.jar",
       "pack.mcmeta"
     ));
-    fileChooser.setInitialDirectory(MinecraftFinder.getResourcePacksDirectory());
+    File dir = MinecraftFinder.getResourcePacksDirectory();
+    if(dir.isDirectory()) {
+      fileChooser.setInitialDirectory(dir);
+    }
     
     List<File> newlyAddedFiles = fileChooser.showOpenMultipleDialog(addNewTargetPackBtn.getScene().getWindow());
     if (newlyAddedFiles == null)


### PR DESCRIPTION
fixes #1445 

The file browser for unlisted resource pack failed to open if .minecraft/resourcepacks directory did not exist.
Instead, it will now open at the filesystem root.