### PR TITLE
Add `Select chunks in radius` button, with configuration menu

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/SelectChunksInRadiusDialog.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/SelectChunksInRadiusDialog.java
@@ -16,7 +16,7 @@ public class SelectChunksInRadiusDialog extends Dialog<ButtonType> {
   protected IntegerTextField selectionZ;
 
   public SelectChunksInRadiusDialog() {
-    this.setTitle("Adjust chunk selection radius");
+    this.setTitle("Select chunks in radius");
 
     this.selectionX = new IntegerTextField();
     this.selectionZ = new IntegerTextField();

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/SelectChunksInRadiusDialog.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/SelectChunksInRadiusDialog.java
@@ -1,0 +1,63 @@
+package se.llbit.chunky.ui.dialogs;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import se.llbit.chunky.ui.DoubleAdjuster;
+import se.llbit.chunky.ui.IntegerTextField;
+
+public class SelectChunksInRadiusDialog extends Dialog<ButtonType> {
+  protected float chunkSelectionRadius = 10;
+
+  protected IntegerTextField selectionX;
+  protected IntegerTextField selectionZ;
+
+  public SelectChunksInRadiusDialog() {
+    this.setTitle("Adjust chunk selection radius");
+
+    this.selectionX = new IntegerTextField();
+    this.selectionZ = new IntegerTextField();
+
+    DialogPane dialogPane = this.getDialogPane();
+    GridPane gridPane = new GridPane();
+    gridPane.setHgap(5);
+    gridPane.setVgap(5);
+
+    DoubleAdjuster chunkRadiusAdjuster = new DoubleAdjuster();
+    chunkRadiusAdjuster.setName("Radius (Chunks)");
+    chunkRadiusAdjuster.setRange(0, 100);
+    chunkRadiusAdjuster.clampMin();
+    chunkRadiusAdjuster.setAlignment(Pos.CENTER);
+    chunkRadiusAdjuster.set(this.chunkSelectionRadius); // set default
+    chunkRadiusAdjuster.onValueChange(value -> this.chunkSelectionRadius = value.floatValue());
+
+    gridPane.add(new Label("Chunk X:"), 0, 0);
+    gridPane.add(this.selectionX, 1, 0);
+    gridPane.add(new Label("Chunk Z:"), 2, 0);
+    gridPane.add(this.selectionZ, 3, 0);
+    gridPane.add(chunkRadiusAdjuster, 0, 1, 4, 1);
+
+    dialogPane.setContent(gridPane);
+    dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+  }
+
+  public float getRadius() {
+    return this.chunkSelectionRadius;
+  }
+
+  public void setSelectionPos(int selectionX, int selectionZ) {
+    this.selectionX.setText(String.valueOf(selectionX));
+    this.selectionZ.setText(String.valueOf(selectionZ));
+  }
+
+  public int getSelectionX() {
+    return this.selectionX.getValue();
+  }
+
+  public int getSelectionZ() {
+    return this.selectionZ.getValue();
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -312,6 +312,38 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
   }
 
   /**
+   * Select chunks within circle.
+   *
+   * @return true if anything was changed, false if no chunks were selected.
+   */
+  public synchronized boolean setChunkRadius(World world, int centerChunkX, int centerChunkZ, float chunksRadius, boolean selected) {
+    // could be optimised to call setRegion() for regions entirely inside the circle, if necessary
+    boolean selectionChanged = false;
+
+    int minChunkX = (int) (centerChunkX - chunksRadius);
+    int minChunkZ = (int) (centerChunkZ - chunksRadius);
+
+    int maxChunkX = (int) (centerChunkX + chunksRadius);
+    int maxChunkZ = (int) (centerChunkZ + chunksRadius);
+
+    float radiusSquared = chunksRadius * chunksRadius;
+
+    for (int chunkX = minChunkX; chunkX < maxChunkX + 1; chunkX++) {
+      for (int chunkZ = minChunkZ; chunkZ < maxChunkZ + 1; chunkZ++) {
+        int chunkXOffset = chunkX - centerChunkX;
+        int chunkZOffset = chunkZ - centerChunkZ;
+        if (chunkXOffset * chunkXOffset + chunkZOffset * chunkZOffset < radiusSquared) {
+          selectionChanged |= setChunk(world, ChunkPosition.get(chunkX, chunkZ), selected);
+        }
+      }
+    }
+    if (selectionChanged) {
+      notifyChunkSelectionChange();
+    }
+    return selectionChanged;
+  }
+
+  /**
    * Deselect all chunks.
    */
   public synchronized void clearSelection() {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/16853282/194317759-577953dd-7bee-4714-8d41-62e36fc24410.png)

Adds the ability to select a circle of chunks, within a radius. It's added to the right click menu on the map view
![image](https://user-images.githubusercontent.com/16853282/194317498-8c4dd553-6795-421c-bbf2-d202ceb6e018.png)

Additionally there's a config dialog available in the right click menu.
![image](https://user-images.githubusercontent.com/16853282/194317577-339baffb-88f0-41ef-9fa8-59ca8d5cfaa9.png)
I can't figure out how to get the button to be square though, so it's a little chunkier than the rest of the icons. If any javafx wizard wants to fix that it'd be much appreciated