### PR TITLE
Remove the chunk position cache.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         options.release = 8
         options.encoding = 'UTF-8'
         options.debug = true
+        options.deprecation = true
     }
 
     javafx {

--- a/chunky/src/java/se/llbit/chunky/map/MapBuffer.java
+++ b/chunky/src/java/se/llbit/chunky/map/MapBuffer.java
@@ -111,10 +111,7 @@ public class MapBuffer {
     }
     for (int x = x0; x <= x1; ++x) {
       for (int z = z0; z <= z1; ++z) {
-        ChunkPosition pos = ChunkPosition.get(x, z);
-        if (!activeTiles.containsKey(pos)) {
-          activeTiles.put(pos, newTile(pos, newView));
-        }
+        activeTiles.computeIfAbsent(new ChunkPosition(x, z), pos -> newTile(pos, newView));
       }
     }
   }
@@ -170,7 +167,7 @@ public class MapBuffer {
     }
     for (int x = x0; x <= x1; ++x) {
       for (int z = z0; z <= z1; ++z) {
-        drawTileCached(mapLoader, ChunkPosition.get(x, z), selection);
+        drawTileCached(mapLoader, new ChunkPosition(x, z), selection);
       }
     }
   }

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -109,7 +109,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     // Enqueue visible regions and chunks to be loaded.
     for (int rx = rx0; rx <= rx1; ++rx) {
       for (int rz = rz0; rz <= rz1; ++rz) {
-        regionQueue.add(ChunkPosition.get(rx, rz));
+        regionQueue.add(new ChunkPosition(rx, rz));
       }
     }
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1376,7 +1376,7 @@ public class Scene implements JsonSerializable, Refreshable {
                         int wz = cp.z * 16 + sz;
                         for (int sy = y - 1; sy < y + 1; sy++) {
                           int wy = sectionY * 16 + sy;
-                          ChunkPosition ccp = ChunkPosition.get(wx >> 4, wz >> 4);
+                          ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
                           if (nonEmptyChunks.contains(ccp)) {
                             nsum += 1;
                             Integer id = biomePaletteIdxStructure.get(wx, wy, wz);
@@ -1431,7 +1431,7 @@ public class Scene implements JsonSerializable, Refreshable {
                   for (int sz = z - 1; sz <= z + 1; ++sz) {
                     int wz = cp.z * 16 + sz;
 
-                    ChunkPosition ccp = ChunkPosition.get(wx >> 4, wz >> 4);
+                    ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
                     if (nonEmptyChunks.contains(ccp)) {
                       nsum += 1;
                       Biome biome = biomePalette.get(biomePaletteIdxStructure.get(wx, 0, wz));
@@ -3089,7 +3089,7 @@ public class Scene implements JsonSerializable, Refreshable {
         int x = chunk.get(0).intValue(Integer.MAX_VALUE);
         int z = chunk.get(1).intValue(Integer.MAX_VALUE);
         if (x != Integer.MAX_VALUE && z != Integer.MAX_VALUE) {
-          chunks.add(ChunkPosition.get(x, z));
+          chunks.add(new ChunkPosition(x, z));
         }
       }
     }

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -99,8 +99,8 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
    * Indicates whether or not the selection rectangle should be drawn.
    */
   protected volatile boolean selectRect = false;
-  protected volatile ChunkPosition start = ChunkPosition.get(0, 0);
-  protected volatile ChunkPosition end = ChunkPosition.get(0, 0);
+  protected volatile ChunkPosition start = new ChunkPosition(0, 0);
+  protected volatile ChunkPosition end = new ChunkPosition(0, 0);
   protected boolean ctrlModifier = false;
   protected boolean shiftModifier = false;
   protected boolean dragging = false;

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -228,7 +228,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       int minChunkZ = region.z << 5;
       for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
         for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
-          mapBuffer.drawTile(mapLoader, ChunkPosition.get(chunkX, chunkZ), chunkSelection);
+          mapBuffer.drawTile(mapLoader, new ChunkPosition(chunkX, chunkZ), chunkSelection);
         }
       }
       repaintRatelimited();
@@ -479,7 +479,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     // Calculate the world block position of the cursor
     int worldBlockX = cx * Chunk.X_MAX + bx;
     int worldBlockZ = cz * Chunk.Z_MAX + bz;
-    ChunkPosition cp = ChunkPosition.get(cx, cz);
+    ChunkPosition cp = new ChunkPosition(cx, cz);
     if (!mouseDown) {
       Chunk hoveredChunk = mapLoader.getWorld().getChunk(cp);
       if (!hoveredChunk.isEmpty()) {

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -371,7 +371,7 @@ public class Chunk {
   protected void queueTopography() {
     for (int x = -1; x <= 1; ++x) {
       for (int z = -1; z <= 1; ++z) {
-        ChunkPosition pos = ChunkPosition.get(position.x + x, position.z + z);
+        ChunkPosition pos = new ChunkPosition(position.x + x, position.z + z);
         Chunk chunk = world.getChunk(pos);
         if (!chunk.isEmpty()) {
           world.chunkTopographyUpdated(chunk);

--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -1,4 +1,5 @@
-/* Copyright (c) 2010-2012 Jesper Öqvist <jesper@llbit.se>
+/* Copyright (c) 2010-2022 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2010-2022 Chunky Contributors
  *
  * This file is part of Chunky.
  *
@@ -18,10 +19,6 @@ package se.llbit.chunky.world;
 
 /**
  * A chunk position consists of two integer coordinates x and z.
- * <p>
- * The filename of a chunk is uniquely defined by it's position.
- *
- * @author Jesper Öqvist (jesper@llbit.se)
  */
 public class ChunkPosition {
 
@@ -37,20 +34,8 @@ public class ChunkPosition {
     this(longPositionX(position), longPositionZ(position));
   }
 
-  public static long positionToLong(int x, int z) {
-    return (z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32;
-  }
-
-  public static int longPositionX(long position) {
-    return (int) (position >>> 32);
-  }
-
-  public static int longPositionZ(long position) {
-    return (int) position;
-  }
-
   /**
-   * @return The long representation of the chunk position
+   * @return This chunk position packed into a long.
    */
   public long getLong() {
     return positionToLong(x, z);
@@ -68,6 +53,27 @@ public class ChunkPosition {
    */
   public ChunkPosition getRegionPosition() {
     return new ChunkPosition(x >> 5, z >> 5);
+  }
+
+  /**
+   * @return The packed {@code long} chunk position for the x and z
+   */
+  public static long positionToLong(int x, int z) {
+    return (z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32;
+  }
+
+  /**
+   * @return The {@code X} component of the packed long position
+   */
+  public static int longPositionX(long position) {
+    return (int) (position >>> 32);
+  }
+
+  /**
+   * @return The {@code Z} component of the packed long position
+   */
+  public static int longPositionZ(long position) {
+    return (int) position;
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -34,11 +34,19 @@ public class ChunkPosition {
   }
 
   public ChunkPosition(long position) {
-    this((int) (position >>> 32), (int) position);
+    this(longPositionX(position), longPositionZ(position));
   }
 
   public static long positionToLong(int x, int z) {
     return (z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32;
+  }
+
+  public static int longPositionX(long position) {
+    return (int) (position >>> 32);
+  }
+
+  public static int longPositionZ(long position) {
+    return (int) position;
   }
 
   /**
@@ -59,7 +67,7 @@ public class ChunkPosition {
    * @return The region position of this chunk position
    */
   public ChunkPosition getRegionPosition() {
-    return get(x >> 5, z >> 5);
+    return new ChunkPosition(x >> 5, z >> 5);
   }
 
   @Override
@@ -81,13 +89,16 @@ public class ChunkPosition {
     return 31 * x + z;
   }
 
+  /**
+   * @deprecated Use {@link ChunkPosition#getRegionPosition()}. Remove in 2.6.
+   */
   @Deprecated
   public ChunkPosition regionPosition() {
-    return get(x >> 5, z >> 5);
+    return getRegionPosition();
   }
 
   /**
-   * @return Integer representation of chunk position
+   * @deprecated Remove in 2.6.
    */
   @Deprecated
   public int getInt() {
@@ -95,13 +106,16 @@ public class ChunkPosition {
   }
 
   /**
-   * @return Decoded chunk position
+   * @deprecated Use {@link ChunkPosition#ChunkPosition(int, int)}. Remove in 2.6.
    */
   @Deprecated
   public static ChunkPosition get(long longValue) {
     return new ChunkPosition(longValue);
   }
 
+  /**
+   * @deprecated Use {@link ChunkPosition#ChunkPosition(long)}. Remove in 2.6.
+   */
   @Deprecated
   public static ChunkPosition get(int x, int z) {
     return new ChunkPosition(x, z);

--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -16,9 +16,6 @@
  */
 package se.llbit.chunky.world;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 /**
  * A chunk position consists of two integer coordinates x and z.
  * <p>
@@ -28,38 +25,20 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ChunkPosition {
 
-  public int x, z;
+  public final int x;
+  public final int z;
 
-  private ChunkPosition(int x, int z) {
+  public ChunkPosition(int x, int z) {
     this.x = x;
     this.z = z;
   }
 
-  @Override
-  public String toString() {
-    return "[" + x + ", " + z + "]";
-  }
-
-  public ChunkPosition regionPosition() {
-    return get(x >> 5, z >> 5);
-  }
-
-  //not using synchronized Long2ReferenceOpenHashMap due to using one lock. ConcurrentHashMap locks on buckets
-  private static final Map<Long, ChunkPosition> positions = new ConcurrentHashMap<>();
-
-  public static ChunkPosition get(int x, int z) {
-    return positions.computeIfAbsent(positionToLong(x, z), (position) -> new ChunkPosition(x, z));
+  public ChunkPosition(long position) {
+    this((int) (position >>> 32), (int) position);
   }
 
   public static long positionToLong(int x, int z) {
     return (z & 0xFFFFFFFFL) | (x & 0xFFFFFFFFL) << 32;
-  }
-
-  /**
-   * @return The .mca name for the region with this position
-   */
-  public String getMcaName() {
-    return String.format("r.%d.%d.mca", x, z);
   }
 
   /**
@@ -70,23 +49,61 @@ public class ChunkPosition {
   }
 
   /**
-   * @return Decoded chunk position
+   * @return The .mca name for the region with this position
    */
-  public static ChunkPosition get(long longValue) {
-    return get((int) (longValue >>> 32), (int) longValue);
+  public String getMcaName() {
+    return String.format("r.%d.%d.mca", x, z);
+  }
+
+  /**
+   * @return The region position of this chunk position
+   */
+  public ChunkPosition getRegionPosition() {
+    return get(x >> 5, z >> 5);
+  }
+
+  @Override
+  public String toString() {
+    return "[" + x + ", " + z + "]";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ChunkPosition) {
+      ChunkPosition other = (ChunkPosition) o;
+      return this.x == other.x && this.z == other.z;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * x + z;
+  }
+
+  @Deprecated
+  public ChunkPosition regionPosition() {
+    return get(x >> 5, z >> 5);
   }
 
   /**
    * @return Integer representation of chunk position
    */
+  @Deprecated
   public int getInt() {
     return (x << 16) | (0xFFFF & z);
   }
 
   /**
-   * @return The region position of a this chunk position
+   * @return Decoded chunk position
    */
-  public ChunkPosition getRegionPosition() {
-    return get(x >> 5, z >> 5);
+  @Deprecated
+  public static ChunkPosition get(long longValue) {
+    return new ChunkPosition(longValue);
+  }
+
+  @Deprecated
+  public static ChunkPosition get(int x, int z) {
+    return new ChunkPosition(x, z);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -85,7 +85,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
         int bitIndex = (chunkX & 31) + ((chunkZ & 31) << 5);
         boolean previousValue = selectedChunksForRegion.get(bitIndex);
         if(previousValue != selected) {
-          ChunkPosition chunkPos = ChunkPosition.get(chunkX, chunkZ);
+          ChunkPosition chunkPos = new ChunkPosition(chunkX, chunkZ);
           Chunk chunk = world.getChunk(chunkPos);
           if(chunk != EmptyRegionChunk.INSTANCE && chunk != EmptyChunk.INSTANCE) {
             selectionChanged = true;
@@ -204,7 +204,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    * @param cz    chunk z-position
    */
   public synchronized void toggleChunk(World world, int cx, int cz) {
-    ChunkPosition chunk = ChunkPosition.get(cx, cz);
+    ChunkPosition chunk = new ChunkPosition(cx, cz);
     if (isChunkSelected(chunk)) {
       setChunk(world, chunk, false);
     } else if (!world.getChunk(chunk).isEmpty()) {
@@ -220,7 +220,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    * @param cz chunk z-position
    */
   public synchronized void selectChunk(World world, int cx, int cz) {
-    ChunkPosition chunk = ChunkPosition.get(cx, cz);
+    ChunkPosition chunk = new ChunkPosition(cx, cz);
     if (!world.getChunk(chunk).isEmpty()) {
       setChunk(world, chunk, true);
       notifyChunkSelectionChange();
@@ -234,8 +234,8 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    * @param cz chunk z-position
    */
   public synchronized void toggleRegion(World world, int cx, int cz) {
-    ChunkPosition chunk = ChunkPosition.get(cx, cz);
-    setRegion(world, ChunkPosition.get(cx >> 5, cz >> 5), !isChunkSelected(chunk));
+    ChunkPosition chunk = new ChunkPosition(cx, cz);
+    setRegion(world, new ChunkPosition(cx >> 5, cz >> 5), !isChunkSelected(chunk));
     notifyChunkSelectionChange();
   }
 
@@ -277,10 +277,10 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
         for (int regionZ = minRegionZ; regionZ < maxRegionZ + 1; regionZ++) {
           if(regionX >= minInnerRegionX && regionX < maxInnerRegionX && regionZ >= minInnerRegionZ && regionZ < maxInnerRegionZ) {
             // this region is an inner region, we set all chunks within it
-            selectionChanged |= setRegion(world, ChunkPosition.get(regionX, regionZ), selected);
+            selectionChanged |= setRegion(world, new ChunkPosition(regionX, regionZ), selected);
           } else {
             // this region is an outer region, we set only the chunks within the bounds of the selection area
-            selectionChanged |= setChunksWithinRegion(world, ChunkPosition.get(regionX, regionZ),
+            selectionChanged |= setChunksWithinRegion(world, new ChunkPosition(regionX, regionZ),
               Math.max(regionX << 5, minChunkX), Math.min(((regionX + 1) << 5) - 1, maxChunkX),
               Math.max(regionZ << 5, minChunkZ), Math.min(((regionZ + 1) << 5) - 1, maxChunkZ),
               selected);
@@ -297,7 +297,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
 
       for (int regionX = minRegionX; regionX < maxRegionX + 1; regionX++) {
         for (int regionZ = minRegionZ; regionZ < maxRegionZ + 1; regionZ++) {
-          selectionChanged |= setChunksWithinRegion(world, ChunkPosition.get(regionX, regionZ),
+          selectionChanged |= setChunksWithinRegion(world, new ChunkPosition(regionX, regionZ),
             Math.max(regionX << 5, minChunkX), Math.min(((regionX + 1) << 5) - 1, maxChunkX),
             Math.max(regionZ << 5, minChunkZ), Math.min(((regionZ + 1) << 5) - 1, maxChunkZ),
             selected);
@@ -320,7 +320,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
       Enumeration<Long> keys = selectedChunksByRegion.keys();
       Collection<ChunkPosition> regionPositions = new ArrayList<>();
       while (keys.hasMoreElements()) {
-        regionPositions.add(ChunkPosition.get(keys.nextElement()));
+        regionPositions.add(new ChunkPosition(keys.nextElement()));
       }
 
       selectedChunksByRegion.clear();
@@ -363,17 +363,17 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
   public synchronized Map<ChunkPosition, List<ChunkPosition>> getSelectionByRegion() {
     Map<ChunkPosition, List<ChunkPosition>> selectedChunksByRegionPosition = new Object2ReferenceOpenHashMap<>();
     selectedChunksByRegion.forEach((regionPosition, selectedChunksBitSet) -> {
-      ChunkPosition regionPos = ChunkPosition.get(regionPosition);
+      ChunkPosition regionPos = new ChunkPosition(regionPosition);
       List<ChunkPosition> positions = new ArrayList<>();
       for (int localX = 0; localX < MCRegion.CHUNKS_X; localX++) {
         for (int localZ = 0; localZ < MCRegion.CHUNKS_Z; localZ++) {
           int idx = localX + (localZ * MCRegion.CHUNKS_X);
           if(selectedChunksBitSet.get(idx)) {
-            positions.add(ChunkPosition.get((regionPos.x << 5) + localX, (regionPos.z << 5) + localZ));
+            positions.add(new ChunkPosition((regionPos.x << 5) + localX, (regionPos.z << 5) + localZ));
           }
         }
       }
-      selectedChunksByRegionPosition.put(ChunkPosition.get(regionPosition), positions);
+      selectedChunksByRegionPosition.put(new ChunkPosition(regionPosition), positions);
     });
     return selectedChunksByRegionPosition;
   }

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -42,7 +42,7 @@ public class EmptyChunk extends Chunk {
   }
 
   private EmptyChunk() {
-    super(ChunkPosition.get(0, 0), EmptyWorld.INSTANCE);
+    super(new ChunkPosition(0, 0), EmptyWorld.INSTANCE);
     surface = IconLayer.CORRUPT;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -42,7 +42,7 @@ public class EmptyRegionChunk extends Chunk {
   }
 
   private EmptyRegionChunk() {
-    super(ChunkPosition.get(0, 0), EmptyWorld.INSTANCE);
+    super(new ChunkPosition(0, 0), EmptyWorld.INSTANCE);
     surface = IconLayer.CORRUPT;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -456,9 +456,9 @@ public class World implements Comparable<World> {
     Map<ChunkPosition, Set<ChunkPosition>> regionMap = new HashMap<>();
 
     for (ChunkPosition chunk : chunks) {
-      ChunkPosition regionPosition = chunk.regionPosition();
+      ChunkPosition regionPosition = chunk.getRegionPosition();
       Set<ChunkPosition> chunkSet = regionMap.computeIfAbsent(regionPosition, k -> new HashSet<>());
-      chunkSet.add(ChunkPosition.get(chunk.x & 31, chunk.z & 31));
+      chunkSet.add(new ChunkPosition(chunk.x & 31, chunk.z & 31));
     }
 
     int work = 0;
@@ -503,7 +503,7 @@ public class World implements Comparable<World> {
     regions.clear();
 
     WorldScanner.Operator operator = (regionDirectory, x, z) ->
-        regions.add(new Pair<>(regionDirectory, ChunkPosition.get(x, z)));
+        regions.add(new Pair<>(regionDirectory, new ChunkPosition(x, z)));
     // TODO make this more dynamic
     File overworld = getRegionDirectory(OVERWORLD_DIMENSION);
     WorldScanner.findExistingChunks(overworld, operator);

--- a/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
+++ b/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
@@ -34,7 +34,7 @@ public interface ChunkUpdateListener {
     int minChunkZ = region.z << 5;
     for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
       for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
-        this.chunkUpdated(ChunkPosition.get(chunkX, chunkZ));
+        this.chunkUpdated(new ChunkPosition(chunkX, chunkZ));
       }
     }
   }

--- a/chunky/src/java/se/llbit/chunky/world/region/CubicRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/CubicRegionChangeWatcher.java
@@ -26,9 +26,9 @@ public class CubicRegionChangeWatcher extends RegionChangeWatcher {
         ChunkView theView = view;
         for (int rx = theView.prx0; rx <= theView.prx1; ++rx) {
           for (int rz = theView.prz0; rz <= theView.prz1; ++rz) {
-            Region region = world.getRegionWithinRange(ChunkPosition.get(rx, rz), theView.yMin, theView.yMax);
+            Region region = world.getRegionWithinRange(new ChunkPosition(rx, rz), theView.yMin, theView.yMax);
             if (region.isEmpty()) {
-              ChunkPosition pos = ChunkPosition.get(rx, rz);
+              ChunkPosition pos = new ChunkPosition(rx, rz);
               if (world.regionExistsWithinRange(pos, theView.yMin, theView.yMax)) {
                 region = world.createRegion(pos);
               }

--- a/chunky/src/java/se/llbit/chunky/world/region/EmptyRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/EmptyRegion.java
@@ -29,7 +29,7 @@ import java.util.NoSuchElementException;
  * @author Jesper Öqvist <jesper@llbit.se>
  */
 public class EmptyRegion implements Region {
-  private static final ChunkPosition position = ChunkPosition.get(0,0);
+  private static final ChunkPosition position = new ChunkPosition(0,0);
 
   /**
    * Singleton instance.

--- a/chunky/src/java/se/llbit/chunky/world/region/ImposterCubicRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/ImposterCubicRegion.java
@@ -53,7 +53,7 @@ public class ImposterCubicRegion implements Region {
   public ImposterCubicRegion(ChunkPosition pos, World world) {
     this.world = world;
     mcRegionPos = pos;
-    min3drPosition = ChunkPosition.get(mcRegionToMinCubicRegion(pos.x), mcRegionToMinCubicRegion(pos.z));
+    min3drPosition = new ChunkPosition(mcRegionToMinCubicRegion(pos.x), mcRegionToMinCubicRegion(pos.z));
     for (int z = 0; z < DIAMETER_IN_VANILLA_CHUNKS; ++z) {
       for (int x = 0; x < DIAMETER_IN_VANILLA_CHUNKS; ++x) {
         chunks[x + z * 32] = EmptyChunk.INSTANCE;
@@ -172,7 +172,7 @@ public class ImposterCubicRegion implements Region {
     //Create marked any columns, delete any unmarked
     for (int localZ = 0; localZ < DIAMETER_IN_VANILLA_CHUNKS; localZ++) {
       for (int localX = 0; localX < DIAMETER_IN_VANILLA_CHUNKS; localX++) {
-        ChunkPosition pos = ChunkPosition.get(mcRegionToChunk(mcRegionPos.x, localX), mcRegionToChunk(mcRegionPos.z, localZ));
+        ChunkPosition pos = new ChunkPosition(mcRegionToChunk(mcRegionPos.x, localX), mcRegionToChunk(mcRegionPos.z, localZ));
         Chunk chunk = getChunk(localX, localZ);
         if (columnsWithCubes.get(localX + localZ*DIAMETER_IN_VANILLA_CHUNKS)) {
           if(chunk.isEmpty()) {

--- a/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
@@ -137,7 +137,7 @@ public class MCRegion implements Region {
 
       for (int z = 0; z < 32; ++z) {
         for (int x = 0; x < 32; ++x) {
-          ChunkPosition pos = ChunkPosition.get((position.x << 5) + x, (position.z << 5) + z);
+          ChunkPosition pos = new ChunkPosition((position.x << 5) + x, (position.z << 5) + z);
           Chunk chunk = getChunk(x, z);
           int loc = file.readInt();
           if (loc != 0) {
@@ -327,7 +327,7 @@ public class MCRegion implements Region {
       for (int i = 0; i < 32 * 32; ++i) {
         location[i] = file.readInt();
         int offset = location[i];
-        if (offset != 0 && (chunks == null || chunks.contains(ChunkPosition.get(i & 31, i >> 5)))) {
+        if (offset != 0 && (chunks == null || chunks.contains(new ChunkPosition(i & 31, i >> 5)))) {
           loc_out[i] = nextFree << 8 | offset & 0xFF;
           nextFree += offset & 0xFF;
         }

--- a/chunky/src/java/se/llbit/chunky/world/region/MCRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/MCRegionChangeWatcher.java
@@ -47,9 +47,9 @@ public class MCRegionChangeWatcher extends RegionChangeWatcher {
         ChunkView theView = view;
         for (int rx = theView.prx0; rx <= theView.prx1; ++rx) {
           for (int rz = theView.prz0; rz <= theView.prz1; ++rz) {
-            Region region = world.getRegion(ChunkPosition.get(rx, rz));
+            ChunkPosition pos = new ChunkPosition(rx, rz);
+            Region region = world.getRegion(pos);
             if (region.isEmpty()) {
-              ChunkPosition pos = ChunkPosition.get(rx, rz);
               if (world.regionExists(pos)) {
                 region = world.createRegion(pos);
               }
@@ -59,8 +59,7 @@ public class MCRegionChangeWatcher extends RegionChangeWatcher {
               mapLoader.regionUpdated(pos);
             } else if (region.hasChanged()) {
               region.parse(theView.yMin, theView.yMax);
-              ChunkPosition pos = region.getPosition();
-              mapLoader.regionUpdated(pos);
+              mapLoader.regionUpdated(region.getPosition());
             }
           }
         }


### PR DESCRIPTION
Previously `ChunkPosition` objects were compared by identity and were cached to make this possible. This removes that cache and implements equality and hashing logic to `ChunkPosition` so they can be created with `new`. This allows the JVM to do more optimizations (such as allocating on the stack).

Tests run on 1 region of Greenfield. On first run, the loading times are comparable: 4.190s (this) vs 4.206s (master). On subsequent runs the loading times is up to 12% faster: 2.098s (this) vs. 2.406s (master).