### PR TITLE
Fix ChunkDataVersion issues with third party applications

### DIFF
--- a/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
@@ -36,7 +36,7 @@ public class CubicDimension extends Dimension {
   }
 
   @Override
-  public ChunkData createChunkData(ChunkData chunkData, int chunkVersion) {
+  public ChunkData createChunkData(ChunkData chunkData, int minY, int maxY) {
     if (chunkData instanceof GenericChunkData) {
       return chunkData;
     }

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -100,18 +100,18 @@ public class Dimension {
    * Returns a ChunkData instance that is compatible with the given chunk version.
    * The provided ChunkData instance may or may not be re-used.
    */
-  public ChunkData createChunkData(@Nullable ChunkData chunkData, int chunkVersion) {
-    if(chunkVersion >= World.VERSION_21W06A) {
-      if(chunkData instanceof GenericChunkData) {
-        return chunkData;
-      }
-      return new GenericChunkData();
-    } else {
-      if(chunkData instanceof SimpleChunkData) {
+  public ChunkData createChunkData(@Nullable ChunkData chunkData, int minY, int maxY) {
+    if (minY >= 0 && maxY <= 255) {
+      if (chunkData instanceof SimpleChunkData) {
         return chunkData;
       }
       return new SimpleChunkData();
     }
+
+    if (chunkData instanceof GenericChunkData) {
+      return chunkData;
+    }
+    return new GenericChunkData();
   }
 
   public Region createRegion(RegionPosition pos) {

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -67,7 +67,7 @@ public class ImposterCubicChunk extends Chunk {
     }
 
     surfaceTimestamp = dataTimestamp;
-    mutableChunkData.set(this.dimension.createChunkData(mutableChunkData.get(), 0)); //chunk version ignored for cubic worlds
+    mutableChunkData.set(this.dimension.createChunkData(mutableChunkData.get(), Integer.MIN_VALUE, Integer.MAX_VALUE));
     ChunkData chunkData = mutableChunkData.get();
     loadSurfaceCubic(data, chunkData, yMin, yMax);
     biomes = IconLayer.UNKNOWN;
@@ -170,7 +170,7 @@ public class ImposterCubicChunk extends Chunk {
     request.add(LEVEL_TILEENTITIES);
     Map<Integer, Map<String, Tag>> data = getCubeTags(request);
     if(reuseChunkData.get() == null || reuseChunkData.get() instanceof EmptyChunkData) {
-      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), 0));
+      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), Integer.MIN_VALUE, Integer.MAX_VALUE));
     } else {
       reuseChunkData.get().clear();
     }


### PR DESCRIPTION
Some WorldPainter worlds have their ChunkDataVersion set to a version prior to minecraft's support for worlds with >=256 height.
This PR changes how we create `ChunkData` objects to be based on the actual block range found in a chunk, rather than its version