### PR TITLE
Add scene refresh event plugin API.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/SceneProvider.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SceneProvider.java
@@ -17,8 +17,10 @@
  */
 package se.llbit.chunky.renderer;
 
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -50,4 +52,16 @@ public interface SceneProvider {
    * Calls the argument function on the scene while holding the scene lock.
    */
   void withEditSceneProtected(Consumer<Scene> fun);
+
+  /**
+   * Add a listener that is called when the scene state has changed.
+   */
+  @PluginApi
+  void addChangeListener(BiConsumer<ResetReason, Scene> listener);
+
+  /**
+   * Remove a listener added by {@link SceneProvider#addChangeListener(BiConsumer)}
+   */
+  @PluginApi
+  void removeChangeListener(BiConsumer<ResetReason, Scene> listener);
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -51,6 +51,7 @@ public class AsynchronousSceneManager extends Thread implements SceneManager {
     taskQueue = new LinkedBlockingQueue<>();
   }
 
+  @Override
   public SceneProvider getSceneProvider() {
     return sceneManager;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneManager.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.renderer.scene;
 
 import se.llbit.chunky.plugin.PluginApi;
+import se.llbit.chunky.renderer.SceneProvider;
 import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.World;
 import se.llbit.util.TaskTracker;
@@ -88,4 +89,9 @@ public interface SceneManager {
    * modifying the state)
    */
   Scene getScene();
+
+  /**
+   * Get the underlying scene provider.
+   */
+  SceneProvider getSceneProvider();
 }

--- a/chunky/src/test/se/llbit/chunky/renderer/MockSceneProvider.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/MockSceneProvider.java
@@ -18,6 +18,7 @@ package se.llbit.chunky.renderer;
 
 import se.llbit.chunky.renderer.scene.Scene;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 class MockSceneProvider implements SceneProvider {
@@ -47,5 +48,15 @@ class MockSceneProvider implements SceneProvider {
 
   @Override public synchronized void withEditSceneProtected(Consumer<Scene> fun) {
     // Won't be edited by the scene manager.
+  }
+
+  @Override
+  public void addChangeListener(BiConsumer<ResetReason, Scene> listener) {
+    // These aren't used yet
+  }
+
+  @Override
+  public void removeChangeListener(BiConsumer<ResetReason, Scene> listener) {
+
   }
 }


### PR DESCRIPTION
For plugins like the denoiser plugin, it would be useful to keep track of scene refresh events (to invalidate auxiliary buffers for example). Currently this is only possible (without hacks) if the plugin registers a renderer and that renderer is being used.