### PR TITLE
Add most controls from `Map` and `Render preview` right-click menus to the menu bar

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -172,11 +172,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
 
     selectVisible.setGraphic(new ImageView(Icon.eye.fxImage()));
     selectVisible.setOnAction(event -> {
-      ChunkView chunkView = new ChunkView(view);  // Make thread-local copy.
-      if (controller.getChunky().sceneInitialized()) {
-        controller.getChunky().getRenderController().getSceneProvider().withSceneProtected(
-            scene -> selectVisibleChunks(chunkView, scene));
-      }
+      selectCameraVisibleChunks();
     });
 
     MenuItem exportZip = new MenuItem("Export selected chunks…");
@@ -214,6 +210,8 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
       loadSelection.setDisable(noChunksSelected);
       exportZip.setDisable(noChunksSelected);
       deleteChunks.setDisable(noChunksSelected);
+
+      controller.disableMapMenuItems(noChunksSelected);
     });
   }
 
@@ -423,6 +421,14 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
 
   public int getHeight() {
     return mapView.getMapView().height;
+  }
+
+  public void selectCameraVisibleChunks() {
+    ChunkView chunkView = new ChunkView(view);  // Make thread-local copy.
+    if (controller.getChunky().sceneInitialized()) {
+      controller.getChunky().getRenderController().getSceneProvider().withSceneProtected(
+        scene -> selectVisibleChunks(chunkView, scene));
+    }
   }
 
   public void onKeyPressed(KeyEvent keyEvent) {

--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -72,7 +72,7 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
 
   private final AtomicBoolean painting = new AtomicBoolean(false);
   private final Canvas canvas;
-  private final Group guideGroup;
+  private final Group guideGroup = new Group();
   private final StackPane canvasPane;
   private final Label noChunksLabel;
   private final RenderManager renderManager;
@@ -80,6 +80,22 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
   private int lastY;
   private Vector2 target = new Vector2(0, 0);
   private Tooltip tooltip = new Tooltip();
+
+  private CheckMenuItem showGuides = new CheckMenuItem("Show guides");
+  private Line hGuide1 = new Line();
+  private Line hGuide2 = new Line();
+  private Line vGuide1 = new Line();
+  private Line vGuide2 = new Line();
+
+  private RadioMenuItem percent25 = new RadioMenuItem(String.format("%d%%", 25));
+  private RadioMenuItem percent50 = new RadioMenuItem(String.format("%d%%", 50));
+  private RadioMenuItem percent75 = new RadioMenuItem(String.format("%d%%", 75));
+  private RadioMenuItem percent100 = new RadioMenuItem(String.format("%d%%", 100));
+  private RadioMenuItem percent150 = new RadioMenuItem(String.format("%d%%", 150));
+  private RadioMenuItem percent200 = new RadioMenuItem(String.format("%d%%", 200));
+  private RadioMenuItem percent300 = new RadioMenuItem(String.format("%d%%", 300));
+  private RadioMenuItem percent400 = new RadioMenuItem(String.format("%d%%", 400));
+  private RadioMenuItem fit = new RadioMenuItem("Fit to screen");
 
   private boolean fitToScreen = PersistentSettings.getCanvasFitToScreen();
 
@@ -110,11 +126,6 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     noChunksLabel.setTextAlignment(TextAlignment.CENTER);
     canvasPane.getChildren().add(noChunksLabel);
 
-    guideGroup = new Group();
-    Line hGuide1 = new Line();
-    Line hGuide2 = new Line();
-    Line vGuide1 = new Line();
-    Line vGuide2 = new Line();
     guideGroup.getChildren().addAll(hGuide1, hGuide2, vGuide1, vGuide2);
     canvasPane.getChildren().add(guideGroup);
 
@@ -183,43 +194,83 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     });
     contextMenu.getItems().add(setTarget);
 
-    CheckMenuItem showGuides = new CheckMenuItem("Show guides");
     showGuides.setSelected(false);
     showGuides.selectedProperty().addListener((observable, oldValue, newValue) -> {
-      hGuide1.setVisible(newValue);
-      hGuide2.setVisible(newValue);
-      vGuide1.setVisible(newValue);
-      vGuide2.setVisible(newValue);
+      changeShowGuides(newValue);
+      chunkyFxController.syncShowGuides(newValue);
     });
     contextMenu.getItems().add(showGuides);
 
     Menu canvasScale = new Menu("Canvas scale");
     ToggleGroup scaleGroup = new ToggleGroup();
-    for (int percent : new int[] { 25, 50, 75, 100, 150, 200, 300, 400 }) {
-      RadioMenuItem item = new RadioMenuItem(String.format("%d%%", percent));
-      item.setToggleGroup(scaleGroup);
-      item.setSelected(PersistentSettings.getCanvasScale() == percent && !fitToScreen);
-      item.setOnAction(e -> {
-        updateCanvasScale(percent / 100.0);
-        PersistentSettings.setCanvasScale(percent);
-        if (fitToScreen) {
-          fitToScreen = false;
-          PersistentSettings.setCanvasFitToScreen(false);
-        }
-      });
-      canvasScale.getItems().add(item);
-    }
-    contextMenu.getItems().add(canvasScale);
-
-    RadioMenuItem fit = new RadioMenuItem("Fit to Screen");
-    fit.setSelected(fitToScreen);
+    percent25.setToggleGroup(scaleGroup);
+    percent50.setToggleGroup(scaleGroup);
+    percent75.setToggleGroup(scaleGroup);
+    percent100.setToggleGroup(scaleGroup);
+    percent150.setToggleGroup(scaleGroup);
+    percent200.setToggleGroup(scaleGroup);
+    percent300.setToggleGroup(scaleGroup);
+    percent400.setToggleGroup(scaleGroup);
     fit.setToggleGroup(scaleGroup);
-    fit.setOnAction(e -> {
-      fitToScreen = true;
-      PersistentSettings.setCanvasFitToScreen(true);
-      updateCanvasFit();
+
+    percent25.setSelected(PersistentSettings.getCanvasScale() == 25 && !fitToScreen);
+    percent50.setSelected(PersistentSettings.getCanvasScale() == 50 && !fitToScreen);
+    percent75.setSelected(PersistentSettings.getCanvasScale() == 75 && !fitToScreen);
+    percent100.setSelected(PersistentSettings.getCanvasScale() == 100 && !fitToScreen);
+    percent150.setSelected(PersistentSettings.getCanvasScale() == 150 && !fitToScreen);
+    percent200.setSelected(PersistentSettings.getCanvasScale() == 200 && !fitToScreen);
+    percent300.setSelected(PersistentSettings.getCanvasScale() == 300 && !fitToScreen);
+    percent400.setSelected(PersistentSettings.getCanvasScale() == 400 && !fitToScreen);
+    fit.setSelected(fitToScreen);
+
+    percent25.setOnAction(e -> {
+      changeCanvasScale(25);
+      chunkyFxController.syncCanvasScale(25);
     });
+    percent50.setOnAction(e -> {
+      changeCanvasScale(50);
+      chunkyFxController.syncCanvasScale(50);
+    });
+    percent75.setOnAction(e -> {
+      changeCanvasScale(75);
+      chunkyFxController.syncCanvasScale(75);
+    });
+    percent100.setOnAction(e -> {
+      changeCanvasScale(100);
+      chunkyFxController.syncCanvasScale(100);
+    });
+    percent150.setOnAction(e -> {
+      changeCanvasScale(150);
+      chunkyFxController.syncCanvasScale(150);
+    });
+    percent200.setOnAction(e -> {
+      changeCanvasScale(200);
+      chunkyFxController.syncCanvasScale(200);
+    });
+    percent300.setOnAction(e -> {
+      changeCanvasScale(300);
+      chunkyFxController.syncCanvasScale(300);
+    });
+    percent400.setOnAction(e -> {
+      changeCanvasScale(400);
+      chunkyFxController.syncCanvasScale(400);
+    });
+    fit.setOnAction(e -> {
+      changeFitToScreen();
+      chunkyFxController.syncFitToScreen();
+    });
+
+    canvasScale.getItems().add(percent25);
+    canvasScale.getItems().add(percent50);
+    canvasScale.getItems().add(percent75);
+    canvasScale.getItems().add(percent100);
+    canvasScale.getItems().add(percent150);
+    canvasScale.getItems().add(percent200);
+    canvasScale.getItems().add(percent300);
+    canvasScale.getItems().add(percent400);
     canvasScale.getItems().add(fit);
+
+    contextMenu.getItems().add(canvasScale);
 
     if (fitToScreen) {
       updateCanvasFit();
@@ -339,6 +390,56 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
           break;
       }
     });
+  }
+
+  public void changeShowGuides(boolean value) {
+    hGuide1.setVisible(value);
+    hGuide2.setVisible(value);
+    vGuide1.setVisible(value);
+    vGuide2.setVisible(value);
+  }
+
+  public void syncShowGuides(boolean value) {
+    showGuides.setSelected(value);
+  }
+
+  public void changeCanvasScale(int percent) {
+    updateCanvasScale(percent / 100.0);
+    PersistentSettings.setCanvasScale(percent);
+    if (fitToScreen) {
+      fitToScreen = false;
+      PersistentSettings.setCanvasFitToScreen(false);
+    }
+  }
+
+  public void syncCanvasScale(int percent) {
+    if (percent == 25) {
+      percent25.setSelected(true);
+    } else if (percent == 50) {
+      percent50.setSelected(true);
+    } else if (percent == 75) {
+      percent75.setSelected(true);
+    } else if (percent == 100) {
+      percent100.setSelected(true);
+    } else if (percent == 150) {
+      percent150.setSelected(true);
+    } else if (percent == 200) {
+      percent200.setSelected(true);
+    } else if (percent == 300) {
+      percent300.setSelected(true);
+    } else if (percent == 400) {
+      percent400.setSelected(true);
+    }
+  }
+
+  public void changeFitToScreen() {
+    fitToScreen = true;
+    PersistentSettings.setCanvasFitToScreen(true);
+    updateCanvasFit();
+  }
+
+  public void syncFitToScreen() {
+    fit.setSelected(true);
   }
 
   private void updateCanvasPane() {

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -133,6 +133,29 @@ public class ChunkyFxController
   @FXML private MenuItem saveSceneCopy;
   @FXML private MenuItem loadScene;
   @FXML private MenuItem loadSceneFile;
+
+  @FXML private MenuItem newScene;
+  @FXML private MenuItem loadSelection;
+  @FXML private MenuItem clearSelection;
+  @FXML private MenuItem selectVisible;
+  @FXML private MenuItem exportZip;
+  @FXML private MenuItem exportPng;
+  @FXML private MenuItem deleteChunks;
+
+  @FXML private CheckMenuItem showGuides;
+  @FXML private Menu canvasScale;
+  @FXML private RadioMenuItem percent25;
+  @FXML private RadioMenuItem percent50;
+  @FXML private RadioMenuItem percent75;
+  @FXML private RadioMenuItem percent100;
+  @FXML private RadioMenuItem percent150;
+  @FXML private RadioMenuItem percent200;
+  @FXML private RadioMenuItem percent300;
+  @FXML private RadioMenuItem percent400;
+  @FXML private RadioMenuItem fit;
+  @FXML private MenuItem saveCurrentFrame;
+  @FXML private MenuItem copyFrame;
+
   @FXML private MenuItem creditsMenuItem;
 
   @FXML private ProgressBar progressBar;
@@ -146,6 +169,8 @@ public class ChunkyFxController
   @FXML private ToggleButton start;
   @FXML private ToggleButton pause;
   @FXML private ToggleButton reset;
+
+  private boolean fitToScreen = PersistentSettings.getCanvasFitToScreen();
 
   RenderControlsFxController sceneControls;
 
@@ -459,6 +484,98 @@ public class ChunkyFxController
       }
     });
 
+    newScene.setGraphic(new ImageView(Icon.sky.fxImage()));
+    newScene.setOnAction(event -> {
+      SceneManager sceneManager = getRenderController().getSceneManager();
+      sceneManager
+        .loadFreshChunks(mapLoader.getWorld(), getChunkSelection().getSelection());
+    });
+    newScene.setDisable(chunkSelection.isEmpty());
+
+    loadSelection.setOnAction(event -> {
+      SceneManager sceneManager = getRenderController().getSceneManager();
+      sceneManager
+        .loadChunks(mapLoader.getWorld(), getChunkSelection().getSelection());
+    });
+    loadSelection.setDisable(chunkSelection.isEmpty());
+
+    clearSelection.setGraphic(new ImageView(Icon.clear.fxImage()));
+    clearSelection.setOnAction(event -> chunkSelection.clearSelection());
+    clearSelection.setDisable(chunkSelection.isEmpty());
+
+    selectVisible.setGraphic(new ImageView(Icon.eye.fxImage()));
+    selectVisible.setOnAction(event -> map.selectCameraVisibleChunks());
+
+    exportZip.setOnAction(e -> exportZip());
+    exportZip.setDisable(chunkSelection.size() == 0);
+
+    exportPng.setOnAction(e -> exportMapView());
+
+    ImageView deleteChunksIcon = new ImageView(Icon.tntSide.fxImage());
+    deleteChunksIcon.setFitHeight(16);
+    deleteChunksIcon.setPreserveRatio(true);
+    deleteChunks.setGraphic(deleteChunksIcon);
+    deleteChunks.setOnAction(e -> promptDeleteSelectedChunks());
+    deleteChunks.setDisable(chunkSelection.size() == 0);
+
+    showGuides.setSelected(false);
+    showGuides.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      canvas.changeShowGuides(newValue);
+      canvas.syncShowGuides(newValue);
+    });
+
+    percent25.setSelected(PersistentSettings.getCanvasScale() == 25 && !fitToScreen);
+    percent50.setSelected(PersistentSettings.getCanvasScale() == 50 && !fitToScreen);
+    percent75.setSelected(PersistentSettings.getCanvasScale() == 75 && !fitToScreen);
+    percent100.setSelected(PersistentSettings.getCanvasScale() == 100 && !fitToScreen);
+    percent150.setSelected(PersistentSettings.getCanvasScale() == 150 && !fitToScreen);
+    percent200.setSelected(PersistentSettings.getCanvasScale() == 200 && !fitToScreen);
+    percent300.setSelected(PersistentSettings.getCanvasScale() == 300 && !fitToScreen);
+    percent400.setSelected(PersistentSettings.getCanvasScale() == 400 && !fitToScreen);
+    fit.setSelected(fitToScreen);
+
+    percent25.setOnAction(e -> {
+      canvas.changeCanvasScale(25);
+      canvas.syncCanvasScale(25);
+    });
+    percent50.setOnAction(e -> {
+      canvas.changeCanvasScale(50);
+      canvas.syncCanvasScale(50);
+    });
+    percent75.setOnAction(e -> {
+      canvas.changeCanvasScale(75);
+      canvas.syncCanvasScale(75);
+    });
+    percent100.setOnAction(e -> {
+      canvas.changeCanvasScale(100);
+      canvas.syncCanvasScale(100);
+    });
+    percent150.setOnAction(e -> {
+      canvas.changeCanvasScale(150);
+      canvas.syncCanvasScale(150);
+    });
+    percent200.setOnAction(e -> {
+      canvas.changeCanvasScale(200);
+
+      canvas.syncCanvasScale(200);
+    });
+    percent300.setOnAction(e -> {
+      canvas.changeCanvasScale(300);
+      canvas.syncCanvasScale(300);
+    });
+    percent400.setOnAction(e -> {
+      canvas.changeCanvasScale(400);
+      canvas.syncCanvasScale(400);
+    });
+    fit.setOnAction(e -> {
+      canvas.changeFitToScreen();
+      canvas.syncFitToScreen();
+    });
+
+    saveCurrentFrame.setOnAction(e -> saveCurrentFrame());
+
+    copyFrame.setOnAction(e -> copyCurrentFrame());
+
     Log.setReceiver(new UILogReceiver(), Level.ERROR, Level.WARNING);
 
     mapLoader = new WorldMapLoader(this, mapView);
@@ -717,6 +834,42 @@ public class ChunkyFxController
     saveDefaultSpp.setTooltip(new Tooltip("Make the current SPP target the default."));
     saveDefaultSpp.setOnAction(e ->
         PersistentSettings.setSppTargetDefault(scene.getTargetSpp()));
+  }
+
+  public void disableMapMenuItems(boolean value) {
+    newScene.setDisable(value);
+    loadSelection.setDisable(value);
+    clearSelection.setDisable(value);
+    exportZip.setDisable(value);
+    deleteChunks.setDisable(value);
+  }
+
+  public void syncShowGuides(boolean value) {
+    showGuides.setSelected(value);
+  }
+
+  public void syncCanvasScale(int percent) {
+    if (percent == 25) {
+      percent25.setSelected(true);
+    } else if (percent == 50) {
+      percent50.setSelected(true);
+    } else if (percent == 75) {
+      percent75.setSelected(true);
+    } else if (percent == 100) {
+      percent100.setSelected(true);
+    } else if (percent == 150) {
+      percent150.setSelected(true);
+    } else if (percent == 200) {
+      percent200.setSelected(true);
+    } else if (percent == 300) {
+      percent300.setSelected(true);
+    } else if (percent == 400) {
+      percent400.setSelected(true);
+    }
+  }
+
+  public void syncFitToScreen() {
+    fit.setSelected(true);
   }
 
   public void openSceneChooser() {

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -21,8 +21,40 @@
       <SeparatorMenuItem/>
       <MenuItem fx:id="menuExit" mnemonicParsing="false" text="Quit"/>
     </Menu>
+    <Menu mnemonicParsing="false" text="Map">
+      <MenuItem fx:id="newScene" mnemonicParsing="false" text="New scene from selection"/>
+      <MenuItem fx:id="loadSelection" mnemonicParsing="false" text="Load selected chunks"/>
+      <MenuItem fx:id="clearSelection" mnemonicParsing="false" text="Clear selection"/>
+      <SeparatorMenuItem/>
+      <MenuItem fx:id="selectVisible" mnemonicParsing="false" text="Select camera-visible chunks"/>
+      <SeparatorMenuItem/>
+      <MenuItem fx:id="exportZip" mnemonicParsing="false" text="Export selected chunks…"/>
+      <MenuItem fx:id="exportPng" mnemonicParsing="false" text="Save map view as…"/>
+      <SeparatorMenuItem/>
+      <MenuItem fx:id="deleteChunks" mnemonicParsing="false" text="Delete selected chunks"/>
+    </Menu>
+    <Menu mnemonicParsing="false" text="Render Preview">
+      <CheckMenuItem fx:id="showGuides" mnemonicParsing="false" text="Show guides"/>
+      <Menu mnemonicParsing="false" text="Canvas scale">
+        <fx:define>
+          <ToggleGroup fx:id="scaleGroup" />
+        </fx:define>
+        <RadioMenuItem fx:id="percent25" toggleGroup="$scaleGroup" mnemonicParsing="false" text="25%"/>
+        <RadioMenuItem fx:id="percent50" toggleGroup="$scaleGroup" mnemonicParsing="false" text="50%"/>
+        <RadioMenuItem fx:id="percent75" toggleGroup="$scaleGroup" mnemonicParsing="false" text="75%"/>
+        <RadioMenuItem fx:id="percent100" toggleGroup="$scaleGroup" mnemonicParsing="false" text="100%"/>
+        <RadioMenuItem fx:id="percent150" toggleGroup="$scaleGroup" mnemonicParsing="false" text="150%"/>
+        <RadioMenuItem fx:id="percent200" toggleGroup="$scaleGroup" mnemonicParsing="false" text="200%"/>
+        <RadioMenuItem fx:id="percent300" toggleGroup="$scaleGroup" mnemonicParsing="false" text="300%"/>
+        <RadioMenuItem fx:id="percent400" toggleGroup="$scaleGroup" mnemonicParsing="false" text="400%"/>
+        <RadioMenuItem fx:id="fit" toggleGroup="$scaleGroup" mnemonicParsing="false" text="Fit to screen"/>
+      </Menu>
+      <SeparatorMenuItem/>
+      <MenuItem fx:id="saveCurrentFrame" mnemonicParsing="false" text="Save image as…"/>
+      <MenuItem fx:id="copyFrame" mnemonicParsing="false" text="Copy image to clipboard"/>
+    </Menu>
     <Menu mnemonicParsing="false" text="Help">
-      <HyperlinkMenuItem link="https://chunky-dev.github.io/docs" text="Chunky Manual"/>
+      <HyperlinkMenuItem link="https://chunky-dev.github.io/docs/" text="Chunky Manual"/>
       <HyperlinkMenuItem link="https://jackjt8.github.io/ChunkyGuide/" text="jackjt8's Guide to Chunky"/>
       <SeparatorMenuItem/>
       <HyperlinkMenuItem link="https://github.com/chunky-dev/chunky" text="GitHub Repo"/>


### PR DESCRIPTION
Closes #1387.

- Added to the menu bar a `Map` menu that contains most controls from the `Map` tab right-click menu.
- Added to the menu bar a `Render preview` menu that contains most controls from the `Render preview` tab right-click menu.

Controls whose effects depend on the location of the cursor at the time of the context menu being opened, such as `Set target` and `Move camera here`, are not added to the menu bar.

**Map menu:**
![image](https://user-images.githubusercontent.com/92183530/194777699-4811ccc8-c3da-4c73-9907-f3875e0892e4.png)

**Render preview menu:**
![image](https://user-images.githubusercontent.com/92183530/194777750-49776b2b-030c-4f97-95c8-03730ade4df3.png)