### PR TITLE
Add context menu transformers for map and render view.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -23,6 +23,7 @@ import se.llbit.chunky.block.BlockSpec;
 import se.llbit.chunky.block.MinecraftBlockProvider;
 import se.llbit.chunky.block.legacy.LegacyMinecraftBlockProvider;
 import se.llbit.chunky.main.CommandLineOptions.Mode;
+import se.llbit.chunky.plugin.ContextMenuTransformer;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.plugin.ChunkyPlugin;
 import se.llbit.chunky.plugin.TabTransformer;
@@ -53,7 +54,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 
@@ -90,6 +93,8 @@ public class Chunky {
   private RenderManagerFactory renderManagerFactory = DefaultRenderManager::new;
   private RenderControlsTabTransformer renderControlsTabTransformer = tabs -> tabs;
   private TabTransformer mainTabTransformer = tabs -> tabs;
+  private final ArrayList<ContextMenuTransformer> mapContextMenuTransformers = new ArrayList<>();
+  private final ArrayList<ContextMenuTransformer> renderContextMenuTransformers = new ArrayList<>();
   private boolean headless = false;
 
   private static ForkJoinPool commonThreads;
@@ -470,6 +475,23 @@ public class Chunky {
   @PluginApi
   public TabTransformer getMainTabTransformer() {
     return mainTabTransformer;
+  }
+
+  /**
+   * Get the mutable list of context menu transformers in the main map view.
+   */
+  @PluginApi
+  public List<ContextMenuTransformer> getMapContextMenuTransformers() {
+    return this.mapContextMenuTransformers;
+  }
+
+
+  /**
+   * Get the mutable list of context menu transformers in the main render view.
+   */
+  @PluginApi
+  public List<ContextMenuTransformer> getRenderContextMenuTransformers() {
+    return this.renderContextMenuTransformers;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/plugin/ContextMenuTransformer.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/ContextMenuTransformer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.plugin;
+
+import javafx.scene.control.ContextMenu;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface ContextMenuTransformer extends Consumer<ContextMenu> {
+}

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -203,6 +203,10 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
         new SeparatorMenuItem(),
         deleteChunks);
 
+    controller.getChunky()
+      .getMapContextMenuTransformers()
+      .forEach(t -> t.accept(contextMenu));
+
     chunkSelection.addSelectionListener(() -> {
       boolean noChunksSelected = chunkSelection.size() == 0;
       clearSelection.setDisable(noChunksSelected);

--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -237,6 +237,10 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     copyFrame.setOnAction(e -> chunkyFxController.copyCurrentFrame());
     contextMenu.getItems().add(copyFrame);
 
+    chunkyFxController.getChunky()
+      .getRenderContextMenuTransformers()
+      .forEach(t -> t.accept(contextMenu));
+
     canvas.setOnMouseClicked(event -> {
       if (event.getButton() == MouseButton.SECONDARY) {
         double invHeight = 1.0 / canvas.getHeight();


### PR DESCRIPTION
These transformers can be used to add more context menu items to the map and render displays. (ie. buttons for map editor plugin or show albedo/normal/beauty/denoised for denoiser).