### PR TITLE
Add a control to lock the camera angle.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
@@ -94,6 +94,8 @@ public class Camera implements JsonSerializable {
 
   private final Refreshable scene;
 
+  private boolean lockCamera = false;
+
   Vector3 pos = new Vector3(0, 0, 0);
 
   /**
@@ -177,6 +179,7 @@ public class Camera implements JsonSerializable {
    * @param other the camera to copy configuration from
    */
   public void set(Camera other) {
+    lockCamera = other.lockCamera;
     pos.set(other.pos);
     yaw = other.yaw;
     pitch = other.pitch;
@@ -619,6 +622,7 @@ public class Camera implements JsonSerializable {
   @Override public JsonObject toJson() {
     JsonObject camera = new JsonObject();
     camera.add("name", name);
+    camera.add("lockCamera", lockCamera);
     camera.add("position", pos.toJson());
 
     JsonObject orientation = new JsonObject();
@@ -650,6 +654,7 @@ public class Camera implements JsonSerializable {
 
   public void importFromJson(JsonObject json) {
     name = json.get("name").stringValue(name);
+    lockCamera = json.get("lockCamera").boolValue(lockCamera);
     if (json.get("position").isObject()) {
       pos.fromJson(json.get("position").object());
     }
@@ -775,5 +780,14 @@ public class Camera implements JsonSerializable {
    */
   public ApertureShape getApertureShape() {
     return apertureShape;
+  }
+
+  public void setCameraLocked(boolean value) {
+    lockCamera = value;
+    scene.refresh();
+  }
+
+  public boolean getCameraLocked() {
+    return lockCamera;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -81,6 +81,8 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
   private Vector2 target = new Vector2(0, 0);
   private Tooltip tooltip = new Tooltip();
 
+  private CheckMenuItem lockCameraAngle = new CheckMenuItem("Lock camera angle");
+
   private boolean fitToScreen = PersistentSettings.getCanvasFitToScreen();
 
   private RenderStatusListener renderListener;
@@ -152,8 +154,8 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     });
 
     canvas.setOnMouseDragged(e -> {
-      if (e.isSecondaryButtonDown()) {
-        // do not drag when right-clicking
+      if (e.isSecondaryButtonDown() | lockCameraAngle.isSelected()) {
+        // do not drag when right-clicking or when the camera angle is locked
         return;
       }
       double dx = lastX - (int) e.getX();
@@ -192,6 +194,9 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
       vGuide2.setVisible(newValue);
     });
     contextMenu.getItems().add(showGuides);
+
+    lockCameraAngle.setSelected(false);
+    contextMenu.getItems().add(lockCameraAngle);
 
     Menu canvasScale = new Menu("Canvas scale");
     ToggleGroup scaleGroup = new ToggleGroup();

--- a/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/RenderCanvasFx.java
@@ -81,8 +81,6 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
   private Vector2 target = new Vector2(0, 0);
   private Tooltip tooltip = new Tooltip();
 
-  private CheckMenuItem lockCameraAngle = new CheckMenuItem("Lock camera angle");
-
   private boolean fitToScreen = PersistentSettings.getCanvasFitToScreen();
 
   private RenderStatusListener renderListener;
@@ -154,7 +152,7 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
     });
 
     canvas.setOnMouseDragged(e -> {
-      if (e.isSecondaryButtonDown() | lockCameraAngle.isSelected()) {
+      if (e.isSecondaryButtonDown() || scene.camera().getCameraLocked()) {
         // do not drag when right-clicking or when the camera angle is locked
         return;
       }
@@ -194,9 +192,6 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
       vGuide2.setVisible(newValue);
     });
     contextMenu.getItems().add(showGuides);
-
-    lockCameraAngle.setSelected(false);
-    contextMenu.getItems().add(lockCameraAngle);
 
     Menu canvasScale = new Menu("Canvas scale");
     ToggleGroup scaleGroup = new ToggleGroup();
@@ -256,6 +251,10 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
       }
     });
     canvas.setOnScroll(e -> {
+      if (scene.camera().getCameraLocked()) {
+        // do not scroll when the camera angle is locked
+        return;
+      }
       // deltaY is zero if shift is pressed because shift switches to horizontal scrolling in JavaFX
       double diff = -(Math.abs(e.getDeltaY()) > 0 ? e.getDeltaY() / e.getMultiplierY() : e.getDeltaX() / e.getMultiplierX());
       if (e.isShiftDown()) {
@@ -292,6 +291,9 @@ public class RenderCanvasFx extends ScrollPane implements Repaintable, SceneStat
 
     canvasPane.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
       if (!isVisible()) {
+        return;
+      }
+      if (scene.camera().getCameraLocked()) {
         return;
       }
       double modifier = 1;

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/CameraTab.java
@@ -23,14 +23,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
-import javafx.scene.control.Button;
-import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.ComboBox;
-import javafx.scene.control.MenuButton;
-import javafx.scene.control.MenuItem;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.TitledPane;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -64,6 +57,7 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
   @FXML private ComboBox<String> cameras;
   @FXML private Button duplicate;
   @FXML private Button removeCamera;
+  @FXML private CheckBox lockCamera;
   @FXML private TitledPane positionOrientation;
   @FXML private DoubleTextField posX;
   @FXML private DoubleTextField posY;
@@ -102,6 +96,7 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     updateDof();
     updateSubjectDistance();
     updateShift();
+    updateCameraLocked();
     preventApertureCallback = true;
     apertureShape.setValue(scene.camera().getApertureShape());
     preventApertureCallback = false;
@@ -136,6 +131,10 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
     shiftY.valueProperty().setValue(scene.camera().getShiftY());
   }
 
+  private void updateCameraLocked() {
+    lockCamera.selectedProperty().setValue(scene.camera().getCameraLocked());
+  }
+
   @Override public void initialize(URL location, ResourceBundle resources) {
     loadPreset.setTooltip(new Tooltip("Load a camera preset. Overwrites current camera settings."));
     for (CameraPreset preset : CameraPreset.values()) {
@@ -167,6 +166,7 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
           updateCameraPosition();
           updateCameraDirection();
           updateShift();
+          updateCameraLocked();
         } else {
           // Create new camera preset.
           cameras.getItems().add(newValue);
@@ -200,8 +200,29 @@ public class CameraTab extends ScrollPane implements RenderControlsTab, Initiali
         updateCameraPosition();
         updateCameraDirection();
         updateShift();
+        updateCameraLocked();
         cameras.getSelectionModel().selectedItemProperty().addListener(cameraSelectionListener);
       }
+    });
+
+    lockCamera.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      scene.camera().setCameraLocked(newValue);
+      loadPreset.setDisable(newValue);
+      posX.setDisable(newValue);
+      posY.setDisable(newValue);
+      posZ.setDisable(newValue);
+      centerCamera.setDisable(newValue);
+      pitchField.setDisable(newValue);
+      rollField.setDisable(newValue);
+      yawField.setDisable(newValue);
+      shiftX.setDisable(newValue);
+      shiftY.setDisable(newValue);
+      projectionMode.setDisable(newValue);
+      fov.setDisable(newValue);
+      dof.setDisable(newValue);
+      subjectDistance.setDisable(newValue);
+      autofocus.setDisable(newValue);
+      apertureShape.setDisable(newValue);
     });
 
     positionOrientation.expandedProperty().addListener((observable, oldValue, newValue) -> {

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/CameraTab.fxml
@@ -3,6 +3,7 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.MenuButton?>
@@ -19,7 +20,7 @@
 
 <?import javafx.scene.control.Tooltip?>
 <?import se.llbit.chunky.ui.elements.TextFieldLabelWrapper?>
-<?import javafx.scene.control.TextField?>
+
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
@@ -31,6 +32,7 @@
       <Button fx:id="duplicate" mnemonicParsing="false" text="Clone" />
       <Button fx:id="removeCamera" mnemonicParsing="false" text="Remove" />
     </HBox>
+    <CheckBox fx:id="lockCamera" mnemonicParsing="false" text="Lock selected camera" />
     <TitledPane fx:id="positionOrientation" animated="false" expanded="false" text="Position &amp; Orientation">
       <GridPane hgap="6.0" vgap="10.0">
         <columnConstraints>


### PR DESCRIPTION
Fixes #1396.

- Added a `Lock selected camera` control, which is associated with the separate cameras.
- The control disables many other controls in the `Camera` tab, and disables camera input from the `Render preview`.

**Disabled:**
![image](https://user-images.githubusercontent.com/92183530/196798688-dd154719-445f-4834-a869-af8f529741e8.png)

**Enabled:**
![image](https://user-images.githubusercontent.com/92183530/196798794-2e186b24-2877-4fc6-9687-d65a53d7e302.png)

Testing is appreciated.