### PR TITLE
Reorganize `Scene` tab and add `<Separator />`s to the `Lighting` and `Sky & Fog` tabs

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -87,6 +87,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
   @FXML private CheckBox loadOtherEntities;
   @FXML private CheckBox saveDumps;
   @FXML private CheckBox saveSnapshots;
+  @FXML private TitledPane dumpSettings;
   @FXML private ComboBox<Number> dumpFrequency;
   @FXML private IntegerAdjuster yMin;
   @FXML private IntegerAdjuster yMax;
@@ -292,6 +293,8 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       } else {
         scene.setDumpFrequency(0);
       }
+      dumpSettings.setVisible(enable);
+      dumpSettings.setExpanded(enable);
     });
     saveSnapshots.selectedProperty().addListener((observable1, oldValue1, newValue1) -> {
       scene.setSaveSnapshots(newValue1);

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -282,6 +282,11 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
         scene.setDumpFrequency(0);
       }
     });
+
+    dumpSettings.visibleProperty().set(saveDumps.isSelected());
+    dumpSettings.expandedProperty().set(saveDumps.isSelected());
+    dumpSettings.managedProperty().set(saveDumps.isSelected());
+
     saveDumps.setTooltip(new Tooltip("Save render progress every time a multiple of the specified number of SPP has been reached."));
     saveDumps.selectedProperty().addListener((observable, oldValue, enable) -> {
       dumpFrequency.setDisable(!enable);
@@ -295,25 +300,31 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       }
       dumpSettings.setVisible(enable);
       dumpSettings.setExpanded(enable);
+      dumpSettings.setManaged(enable);
     });
+
     saveSnapshots.selectedProperty().addListener((observable1, oldValue1, newValue1) -> {
       scene.setSaveSnapshots(newValue1);
     });
+
     yMax.setTooltip(
         "Blocks above this Y value are not loaded. Requires reloading chunks to take effect.");
     yMax.onValueChange(value -> {
       scene.setYClipMax(value);
       renderControls.showPopup("Reload the chunks for this to take effect.", yMax);
     });
+
     yMin.setTooltip(
         "Blocks below this Y value are not loaded. Requires reloading chunks to take effect.");
     yMin.onValueChange(value -> {
       scene.setYClipMin(value);
       renderControls.showPopup("Reload the chunks for this to take effect.", yMax);
     });
+
     openSceneDirBtn.setTooltip(
         new Tooltip("Open the directory where Chunky stores the scene description and renders of this scene."));
     openSceneDirBtn.setOnAction(e -> chunkyFxController.openDirectory(chunkyFxController.getRenderController().getContext().getSceneDirectory()));
+
     loadSelectedChunks
         .setTooltip(new Tooltip("Load the chunks that are currently selected in the map view"));
     loadSelectedChunks.setOnAction(e -> {
@@ -321,6 +332,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
           .loadChunks(mapLoader.getWorld(), chunkyFxController.getChunkSelection().getSelection());
       reloadChunks.setDisable(chunkyFxController.getChunkSelection().isEmpty());
     });
+
     reloadChunks.setTooltip(new Tooltip("Reload all chunks in the scene."));
     reloadChunks.setGraphic(new ImageView(Icon.reload.fxImage()));
     reloadChunks.setOnAction(e -> controller.getSceneManager().reloadChunks());

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -9,16 +9,49 @@
 
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
+    <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open scene directory" />
+    <Separator />
     <FlowPane hgap="10" vgap="10">
-      <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open scene directory" />
       <Button fx:id="exportSettings" mnemonicParsing="false" text="Export settings" />
       <Button fx:id="importSettings" mnemonicParsing="false" text="Import settings" />
       <Button fx:id="restoreDefaults" mnemonicParsing="false" text="Restore default settings" />
     </FlowPane>
-    <HBox spacing="10.0">
-      <Button fx:id="loadSelectedChunks" mnemonicParsing="false" text="Load selected chunks" />
-      <Button fx:id="reloadChunks" mnemonicParsing="false" text="Reload chunks" />
-    </HBox>
+    <Separator />
+    <VBox spacing="10.0">
+      <HBox spacing="10.0">
+        <Button fx:id="loadSelectedChunks" mnemonicParsing="false" text="Load selected chunks" />
+        <Button fx:id="reloadChunks" mnemonicParsing="false" text="Reload chunks" />
+      </HBox>
+      <TitledPane collapsible="false" animated="false" text="Scene Y clip">
+        <VBox spacing="10.0">
+          <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <IntegerAdjuster fx:id="yMin" name="Min Y level" />
+            <Button fx:id="setDefaultYMin" mnemonicParsing="false" text="Set default" />
+          </HBox>
+          <HBox alignment="CENTER_LEFT" spacing="10.0">
+            <IntegerAdjuster fx:id="yMax" name="Max Y level" />
+            <Button fx:id="setDefaultYMax" mnemonicParsing="false" text="Set default" />
+          </HBox>
+        </VBox>
+      </TitledPane>
+      <Accordion>
+        <panes>
+          <TitledPane animated="false" text="Load entities">
+            <VBox spacing="10.0">
+              <HBox spacing="10.0">
+                <Button fx:id="loadAllEntities" mnemonicParsing="false" text="Select All" />
+                <Button fx:id="loadNoEntity" mnemonicParsing="false" text="Deselect All" />
+              </HBox>
+              <CheckBox fx:id="loadPlayers" mnemonicParsing="false" text="Players" />
+              <CheckBox fx:id="loadArmorStands" mnemonicParsing="false" text="Armor stands" />
+              <CheckBox fx:id="loadBooks" mnemonicParsing="false" text="Books" />
+              <CheckBox fx:id="loadPaintings" mnemonicParsing="false" text="Paintings" />
+              <CheckBox fx:id="loadOtherEntities" mnemonicParsing="false" text="Other" />
+            </VBox>
+          </TitledPane>
+        </panes>
+      </Accordion>
+    </VBox>
     <Separator />
     <HBox alignment="CENTER_LEFT" spacing="16">
       <VBox spacing="4">
@@ -38,43 +71,20 @@
       </VBox>
     </HBox>
     <Separator />
-    <Accordion>
-      <panes>
-        <TitledPane animated="false" text="Load entities">
-          <VBox spacing="10.0">
-            <HBox spacing="10.0">
-              <Button fx:id="loadAllEntities" mnemonicParsing="false" text="Select All" />
-              <Button fx:id="loadNoEntity" mnemonicParsing="false" text="Deselect All" />
-            </HBox>
-            <CheckBox fx:id="loadPlayers" mnemonicParsing="false" text="Players" />
-            <CheckBox fx:id="loadArmorStands" mnemonicParsing="false" text="Armor stands" />
-            <CheckBox fx:id="loadBooks" mnemonicParsing="false" text="Books" />
-            <CheckBox fx:id="loadPaintings" mnemonicParsing="false" text="Paintings" />
-            <CheckBox fx:id="loadOtherEntities" mnemonicParsing="false" text="Other" />
-          </VBox>
-        </TitledPane>
-      </panes>
-    </Accordion>
-    <HBox alignment="CENTER_LEFT" spacing="10.0">
-      <CheckBox fx:id="saveDumps" mnemonicParsing="false" text="Save dump once every" />
-      <ComboBox fx:id="dumpFrequency" />
-      <Label text="frames" />
-    </HBox>
-    <CheckBox fx:id="saveSnapshots" mnemonicParsing="false" text="Save snapshot for each dump" />
+    <VBox alignment="CENTER_LEFT" spacing="10.0">
+      <CheckBox fx:id="saveDumps" mnemonicParsing="false" text="Enable autosave" />
+      <TitledPane fx:id="dumpSettings" animated="false" text="Autosave settings">
+        <VBox spacing="10.0">
+          <HBox spacing="10.0">
+            <Label text="Autosave frequency: " />
+            <ComboBox fx:id="dumpFrequency" />
+            <Label text=" SPP" />
+          </HBox>
+          <CheckBox fx:id="saveSnapshots" mnemonicParsing="false" text="Save snapshot for each dump" />
+        </VBox>
+      </TitledPane>
+    </VBox>
     <Separator/>
-    <Label text="Scene Y clip:">
-      <font>
-        <Font name="System Bold" size="12.0" />
-      </font>
-    </Label>
-    <HBox alignment="CENTER_LEFT" spacing="10.0">
-      <IntegerAdjuster fx:id="yMin" name="Min Y level" />
-      <Button fx:id="setDefaultYMin" mnemonicParsing="false" text="Set default" />
-    </HBox>
-    <HBox alignment="CENTER_LEFT" spacing="10.0">
-      <IntegerAdjuster fx:id="yMax" name="Max Y level" />
-      <Button fx:id="setDefaultYMax" mnemonicParsing="false" text="Set default" />
-    </HBox>
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -80,7 +80,7 @@
             <ComboBox fx:id="dumpFrequency" />
             <Label text=" SPP" />
           </HBox>
-          <CheckBox fx:id="saveSnapshots" mnemonicParsing="false" text="Save snapshot for each dump" />
+          <CheckBox fx:id="saveSnapshots" mnemonicParsing="false" text="Save snapshot on each autosave" />
         </VBox>
       </TitledPane>
     </VBox>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -84,7 +84,6 @@
         </VBox>
       </TitledPane>
     </VBox>
-    <Separator/>
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -3,7 +3,6 @@
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.text.Font?>
 <?import se.llbit.chunky.ui.*?>
 <?import se.llbit.chunky.ui.elements.*?>
 
@@ -11,18 +10,30 @@
   <VBox spacing="10.0">
     <Button fx:id="openSceneDirBtn" mnemonicParsing="false" text="Open scene directory" />
     <Separator />
-    <FlowPane hgap="10" vgap="10">
-      <Button fx:id="exportSettings" mnemonicParsing="false" text="Export settings" />
-      <Button fx:id="importSettings" mnemonicParsing="false" text="Import settings" />
-      <Button fx:id="restoreDefaults" mnemonicParsing="false" text="Restore default settings" />
-    </FlowPane>
+    <HBox alignment="CENTER_LEFT" spacing="16">
+      <VBox spacing="4">
+        <Label fx:id="canvasSizeLabel" text="Canvas size:" style="-fx-font-weight: bold;"/>
+        <padding>
+          <Insets left="8"/>
+        </padding>
+        <SizeInput fx:id="canvasSizeInput" initialWidth="400" initialHeight="400" showAspectRatioDetails="true"/>
+      </VBox>
+      <VBox alignment="CENTER_LEFT" spacing="4">
+        <HBox spacing="4">
+          <Button fx:id="applySize" mnemonicParsing="false" text="Apply"/>
+          <Button fx:id="makeDefaultSize" mnemonicParsing="false" text="Set default"/>
+        </HBox>
+        <Button fx:id="flipAxesBtn" mnemonicParsing="false" text="Flip axes"/>
+        <HBox spacing="4" fx:id="scaleButtonArea"/>
+      </VBox>
+    </HBox>
     <Separator />
     <VBox spacing="10.0">
       <HBox spacing="10.0">
         <Button fx:id="loadSelectedChunks" mnemonicParsing="false" text="Load selected chunks" />
         <Button fx:id="reloadChunks" mnemonicParsing="false" text="Reload chunks" />
       </HBox>
-      <TitledPane collapsible="false" animated="false" text="Scene Y clip">
+      <TitledPane animated="false" text="Scene Y clip">
         <VBox spacing="10.0">
           <HBox alignment="CENTER_LEFT" spacing="10.0">
             <IntegerAdjuster fx:id="yMin" name="Min Y level" />
@@ -53,23 +64,11 @@
       </Accordion>
     </VBox>
     <Separator />
-    <HBox alignment="CENTER_LEFT" spacing="16">
-      <VBox spacing="4">
-        <Label fx:id="canvasSizeLabel" text="Canvas size:" style="-fx-font-weight: bold;"/>
-        <padding>
-          <Insets left="8"/>
-        </padding>
-        <SizeInput fx:id="canvasSizeInput" initialWidth="400" initialHeight="400" showAspectRatioDetails="true"/>
-      </VBox>
-      <VBox alignment="CENTER_LEFT" spacing="4">
-        <HBox spacing="4">
-          <Button fx:id="applySize" mnemonicParsing="false" text="Apply"/>
-          <Button fx:id="makeDefaultSize" mnemonicParsing="false" text="Set default"/>
-        </HBox>
-        <Button fx:id="flipAxesBtn" mnemonicParsing="false" text="Flip axes"/>
-        <HBox spacing="4" fx:id="scaleButtonArea"/>
-      </VBox>
-    </HBox>
+    <FlowPane hgap="10" vgap="10">
+      <Button fx:id="exportSettings" mnemonicParsing="false" text="Export settings" />
+      <Button fx:id="importSettings" mnemonicParsing="false" text="Import settings" />
+      <Button fx:id="restoreDefaults" mnemonicParsing="false" text="Restore default settings" />
+    </FlowPane>
     <Separator />
     <VBox alignment="CENTER_LEFT" spacing="10.0">
       <CheckBox fx:id="saveDumps" mnemonicParsing="false" text="Enable autosave" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/HelpTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/HelpTab.fxml
@@ -12,24 +12,24 @@
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250" text="Many controls contain a short description. Hover the cursor over the control to view that description." />
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350" text="Many controls contain a short description. Hover the cursor over the control to view that description." />
     <Label />
     <Label text="Map controls:">
       <font>
         <Font name="System Bold" size="12.0" />
       </font>
     </Label>
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Left-click and drag to move the map view." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Left-click to select or deselect a single chunk or region." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Hold Shift and left-click and drag to select multiple chunks." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Hold Ctrl+Shift and left-click and drag to deselect multiple chunks." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Use the mouse wheel to change the map scale (zoom)." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Right-click the map to show more actions." />
     <Label />
     <Label text="Camera controls:">
@@ -37,22 +37,22 @@
         <Font name="System Bold" size="12.0" />
       </font>
     </Label>
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Left-click and drag to change the viewing angle of the camera." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Use the scroll wheel to change the camera FoV (zoom)." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Right-click the render preview to show more actions." />
     <Label />
     <Label text="- W, A, S, D: Move the camera." />
     <Label text="- R: Move the camera up." />
     <Label text="- F: Move the camera down." />
     <Label />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Holding Shift while using the movement controls multiplies the movement of the camera by 0.1." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Holding Ctrl while using the movement controls multiplies the movement of the camera by 100." />
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="250"
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350"
           text="- Holding Ctrl+Shift while using the movement controls multiplies the movement of the camera by 10." />
   </VBox>
 </fx:root>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -16,6 +16,7 @@
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="apparentSkyIntensity" maxWidth="1.7976931348623157E308" />
     <Separator />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -3,24 +3,27 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
-
 <?import se.llbit.chunky.ui.elements.AngleAdjuster?>
 <?import se.llbit.fx.LuxColorPicker?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ComboBox?>
+
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
+    <Separator />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Emitter Sampling Strategy:" />
       <ChoiceBox fx:id="emitterSamplingStrategy" />
     </HBox>
+    <Separator />
     <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Sun Sampling Strategy:" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.text.Text?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
 <?import se.llbit.fx.LuxColorPicker?>
 
@@ -43,7 +44,7 @@
       <Label text="Fog color:" />
       <LuxColorPicker fx:id="fogColor" />
     </HBox>
-    <Label text="Hint: Set fog density &gt; 0.1 for thick fog, and &lt; 0.1 for haze effect." />
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="350" text="Hint: Set fog density &gt; 0.1 for thick fog, and &lt; 0.1 for haze effect. Set fog density to 0.0 to disable fog." />
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
@@ -4,13 +4,14 @@
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
-
 <?import se.llbit.fx.LuxColorPicker?>
+
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
@@ -29,11 +30,13 @@
       </VBox>
     </TitledPane>
     <CheckBox fx:id="transparentSkyEnabled" mnemonicParsing="false" text="Transparent sky" />
+    <Separator />
     <CheckBox fx:id="cloudsEnabled" mnemonicParsing="false" text="Enable clouds" />
     <DoubleAdjuster fx:id="cloudSize" />
     <DoubleAdjuster fx:id="cloudX" name="Cloud X" />
     <DoubleAdjuster fx:id="cloudY" name="Cloud Y" />
     <DoubleAdjuster fx:id="cloudZ" name="Cloud Z" />
+    <Separator />
     <DoubleAdjuster fx:id="fogDensity" name="Fog density" />
     <DoubleAdjuster fx:id="skyFogDensity" name="Sky fog blending" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">


### PR DESCRIPTION
Fixes #1432.

- Reorganized the `Scene` tab; grouped related controls together.
- Renamed dump controls to "autosave" controls.
- Placed autosave controls into a collapsible panel akin to those in #1456.
- Added separators to the `Lighting` and `Sky & Fog` tabs to separate different groups of controls.

**Scene tab:**
![image](https://user-images.githubusercontent.com/92183530/194171663-b6e5ca67-1dc7-4bdc-b27d-89eafb254824.png)

**Lighting tab:**
![image](https://user-images.githubusercontent.com/92183530/194170619-c00c12c4-100a-4dd8-b8e1-792220980213.png)

**Sky & Fog tab:**
![image](https://user-images.githubusercontent.com/92183530/194170687-f187d92b-4099-40be-b35c-1fd5f3b8cadf.png)
