### PR TITLE
Fix single color textures not working with biome colors

### DIFF
--- a/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
@@ -53,13 +53,13 @@ public abstract class AnimatedQuadModel extends QuadModel {
     }
 
     float[] color = null;
+    Tint tint = Tint.NONE;
     for (int i = 0; i < quads.length; ++i) {
       Quad quad = quads[i];
       if (quad.intersect(ray)) {
         float[] c = textures[i].getColor(ray.u, ray.v, j);
         if (c[3] > Ray.EPSILON) {
-          Tint tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
-          tint.tint(c, ray, scene);
+          tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
           color = c;
           ray.t = ray.tNext;
           if (quad.doubleSided)
@@ -81,6 +81,7 @@ public abstract class AnimatedQuadModel extends QuadModel {
       }
 
       ray.color.set(color);
+      tint.tint(ray.color, ray, scene);
       ray.distance += ray.t;
       ray.o.scaleAdd(ray.t, ray.d);
     }

--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -55,13 +55,13 @@ public abstract class QuadModel implements BlockModel {
     Tint[] tintedQuads = getTints();
 
     float[] color = null;
+    Tint tint = Tint.NONE;
     for (int i = 0; i < quads.length; ++i) {
       Quad quad = quads[i];
       if (quad.intersect(ray)) {
         float[] c = textures[i].getColor(ray.u, ray.v);
         if (c[3] > Ray.EPSILON) {
-          Tint tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
-          tint.tint(c, ray, scene);
+          tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
           color = c;
           ray.t = ray.tNext;
           if (quad.doubleSided)
@@ -83,6 +83,7 @@ public abstract class QuadModel implements BlockModel {
       }
 
       ray.color.set(color);
+      tint.tint(ray.color, ray, scene);
       ray.distance += ray.t;
       ray.o.scaleAdd(ray.t, ray.d);
     }

--- a/chunky/src/java/se/llbit/chunky/model/Tint.java
+++ b/chunky/src/java/se/llbit/chunky/model/Tint.java
@@ -4,6 +4,7 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.log.Log;
 import se.llbit.math.ColorUtil;
 import se.llbit.math.Ray;
+import se.llbit.math.Vector4;
 
 public class Tint {
   public enum TintType {
@@ -35,6 +36,7 @@ public class Tint {
 
   /**
    * Create a constant tint.
+   *
    * @param tint Tint color as an ARGB integer
    */
   public Tint(int tint) {
@@ -46,6 +48,7 @@ public class Tint {
 
   /**
    * Create a constant tint.
+   *
    * @param tint Tint color as an array of floats (length >= 3)
    */
   public Tint(float[] tint) {
@@ -54,33 +57,45 @@ public class Tint {
     System.arraycopy(tint, 0, this.tint, 0, 3);
   }
 
+  private float[] getTintColor(Ray ray, Scene scene) {
+    switch (type) {
+      case NONE:
+        return null;
+      case CONSTANT:
+        return this.tint;
+      case BIOME_FOLIAGE:
+        return ray.getBiomeFoliageColor(scene);
+      case BIOME_GRASS:
+        return ray.getBiomeGrassColor(scene);
+      case BIOME_WATER:
+        return ray.getBiomeWaterColor(scene);
+      default:
+        Log.warn("Unsupported tint type " + type);
+        return null;
+    }
+  }
+
   /**
    * Tint a color array with the tint option of this Tint object.
    */
   public void tint(float[] color, Ray ray, Scene scene) {
-    if (type == TintType.NONE) return;
-
-    float[] tintColor;
-    switch (type) {
-      case CONSTANT:
-        tintColor = this.tint;
-        break;
-      case BIOME_FOLIAGE:
-        tintColor = ray.getBiomeFoliageColor(scene);
-        break;
-      case BIOME_GRASS:
-        tintColor = ray.getBiomeGrassColor(scene);
-        break;
-      case BIOME_WATER:
-        tintColor = ray.getBiomeWaterColor(scene);
-        break;
-      default:
-        Log.warn("Unsupported tint type " + type);
-        return;
+    float[] tintColor = this.getTintColor(ray, scene);
+    if (tintColor != null) {
+      color[0] *= tintColor[0];
+      color[1] *= tintColor[1];
+      color[2] *= tintColor[2];
     }
+  }
 
-    color[0] *= tintColor[0];
-    color[1] *= tintColor[1];
-    color[2] *= tintColor[2];
+  /**
+   * Tint a color vector with the tint option of this Tint object.
+   */
+  public void tint(Vector4 color, Ray ray, Scene scene) {
+    float[] tintColor = this.getTintColor(ray, scene);
+    if (tintColor != null) {
+      color.x *= tintColor[0];
+      color.y *= tintColor[1];
+      color.z *= tintColor[2];
+    }
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
@@ -116,7 +116,7 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
 
       scene.setBiomeBlendingEnabled(newValue);
 
-      if(enabled != newValue && newValue) { // Jank to avoid not snapshotting the scene settings
+      if(enabled != newValue) {
         alertIfReloadNeeded("biome blending");
       }
     });


### PR DESCRIPTION
This also changes the tinting to not tint every hit but only the final block hit color, resulting in less biome color lookups.