### PR TITLE
Add an `Apparent sky brightness` control

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -54,7 +54,7 @@ public class PreviewRayTracer implements RayTracer {
     }
 
     if (ray.getCurrentMaterial() == Air.INSTANCE) {
-      scene.sky.getSkyApparentColor(ray, true);
+      scene.sky.getApparentSkyColor(ray, true);
     } else {
       scene.sun.flatShading(ray);
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -54,7 +54,7 @@ public class PreviewRayTracer implements RayTracer {
     }
 
     if (ray.getCurrentMaterial() == Air.INSTANCE) {
-      scene.sky.getSkyColor(ray, true);
+      scene.sky.getSkyApparentColor(ray, true);
     } else {
       scene.sun.flatShading(ray);
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -160,7 +160,7 @@ public class Sky implements JsonSerializable {
   private final Vector3 cloudOffset = new Vector3(0, DEFAULT_CLOUD_HEIGHT, 0);
 
   private double skyLightModifier = DEFAULT_INTENSITY;
-  private double skyApparentLightModifier = DEFAULT_INTENSITY;
+  private double apparentSkyLightModifier = DEFAULT_INTENSITY;
 
   /** Color gradient used for the GRADIENT sky mode. */
   private List<Vector4> gradient = new LinkedList<>();
@@ -234,7 +234,7 @@ public class Sky implements JsonSerializable {
     rotation = other.rotation;
     mirrored = other.mirrored;
     skyLightModifier = other.skyLightModifier;
-    skyApparentLightModifier = other.skyApparentLightModifier;
+    apparentSkyLightModifier = other.apparentSkyLightModifier;
     gradient = new ArrayList<>(other.gradient);
     color.set(other.color);
     mode = other.mode;
@@ -367,9 +367,9 @@ public class Sky implements JsonSerializable {
     ray.color.w = 1;
   }
 
-  public void getSkyApparentColor(Ray ray, boolean drawSun) {
+  public void getApparentSkyColor(Ray ray, boolean drawSun) {
     getSkyDiffuseColorInner(ray);
-    ray.color.scale(skyApparentLightModifier);
+    ray.color.scale(apparentSkyLightModifier);
     if (drawSun) addSunColor(ray);
     ray.color.w = 1;
   }
@@ -453,7 +453,7 @@ public class Sky implements JsonSerializable {
       }
     }
     addSunColor(ray);
-    ray.color.scale(skyApparentLightModifier);
+    ray.color.scale(apparentSkyLightModifier);
     ray.color.w = 1;
   }
 
@@ -572,7 +572,7 @@ public class Sky implements JsonSerializable {
     sky.add("skyYaw", rotation);
     sky.add("skyMirrored", mirrored);
     sky.add("skyLight", skyLightModifier);
-    sky.add("skyApparentLight", skyApparentLightModifier);
+    sky.add("apparentSkyLight", apparentSkyLightModifier);
     sky.add("mode", mode.name());
     sky.add("horizonOffset", horizonOffset);
     sky.add("cloudsEnabled", cloudsEnabled);
@@ -620,7 +620,7 @@ public class Sky implements JsonSerializable {
     rotation = json.get("skyYaw").doubleValue(rotation);
     mirrored = json.get("skyMirrored").boolValue(mirrored);
     skyLightModifier = json.get("skyLight").doubleValue(skyLightModifier);
-    skyApparentLightModifier = json.get("skyApparentLight").doubleValue(skyApparentLightModifier);
+    apparentSkyLightModifier = json.get("apparentSkyLight").doubleValue(apparentSkyLightModifier);
     mode = SkyMode.get(json.get("mode").stringValue(mode.name()));
     horizonOffset = json.get("horizonOffset").doubleValue(horizonOffset);
     cloudsEnabled = json.get("cloudsEnabled").boolValue(cloudsEnabled);
@@ -680,8 +680,8 @@ public class Sky implements JsonSerializable {
     scene.refresh();
   }
 
-  public void setSkyApparentLight(double newValue) {
-    skyApparentLightModifier = newValue;
+  public void setApparentSkyLight(double newValue) {
+    apparentSkyLightModifier = newValue;
     scene.refresh();
   }
 
@@ -692,8 +692,8 @@ public class Sky implements JsonSerializable {
     return skyLightModifier;
   }
 
-  public double getSkyApparentLight() {
-    return skyApparentLightModifier;
+  public double getApparentSkyLight() {
+    return apparentSkyLightModifier;
   }
 
   public void setGradient(List<Vector4> newGradient) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -68,14 +68,24 @@ public class Sky implements JsonSerializable {
   protected static final int DEFAULT_CLOUD_SIZE = 64;
 
   /**
+   * Minimum sky light intensity
+   */
+  public static final double MIN_INTENSITY = 0.0;
+
+  /**
    * Maximum sky light intensity
    */
   public static final double MAX_INTENSITY = 50;
 
   /**
-   * Minimum sky light intensity
+   * Minimum apparent sky light intensity
    */
-  public static final double MIN_INTENSITY = 0.0;
+  public static final double MIN_APPARENT_INTENSITY = 0.0;
+
+  /**
+   * Maximum apparent sky light intensity
+   */
+  public static final double MAX_APPARENT_INTENSITY = 50;
 
   public static final int SKYBOX_UP = 0;
   public static final int SKYBOX_DOWN = 1;
@@ -150,6 +160,7 @@ public class Sky implements JsonSerializable {
   private final Vector3 cloudOffset = new Vector3(0, DEFAULT_CLOUD_HEIGHT, 0);
 
   private double skyLightModifier = DEFAULT_INTENSITY;
+  private double skyApparentLightModifier = DEFAULT_INTENSITY;
 
   /** Color gradient used for the GRADIENT sky mode. */
   private List<Vector4> gradient = new LinkedList<>();
@@ -223,6 +234,7 @@ public class Sky implements JsonSerializable {
     rotation = other.rotation;
     mirrored = other.mirrored;
     skyLightModifier = other.skyLightModifier;
+    skyApparentLightModifier = other.skyApparentLightModifier;
     gradient = new ArrayList<>(other.gradient);
     color.set(other.color);
     mode = other.mode;
@@ -355,6 +367,13 @@ public class Sky implements JsonSerializable {
     ray.color.w = 1;
   }
 
+  public void getSkyApparentColor(Ray ray, boolean drawSun) {
+    getSkyDiffuseColorInner(ray);
+    ray.color.scale(skyApparentLightModifier);
+    if (drawSun) addSunColor(ray);
+    ray.color.w = 1;
+  }
+
   /**
    * Bilinear interpolated panoramic skymap color.
    */
@@ -434,7 +453,7 @@ public class Sky implements JsonSerializable {
       }
     }
     addSunColor(ray);
-    //ray.color.scale(skyLightModifier);
+    ray.color.scale(skyApparentLightModifier);
     ray.color.w = 1;
   }
 
@@ -553,6 +572,7 @@ public class Sky implements JsonSerializable {
     sky.add("skyYaw", rotation);
     sky.add("skyMirrored", mirrored);
     sky.add("skyLight", skyLightModifier);
+    sky.add("skyApparentLight", skyApparentLightModifier);
     sky.add("mode", mode.name());
     sky.add("horizonOffset", horizonOffset);
     sky.add("cloudsEnabled", cloudsEnabled);
@@ -600,6 +620,7 @@ public class Sky implements JsonSerializable {
     rotation = json.get("skyYaw").doubleValue(rotation);
     mirrored = json.get("skyMirrored").boolValue(mirrored);
     skyLightModifier = json.get("skyLight").doubleValue(skyLightModifier);
+    skyApparentLightModifier = json.get("skyApparentLight").doubleValue(skyApparentLightModifier);
     mode = SkyMode.get(json.get("mode").stringValue(mode.name()));
     horizonOffset = json.get("horizonOffset").doubleValue(horizonOffset);
     cloudsEnabled = json.get("cloudsEnabled").boolValue(cloudsEnabled);
@@ -659,11 +680,20 @@ public class Sky implements JsonSerializable {
     scene.refresh();
   }
 
+  public void setSkyApparentLight(double newValue) {
+    skyApparentLightModifier = newValue;
+    scene.refresh();
+  }
+
   /**
    * @return Current sky light modifier
    */
   public double getSkyLight() {
     return skyLightModifier;
+  }
+
+  public double getSkyApparentLight() {
+    return skyApparentLightModifier;
   }
 
   public void setGradient(List<Vector4> newGradient) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -49,7 +49,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   private Scene scene;
 
   @FXML private DoubleAdjuster skyIntensity;
-  @FXML private DoubleAdjuster skyApparentIntensity;
+  @FXML private DoubleAdjuster apparentSkyIntensity;
   @FXML private DoubleAdjuster emitterIntensity;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
@@ -79,12 +79,12 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     skyIntensity.clampMin();
     skyIntensity.onValueChange(value -> scene.sky().setSkyLight(value));
 
-    skyApparentIntensity.setName("Apparent sky brightness");
-    skyApparentIntensity.setTooltip("Apparent sky light intensity modifier");
-    skyApparentIntensity.setRange(Sky.MIN_APPARENT_INTENSITY, Sky.MAX_APPARENT_INTENSITY);
-    skyApparentIntensity.makeLogarithmic();
-    skyApparentIntensity.clampMin();
-    skyApparentIntensity.onValueChange(value -> scene.sky().setSkyApparentLight(value));
+    apparentSkyIntensity.setName("Apparent sky brightness");
+    apparentSkyIntensity.setTooltip("Apparent sky light intensity modifier");
+    apparentSkyIntensity.setRange(Sky.MIN_APPARENT_INTENSITY, Sky.MAX_APPARENT_INTENSITY);
+    apparentSkyIntensity.makeLogarithmic();
+    apparentSkyIntensity.clampMin();
+    apparentSkyIntensity.onValueChange(value -> scene.sky().setApparentSkyLight(value));
 
     emitterIntensity.setName("Emitter intensity");
     emitterIntensity.setTooltip("Light intensity modifier for emitters");
@@ -157,7 +157,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
   @Override public void update(Scene scene) {
     skyIntensity.set(scene.sky().getSkyLight());
-    skyApparentIntensity.set(scene.sky().getSkyApparentLight());
+    apparentSkyIntensity.set(scene.sky().getApparentSkyLight());
     emitterIntensity.set(scene.getEmitterIntensity());
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -49,6 +49,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   private Scene scene;
 
   @FXML private DoubleAdjuster skyIntensity;
+  @FXML private DoubleAdjuster skyApparentIntensity;
   @FXML private DoubleAdjuster emitterIntensity;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
@@ -71,12 +72,19 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   }
 
   @Override public void initialize(URL location, ResourceBundle resources) {
-    skyIntensity.setName("Sky light");
+    skyIntensity.setName("Sky brightness");
     skyIntensity.setTooltip("Sky light intensity modifier");
     skyIntensity.setRange(Sky.MIN_INTENSITY, Sky.MAX_INTENSITY);
     skyIntensity.makeLogarithmic();
     skyIntensity.clampMin();
     skyIntensity.onValueChange(value -> scene.sky().setSkyLight(value));
+
+    skyApparentIntensity.setName("Apparent sky brightness");
+    skyApparentIntensity.setTooltip("Apparent sky light intensity modifier");
+    skyApparentIntensity.setRange(Sky.MIN_APPARENT_INTENSITY, Sky.MAX_APPARENT_INTENSITY);
+    skyApparentIntensity.makeLogarithmic();
+    skyApparentIntensity.clampMin();
+    skyApparentIntensity.onValueChange(value -> scene.sky().setSkyApparentLight(value));
 
     emitterIntensity.setName("Emitter intensity");
     emitterIntensity.setTooltip("Light intensity modifier for emitters");
@@ -149,6 +157,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
   @Override public void update(Scene scene) {
     skyIntensity.set(scene.sky().getSkyLight());
+    skyApparentIntensity.set(scene.sky().getSkyApparentLight());
     emitterIntensity.set(scene.getEmitterIntensity());
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -7,14 +7,15 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
-
 <?import se.llbit.chunky.ui.elements.AngleAdjuster?>
 <?import se.llbit.fx.LuxColorPicker?>
 <?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.ComboBox?>
+
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="skyApparentIntensity" maxWidth="1.7976931348623157E308" />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -15,7 +15,7 @@
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
-    <DoubleAdjuster fx:id="skyApparentIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="apparentSkyIntensity" maxWidth="1.7976931348623157E308" />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">


### PR DESCRIPTION
Closes #514.

- Fixed the `Sky light` control changing apparent sky brightness in render preview, but not in the path-traced render.

- Renamed `Sky light` to `Sky brightness`.

- Added an `Apparent sky brightness` control which acts independently from the `Sky brightness` control.

**New:**
![image](https://user-images.githubusercontent.com/92183530/194367204-6f2c82d0-4e01-4f3d-b08a-7460d2c9c7f0.png)

Please tell me if I did anything wrong, and feel free to commit fixes, if any are needed.
