### PR TITLE
Automatically hide and collapse `Water` tab panels

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
@@ -171,6 +171,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
 
     waterWorldModeDetailsPane.visibleProperty().set(waterPlaneEnabled.isSelected());
     waterWorldModeDetailsPane.expandedProperty().set(waterPlaneEnabled.isSelected());
+    waterWorldModeDetailsPane.managedProperty().set(waterPlaneEnabled.isSelected());
 
     waterPlaneEnabled.setTooltip(
       new Tooltip("If enabled, an infinite ocean fills the scene. This ignores air from loaded chunks."));
@@ -178,6 +179,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       scene.setWaterPlaneEnabled(newValue);
       waterWorldModeDetailsPane.setVisible(newValue);
       waterWorldModeDetailsPane.setExpanded(newValue);
+      waterWorldModeDetailsPane.setManaged(newValue);
     });
 
     waterPlaneHeight.setName("Water height");
@@ -196,6 +198,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
 
     proceduralWaterDetailsPane.visibleProperty().set(useProceduralWater.isSelected());
     proceduralWaterDetailsPane.expandedProperty().set(useProceduralWater.isSelected());
+    proceduralWaterDetailsPane.managedProperty().set(useProceduralWater.isSelected());
 
     useProceduralWater.setTooltip(new Tooltip("Generate customized water waves using noise to prevent tiling at large distances."));
     useProceduralWater.selectedProperty().addListener((observable, oldValue, newValue) -> {
@@ -213,6 +216,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       }
       proceduralWaterDetailsPane.setVisible(newValue);
       proceduralWaterDetailsPane.setExpanded(newValue);
+      proceduralWaterDetailsPane.setManaged(newValue);
     });
 
     proceduralWaterIterations.setName("Iterations");

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
@@ -169,11 +169,16 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       }
     });
 
+    waterWorldModeDetailsPane.visibleProperty().set(waterPlaneEnabled.isSelected());
+    waterWorldModeDetailsPane.expandedProperty().set(waterPlaneEnabled.isSelected());
+
     waterPlaneEnabled.setTooltip(
       new Tooltip("If enabled, an infinite ocean fills the scene. This ignores air from loaded chunks."));
-    waterPlaneEnabled.selectedProperty().addListener((observable, oldValue, newValue) ->
-      scene.setWaterPlaneEnabled(newValue)
-    );
+    waterPlaneEnabled.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      scene.setWaterPlaneEnabled(newValue);
+      waterWorldModeDetailsPane.setVisible(newValue);
+      waterWorldModeDetailsPane.setExpanded(newValue);
+    });
 
     waterPlaneHeight.setName("Water height");
     waterPlaneHeight.setTooltip("The default ocean height is " + World.SEA_LEVEL + ".");
@@ -188,8 +193,9 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneChunkClip(newValue)
     );
-    waterWorldModeDetailsPane.visibleProperty().bind(waterPlaneEnabled.selectedProperty());
-    waterWorldModeDetailsPane.expandedProperty().bind(waterPlaneEnabled.selectedProperty());
+
+    proceduralWaterDetailsPane.visibleProperty().set(useProceduralWater.isSelected());
+    proceduralWaterDetailsPane.expandedProperty().set(useProceduralWater.isSelected());
 
     useProceduralWater.setTooltip(new Tooltip("Generate customized water waves using noise to prevent tiling at large distances."));
     useProceduralWater.selectedProperty().addListener((observable, oldValue, newValue) -> {
@@ -205,9 +211,9 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
         scene.setWaterShading(new LegacyWaterShader());
         scene.refresh();
       }
+      proceduralWaterDetailsPane.setVisible(newValue);
+      proceduralWaterDetailsPane.setExpanded(newValue);
     });
-    proceduralWaterDetailsPane.visibleProperty().bind(useProceduralWater.selectedProperty());
-    proceduralWaterDetailsPane.expandedProperty().bind(useProceduralWater.selectedProperty());
 
     proceduralWaterIterations.setName("Iterations");
     proceduralWaterIterations.setTooltip("The number of iterations (layers) of noise used");

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
@@ -169,9 +169,9 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       }
     });
 
-    waterWorldModeDetailsPane.visibleProperty().set(waterPlaneEnabled.isSelected());
-    waterWorldModeDetailsPane.expandedProperty().set(waterPlaneEnabled.isSelected());
-    waterWorldModeDetailsPane.managedProperty().set(waterPlaneEnabled.isSelected());
+    waterWorldModeDetailsPane.setVisible(waterPlaneEnabled.isSelected());
+    waterWorldModeDetailsPane.setExpanded(waterPlaneEnabled.isSelected());
+    waterWorldModeDetailsPane.setManaged(waterPlaneEnabled.isSelected());
 
     waterPlaneEnabled.setTooltip(
       new Tooltip("If enabled, an infinite ocean fills the scene. This ignores air from loaded chunks."));
@@ -196,9 +196,9 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       scene.setWaterPlaneChunkClip(newValue)
     );
 
-    proceduralWaterDetailsPane.visibleProperty().set(useProceduralWater.isSelected());
-    proceduralWaterDetailsPane.expandedProperty().set(useProceduralWater.isSelected());
-    proceduralWaterDetailsPane.managedProperty().set(useProceduralWater.isSelected());
+    proceduralWaterDetailsPane.setVisible(useProceduralWater.isSelected());
+    proceduralWaterDetailsPane.setExpanded(useProceduralWater.isSelected());
+    proceduralWaterDetailsPane.setManaged(useProceduralWater.isSelected());
 
     useProceduralWater.setTooltip(new Tooltip("Generate customized water waves using noise to prevent tiling at large distances."));
     useProceduralWater.selectedProperty().addListener((observable, oldValue, newValue) -> {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
@@ -56,6 +56,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
   @FXML private DoubleAdjuster waterPlaneHeight;
   @FXML private CheckBox waterPlaneOffsetEnabled;
   @FXML private CheckBox waterPlaneClip;
+  @FXML private TitledPane waterWorldModeDetailsPane;
   @FXML private CheckBox useProceduralWater;
   @FXML private IntegerAdjuster proceduralWaterIterations;
   @FXML private DoubleAdjuster proceduralWaterFrequency;
@@ -187,6 +188,8 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneChunkClip(newValue)
     );
+    waterWorldModeDetailsPane.visibleProperty().bind(waterPlaneEnabled.selectedProperty());
+    waterWorldModeDetailsPane.expandedProperty().bind(waterPlaneEnabled.selectedProperty());
 
     useProceduralWater.setTooltip(new Tooltip("Generate customized water waves using noise to prevent tiling at large distances."));
     useProceduralWater.selectedProperty().addListener((observable, oldValue, newValue) -> {
@@ -204,6 +207,7 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
       }
     });
     proceduralWaterDetailsPane.visibleProperty().bind(useProceduralWater.selectedProperty());
+    proceduralWaterDetailsPane.expandedProperty().bind(useProceduralWater.selectedProperty());
 
     proceduralWaterIterations.setName("Iterations");
     proceduralWaterIterations.setTooltip("The number of iterations (layers) of noise used");

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
@@ -17,7 +17,7 @@
       <Label text="Sky mode:" />
       <ChoiceBox fx:id="skyMode" prefWidth="150.0" />
     </HBox>
-    <TitledPane fx:id="detailsPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" text="Sky mode settings">
+    <TitledPane fx:id="detailsPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" animated="false" text="Sky mode settings">
       <VBox.margin>
         <Insets />
       </VBox.margin>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/WaterTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/WaterTab.fxml
@@ -24,7 +24,7 @@
     <Button fx:id="saveDefaults" mnemonicParsing="false" text="Save as defaults" />
     <Separator prefWidth="200.0" />
     <CheckBox fx:id="waterPlaneEnabled" mnemonicParsing="false" text="Water world mode" />
-    <TitledPane fx:id="waterWorldModeDetailsPane" text="Water world mode settings">
+    <TitledPane fx:id="waterWorldModeDetailsPane" animated="false" text="Water world mode settings">
       <VBox spacing="10.0">
         <padding>
           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
@@ -35,7 +35,7 @@
       </VBox>
     </TitledPane>
     <CheckBox fx:id="useProceduralWater" mnemonicParsing="false" text="Procedural water" />
-    <TitledPane fx:id="proceduralWaterDetailsPane" text="Procedural water settings">
+    <TitledPane fx:id="proceduralWaterDetailsPane" animated="false" text="Procedural water settings">
       <VBox spacing="10.0">
         <padding>
           <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />


### PR DESCRIPTION
Fixes #1454.

- Hide and collapse `Water world mode settings` panel if `Water world mode` is disabled.

- Hide and collapse `Procedural water settings` panel if `Procedural water` is disabled.

- Set the animated property of aforementioned panels and the `Sky mode settings` panel to false.

**Collapsed and hidden when disabled:**
![image](https://user-images.githubusercontent.com/92183530/194064914-58cc166e-8af1-4c8e-8a1d-2233147c82e5.png)

**Expanded and shown when enabled:**
![image](https://user-images.githubusercontent.com/92183530/194064995-08db982c-7508-4c9d-96f9-92b7c54ad9c6.png)
