### PR TITLE
Increase the range of cloud offset sliders and change default cloud size

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -65,7 +65,7 @@ public class Sky implements JsonSerializable {
    */
   protected static final int DEFAULT_CLOUD_HEIGHT = 128;
 
-  protected static final int DEFAULT_CLOUD_SIZE = 64;
+  protected static final int DEFAULT_CLOUD_SIZE = 12;
 
   /**
    * Maximum sky light intensity

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
@@ -131,16 +131,20 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     simulatedSky.setTooltip(new Tooltip(skiesTooltip(Sky.skies)));
 
     cloudSize.setName("Cloud size");
+    cloudSize.setTooltip("Cloud size, measured in blocks per pixel of clouds.png texture");
     cloudSize.setRange(0.1, 128);
     cloudSize.clampMin();
     cloudSize.makeLogarithmic();
     cloudSize.onValueChange(value -> scene.sky().setCloudSize(value));
 
     cloudX.setTooltip("Cloud X offset.");
+    cloudX.setRange(-256, 256);
     cloudX.onValueChange(value -> scene.sky().setCloudXOffset(value));
     cloudY.setTooltip("Cloud Y offset.");
+    cloudY.setRange(-64, 320);
     cloudY.onValueChange(value -> scene.sky().setCloudYOffset(value));
     cloudZ.setTooltip("Cloud Z offset.");
+    cloudZ.setRange(-256, 256);
     cloudZ.onValueChange(value -> scene.sky().setCloudZOffset(value));
 
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");


### PR DESCRIPTION
Fixes #1388.
- Changed default cloud size to 12, to match Minecraft Fancy clouds.
- Changed cloud X offset range to (-256, 256).
- Changed cloud Y offset range to (-64, 320).
- Changed cloud Z offset range to (-256, 256).
- Added a tooltip to `Cloud size` control.

**New:**
![image](https://user-images.githubusercontent.com/92183530/194267724-f818a7b2-a5a4-4870-ac9f-d90fc2d187c6.png)
