### PR TITLE
Add a `Sky exposure` control, fix the `Draw sun` control disabling sunlight, and add few new sun controls

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -87,7 +87,7 @@ public class PathTracer implements RayTracer {
           hit = true;
         } else {
           // Indirect sky hit - diffuse color.
-          scene.sky.getSkyColor(ray, scene.getSunSamplingStrategy().isDiffuseSun());
+          scene.sky.getSkyColorDiffuseSun(ray, scene.getSunSamplingStrategy().isDiffuseSun());
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
         }
@@ -200,7 +200,7 @@ public class PathTracer implements RayTracer {
               }
             }
 
-            if (scene.sun().drawTexture() && scene.getSunSamplingStrategy().doSunSampling()) {
+            if (scene.getSunSamplingStrategy().doSunSampling()) {
               reflected.set(ray);
               scene.sun.getRandomSunDirection(reflected, random);
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -1157,6 +1157,6 @@ public class Sky implements JsonSerializable {
   }
 
   public Vector3 getColor() {
-    return new Vector3(color);
+    return color;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -157,6 +157,7 @@ public class Sky implements JsonSerializable {
   private double cloudSize = DEFAULT_CLOUD_SIZE;
   private final Vector3 cloudOffset = new Vector3(0, DEFAULT_CLOUD_HEIGHT, 0);
 
+  private double skyExposure = DEFAULT_INTENSITY;
   private double skyLightModifier = DEFAULT_INTENSITY;
   private double apparentSkyLightModifier = DEFAULT_INTENSITY;
 
@@ -235,6 +236,7 @@ public class Sky implements JsonSerializable {
     roll = other.roll;
     rotation.set(other.rotation);
     mirrored = other.mirrored;
+    skyExposure = other.skyExposure;
     skyLightModifier = other.skyLightModifier;
     apparentSkyLightModifier = other.apparentSkyLightModifier;
     gradient = new ArrayList<>(other.gradient);
@@ -360,6 +362,7 @@ public class Sky implements JsonSerializable {
    */
   public void getSkyColor(Ray ray, boolean drawSun) {
     getSkyDiffuseColorInner(ray);
+    ray.color.scale(skyExposure);
     ray.color.scale(skyLightModifier);
     if (drawSun) addSunColor(ray);
     ray.color.w = 1;
@@ -367,6 +370,7 @@ public class Sky implements JsonSerializable {
 
   public void getApparentSkyColor(Ray ray, boolean drawSun) {
     getSkyDiffuseColorInner(ray);
+    ray.color.scale(skyExposure);
     ray.color.scale(apparentSkyLightModifier);
     if (drawSun) addSunColor(ray);
     ray.color.w = 1;
@@ -445,8 +449,9 @@ public class Sky implements JsonSerializable {
         getSkyDiffuseColorInner(ray);
       }
     }
-    addSunColor(ray);
+    ray.color.scale(skyExposure);
     ray.color.scale(apparentSkyLightModifier);
+    addSunColor(ray);
     ray.color.w = 1;
   }
 
@@ -459,7 +464,29 @@ public class Sky implements JsonSerializable {
     double g = ray.color.y;
     double b = ray.color.z;
     if (scene.sun().intersect(ray)) {
-      double mult = scene.getSunSamplingStrategy().isSunLuminosity() ? scene.sun().getLuminosity() : 1;
+
+      // Blend sun color with current color.
+      ray.color.x = ray.color.x + r;
+      ray.color.y = ray.color.y + g;
+      ray.color.z = ray.color.z + b;
+    }
+  }
+
+  public void getSkyColorDiffuseSun(Ray ray, boolean diffuseSun) {
+    getSkyDiffuseColorInner(ray);
+    ray.color.scale(skyExposure);
+    ray.color.scale(skyLightModifier);
+    if (diffuseSun) addSunColorDiffuseSun(ray);
+    ray.color.w = 1;
+  }
+
+  public void addSunColorDiffuseSun(Ray ray) {
+    double r = ray.color.x;
+    double g = ray.color.y;
+    double b = ray.color.z;
+
+    if (scene.sun().intersectDiffuse(ray)) {
+      double mult = scene.sun().getLuminosity();
 
       // Blend sun color with current color.
       ray.color.x = ray.color.x * mult + r;
@@ -599,6 +626,7 @@ public class Sky implements JsonSerializable {
     sky.add("skyPitch", pitch);
     sky.add("skyRoll", roll);
     sky.add("skyMirrored", mirrored);
+    sky.add("skyExposure", skyExposure);
     sky.add("skyLight", skyLightModifier);
     sky.add("apparentSkyLight", apparentSkyLightModifier);
     sky.add("mode", mode.name());
@@ -650,6 +678,7 @@ public class Sky implements JsonSerializable {
     roll = json.get("skyRoll").doubleValue(roll);
     updateTransform();
     mirrored = json.get("skyMirrored").boolValue(mirrored);
+    skyExposure = json.get("skyExposure").doubleValue(skyExposure);
     skyLightModifier = json.get("skyLight").doubleValue(skyLightModifier);
     apparentSkyLightModifier = json.get("apparentSkyLight").doubleValue(apparentSkyLightModifier);
     mode = SkyMode.get(json.get("mode").stringValue(mode.name()));
@@ -707,6 +736,11 @@ public class Sky implements JsonSerializable {
     rotation.rotate(-pitch, -yaw, -roll);
   }
 
+  public void setSkyExposure(double newValue) {
+    skyExposure = newValue;
+    scene.refresh();
+  }
+
   /**
    * Set the sky light modifier.
    */
@@ -718,6 +752,10 @@ public class Sky implements JsonSerializable {
   public void setApparentSkyLight(double newValue) {
     apparentSkyLightModifier = newValue;
     scene.refresh();
+  }
+
+  public double getSkyExposure() {
+    return skyExposure;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -500,11 +500,11 @@ public class Sun implements JsonSerializable {
    * @return sun color
    */
   public Vector3 getColor() {
-    return new Vector3(color);
+    return color;
   }
 
   public Vector3 getApparentColor() {
-    return new Vector3(apparentColor);
+    return apparentColor;
   }
 
   public void setDrawTexture(boolean value) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -51,8 +51,14 @@ public class Sun implements JsonSerializable {
    */
   public static final double MIN_INTENSITY = 0.1;
 
+  /**
+   * Minimum apparent sun brightness
+   */
   public static final double MIN_APPARENT_BRIGHTNESS = 0.01;
 
+  /**
+   * Maximum apparent sun brightness
+   */
   public static final double MAX_APPARENT_BRIGHTNESS = 50;
 
   private static final double xZenithChroma[][] =

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -50,7 +50,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
   @FXML private DoubleAdjuster skyExposure;
   @FXML private DoubleAdjuster skyIntensity;
-  @FXML private DoubleAdjuster apparentSkyIntensity;
+  @FXML private DoubleAdjuster apparentSkyBrightness;
   @FXML private DoubleAdjuster emitterIntensity;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
@@ -79,32 +79,55 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
   @Override public void initialize(URL location, ResourceBundle resources) {
     skyExposure.setName("Sky exposure");
-    skyExposure.setTooltip("Changes the exposure of the sky");
+    skyExposure.setTooltip("Changes the exposure of the sky.");
     skyExposure.setRange(Sky.MIN_INTENSITY, Sky.MAX_INTENSITY);
     skyExposure.makeLogarithmic();
     skyExposure.clampMin();
     skyExposure.onValueChange(value -> scene.sky().setSkyExposure(value));
 
-    skyIntensity.setName("Sky brightness modifier");
-    skyIntensity.setTooltip("Modifies the intensity of the sky light");
+    skyIntensity.setName("Sky light intensity modifier");
+    skyIntensity.setTooltip("Modifies the intensity of the light emitted by the sky.");
     skyIntensity.setRange(Sky.MIN_INTENSITY, Sky.MAX_INTENSITY);
     skyIntensity.makeLogarithmic();
     skyIntensity.clampMin();
     skyIntensity.onValueChange(value -> scene.sky().setSkyLight(value));
 
-    apparentSkyIntensity.setName("Apparent sky brightness modifier");
-    apparentSkyIntensity.setTooltip("Modifies the apparent brightness of the sky");
-    apparentSkyIntensity.setRange(Sky.MIN_APPARENT_INTENSITY, Sky.MAX_APPARENT_INTENSITY);
-    apparentSkyIntensity.makeLogarithmic();
-    apparentSkyIntensity.clampMin();
-    apparentSkyIntensity.onValueChange(value -> scene.sky().setApparentSkyLight(value));
+    apparentSkyBrightness.setName("Apparent sky brightness modifier");
+    apparentSkyBrightness.setTooltip("Modifies the apparent brightness of the sky.");
+    apparentSkyBrightness.setRange(Sky.MIN_APPARENT_INTENSITY, Sky.MAX_APPARENT_INTENSITY);
+    apparentSkyBrightness.makeLogarithmic();
+    apparentSkyBrightness.clampMin();
+    apparentSkyBrightness.onValueChange(value -> scene.sky().setApparentSkyLight(value));
+
+    enableEmitters.setTooltip(new Tooltip("Allow blocks to emit light based on their material settings."));
+    enableEmitters.selectedProperty().addListener(
+      (observable, oldValue, newValue) -> scene.setEmittersEnabled(newValue));
 
     emitterIntensity.setName("Emitter intensity");
-    emitterIntensity.setTooltip("Light intensity modifier for emitters");
+    emitterIntensity.setTooltip("Modifies the intensity of emitter light.");
     emitterIntensity.setRange(Scene.MIN_EMITTER_INTENSITY, Scene.MAX_EMITTER_INTENSITY);
     emitterIntensity.makeLogarithmic();
     emitterIntensity.clampMin();
     emitterIntensity.onValueChange(value -> scene.setEmitterIntensity(value));
+
+    emitterSamplingStrategy.getItems().addAll(EmitterSamplingStrategy.values());
+    emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
+      .addListener((observable, oldvalue, newvalue) -> {
+        scene.setEmitterSamplingStrategy(newvalue);
+        if (newvalue != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() == null && scene.haveLoadedChunks()) {
+          Alert warning = Dialogs.createAlert(AlertType.CONFIRMATION);
+          warning.setContentText("The selected chunks need to be reloaded in order for emitter sampling to work.");
+          warning.getButtonTypes().setAll(
+            ButtonType.CANCEL,
+            new ButtonType("Reload chunks", ButtonData.FINISH));
+          warning.setTitle("Chunk reload required");
+          ButtonType result = warning.showAndWait().orElse(ButtonType.CANCEL);
+          if (result.getButtonData() == ButtonData.FINISH) {
+            controller.getRenderController().getSceneManager().reloadChunks();
+          }
+        }
+      });
+    emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce."));
 
     drawSun.selectedProperty().addListener((observable, oldValue, newValue) -> scene.sun().setDrawTexture(newValue));
     drawSun.setTooltip(new Tooltip("Draws the sun texture on top of the skymap."));
@@ -112,44 +135,37 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunSamplingStrategy.getItems().addAll(SunSamplingStrategy.values());
     sunSamplingStrategy.getSelectionModel().selectedItemProperty().addListener(
             (observable, oldValue, newValue) -> scene.setSunSamplingStrategy(newValue));
-    sunSamplingStrategy.setTooltip(new Tooltip("Determine how the sun is sampled at each bounce."));
+    sunSamplingStrategy.setTooltip(new Tooltip("Determines how the sun is sampled at each bounce."));
 
-    apparentSunBrightness.setName("Apparent sun brightness");
-    apparentSunBrightness.setTooltip("Apparent brightness of the sun texture");
-    apparentSunBrightness.setRange(Sun.MIN_INTENSITY, Sun.MAX_INTENSITY);
-    apparentSunBrightness.makeLogarithmic();
-    apparentSunBrightness.clampMin();
-    apparentSunBrightness.onValueChange(value -> scene.sun().setApparentBrightness(value));
-
-    sunIntensity.setName("Sun intensity");
-    sunIntensity.setTooltip("Sunlight intensity modifier.");
+    sunIntensity.setName("Sunlight intensity");
+    sunIntensity.setTooltip("Changes the intensity of sunlight. Only used when Sun Sampling Strategy is set to FAST or HIGH_QUALITY.");
     sunIntensity.setRange(Sun.MIN_INTENSITY, Sun.MAX_INTENSITY);
     sunIntensity.makeLogarithmic();
     sunIntensity.clampMin();
     sunIntensity.onValueChange(value -> scene.sun().setIntensity(value));
 
     sunLuminosity.setName("Sun luminosity");
-    sunLuminosity.setTooltip("Absolute brightness of the sun. Only used when Sun Sampling Strategy is set to OFF or HIGH_QUALITY.");
-    sunLuminosity.setRange(1, 10000);
+    sunLuminosity.setTooltip("Changes the absolute brightness of the sun. Only used when Sun Sampling Strategy is set to OFF or HIGH_QUALITY.");    sunLuminosity.setRange(1, 10000);
     sunLuminosity.makeLogarithmic();
     sunLuminosity.clampMin();
     sunLuminosity.onValueChange(value -> scene.sun().setLuminosity(value));
 
-    sunAzimuth.setName("Sun azimuth");
-    sunAzimuth.setTooltip("The horizontal direction of the sun from a reference direction of East.");
-    sunAzimuth.onValueChange(value -> scene.sun().setAzimuth(-QuickMath.degToRad(value)));
+    apparentSunBrightness.setName("Apparent sun brightness");
+    apparentSunBrightness.setTooltip("Changes the apparent brightness of the sun texture.");
+    apparentSunBrightness.setRange(Sun.MIN_APPARENT_BRIGHTNESS, Sun.MAX_APPARENT_BRIGHTNESS);
+    apparentSunBrightness.makeLogarithmic();
+    apparentSunBrightness.clampMin();
+    apparentSunBrightness.onValueChange(value -> scene.sun().setApparentBrightness(value));
 
-    sunAltitude.setName("Sun altitude");
-    sunAltitude.setTooltip("The vertical direction of the sun from a reference altitude of the horizon.");
-    sunAltitude.onValueChange(value -> scene.sun().setAltitude(QuickMath.degToRad(value)));
-
-    enableEmitters.setTooltip(new Tooltip("Allow blocks to emit light based on their material settings."));
-    enableEmitters.selectedProperty().addListener(
-        (observable, oldValue, newValue) -> scene.setEmittersEnabled(newValue));
+    sunRadius.setName("Sun size");
+    sunRadius.setTooltip("Changes the size of the sun.");
+    sunRadius.setRange(0.01, 10);
+    sunRadius.clampMin();
+    sunRadius.onValueChange(value -> scene.sun().setSunRadius(value));
 
     sunColor.colorProperty().addListener(sunColorListener);
 
-    modifySunTexture.setTooltip(new Tooltip("Change whether the the color of the sun texture is modified by the apparent sun color"));
+    modifySunTexture.setTooltip(new Tooltip("Changes whether the the color of the sun texture is modified by the apparent sun color."));
     modifySunTexture.selectedProperty().addListener((observable, oldValue, newValue) -> {
       scene.sun().setEnableTextureModification(newValue);
       apparentSunColor.setDisable(!newValue);
@@ -158,30 +174,13 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     apparentSunColor.setDisable(true);
     apparentSunColor.colorProperty().addListener(apparentSunColorListener);
 
-    sunRadius.setName("Sun radius");
-    sunRadius.setTooltip("Radius of the sun");
-    sunRadius.setRange(0.01, 10);
-    sunRadius.clampMin();
-    sunRadius.onValueChange(value -> scene.sun().setSunRadius(value));
+    sunAzimuth.setName("Sun azimuth");
+    sunAzimuth.setTooltip("Changes the horizontal direction of the sun from a reference direction of East.");
+    sunAzimuth.onValueChange(value -> scene.sun().setAzimuth(-QuickMath.degToRad(value)));
 
-    emitterSamplingStrategy.getItems().addAll(EmitterSamplingStrategy.values());
-    emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
-        .addListener((observable, oldvalue, newvalue) -> {
-          scene.setEmitterSamplingStrategy(newvalue);
-          if (newvalue != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() == null && scene.haveLoadedChunks()) {
-            Alert warning = Dialogs.createAlert(AlertType.CONFIRMATION);
-            warning.setContentText("The selected chunks need to be reloaded in order for emitter sampling to work.");
-            warning.getButtonTypes().setAll(
-              ButtonType.CANCEL,
-              new ButtonType("Reload chunks", ButtonData.FINISH));
-            warning.setTitle("Chunk reload required");
-            ButtonType result = warning.showAndWait().orElse(ButtonType.CANCEL);
-            if (result.getButtonData() == ButtonData.FINISH) {
-              controller.getRenderController().getSceneManager().reloadChunks();
-            }
-          }
-        });
-    emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce"));
+    sunAltitude.setName("Sun altitude");
+    sunAltitude.setTooltip("Changes the vertical direction of the sun from a reference altitude of the horizon.");
+    sunAltitude.onValueChange(value -> scene.sun().setAltitude(QuickMath.degToRad(value)));
   }
 
   @Override
@@ -193,7 +192,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @Override public void update(Scene scene) {
     skyExposure.set(scene.sky().getSkyExposure());
     skyIntensity.set(scene.sky().getSkyLight());
-    apparentSkyIntensity.set(scene.sky().getApparentSkyLight());
+    apparentSkyBrightness.set(scene.sky().getApparentSkyLight());
     emitterIntensity.set(scene.getEmitterIntensity());
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -57,15 +57,18 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private ComboBox<SunSamplingStrategy> sunSamplingStrategy;
   @FXML private DoubleAdjuster sunLuminosity;
   @FXML private DoubleAdjuster apparentSunBrightness;
+  @FXML private DoubleAdjuster sunRadius;
   @FXML private AngleAdjuster sunAzimuth;
   @FXML private AngleAdjuster sunAltitude;
   @FXML private CheckBox enableEmitters;
   @FXML private LuxColorPicker sunColor;
+  @FXML private LuxColorPicker apparentSunColor;
   @FXML private CheckBox modifySunTexture;
   @FXML private ChoiceBox<EmitterSamplingStrategy> emitterSamplingStrategy;
 
-  private ChangeListener<Color> sunColorListener = (observable, oldValue, newValue) ->
-      scene.sun().setColor(ColorUtil.fromFx(newValue));
+  private ChangeListener<Color> sunColorListener = (observable, oldValue, newValue) -> scene.sun().setColor(ColorUtil.fromFx(newValue));
+
+  private ChangeListener<Color> apparentSunColorListener = (observable, oldValue, newValue) -> scene.sun().setApparentColor(ColorUtil.fromFx(newValue));
 
   public LightingTab() throws IOException {
     FXMLLoader loader = new FXMLLoader(getClass().getResource("LightingTab.fxml"));
@@ -146,10 +149,20 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
     sunColor.colorProperty().addListener(sunColorListener);
 
-    modifySunTexture.setTooltip(new Tooltip("Change whether the Sun color control modifies the color of the sun texture"));
+    modifySunTexture.setTooltip(new Tooltip("Change whether the the color of the sun texture is modified by the apparent sun color"));
     modifySunTexture.selectedProperty().addListener((observable, oldValue, newValue) -> {
       scene.sun().setEnableTextureModification(newValue);
+      apparentSunColor.setDisable(!newValue);
     });
+
+    apparentSunColor.setDisable(true);
+    apparentSunColor.colorProperty().addListener(apparentSunColorListener);
+
+    sunRadius.setName("Sun radius");
+    sunRadius.setTooltip("Radius of the sun");
+    sunRadius.setRange(0.01, 10);
+    sunRadius.clampMin();
+    sunRadius.onValueChange(value -> scene.sun().setSunRadius(value));
 
     emitterSamplingStrategy.getItems().addAll(EmitterSamplingStrategy.values());
     emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
@@ -185,6 +198,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());
     apparentSunBrightness.set(scene.sun().getApparentBrightness());
+    sunRadius.set(scene.sun().getSunRadius());
     modifySunTexture.setSelected(scene.sun().getEnableTextureModification());
     sunAzimuth.set(-QuickMath.radToDeg(scene.sun().getAzimuth()));
     sunAltitude.set(QuickMath.radToDeg(scene.sun().getAltitude()));
@@ -194,6 +208,9 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunColor.colorProperty().removeListener(sunColorListener);
     sunColor.setColor(ColorUtil.toFx(scene.sun().getColor()));
     sunColor.colorProperty().addListener(sunColorListener);
+    apparentSunColor.colorProperty().removeListener(apparentSunColorListener);
+    apparentSunColor.setColor(ColorUtil.toFx(scene.sun().getApparentColor()));
+    apparentSunColor.colorProperty().addListener(apparentSunColorListener);
     emitterSamplingStrategy.getSelectionModel().select(scene.getEmitterSamplingStrategy());
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -158,7 +158,6 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     apparentSunBrightness.onValueChange(value -> scene.sun().setApparentBrightness(value));
 
     sunRadius.setName("Sun size");
-    sunRadius.setTooltip("Changes the size of the sun.");
     sunRadius.setRange(0.01, 10);
     sunRadius.clampMin();
     sunRadius.onValueChange(value -> scene.sun().setSunRadius(value));

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -76,7 +76,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
 
   @Override public void initialize(URL location, ResourceBundle resources) {
     skyExposure.setName("Sky exposure");
-    skyExposure.setTooltip("Changes both the Sky light and the Apparent sky light");
+    skyExposure.setTooltip("Changes the exposure of the sky");
     skyExposure.setRange(Sky.MIN_INTENSITY, Sky.MAX_INTENSITY);
     skyExposure.makeLogarithmic();
     skyExposure.clampMin();

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -17,7 +17,7 @@
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="skyExposure" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
-    <DoubleAdjuster fx:id="apparentSkyIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="apparentSkyBrightness" maxWidth="1.7976931348623157E308" />
     <Separator />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
@@ -34,7 +34,7 @@
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="sunLuminosity" maxWidth="Infinity" />
     <DoubleAdjuster fx:id="apparentSunBrightness" maxWidth="Infinity" />
-    <DoubleAdjuster fx:id="sunRadius" maxWidth="-Infinity" />
+    <DoubleAdjuster fx:id="sunRadius" maxWidth="Infinity" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Sunlight color:" />
       <LuxColorPicker fx:id="sunColor" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -34,13 +34,18 @@
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="sunLuminosity" maxWidth="Infinity" />
     <DoubleAdjuster fx:id="apparentSunBrightness" maxWidth="Infinity" />
-    <AngleAdjuster fx:id="sunAzimuth" />
-    <AngleAdjuster fx:id="sunAltitude" />
+    <DoubleAdjuster fx:id="sunRadius" maxWidth="-Infinity" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-      <Label text="Sun color:" />
+      <Label text="Sunlight color:" />
       <LuxColorPicker fx:id="sunColor" />
     </HBox>
     <CheckBox fx:id="modifySunTexture" mnemonicParsing="false" text="Modify sun texture by color" />
+    <HBox alignment="CENTER_LEFT" spacing="10.0">
+      <Label text="Apparent sun color:" />
+      <LuxColorPicker fx:id="apparentSunColor" />
+    </HBox>
+    <AngleAdjuster fx:id="sunAzimuth" />
+    <AngleAdjuster fx:id="sunAltitude" />
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -15,6 +15,7 @@
 
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
+    <DoubleAdjuster fx:id="skyExposure" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="skyIntensity" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="apparentSkyIntensity" maxWidth="1.7976931348623157E308" />
     <Separator />
@@ -32,12 +33,14 @@
     </HBox>
     <DoubleAdjuster fx:id="sunIntensity" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="sunLuminosity" maxWidth="Infinity" />
+    <DoubleAdjuster fx:id="apparentSunBrightness" maxWidth="Infinity" />
     <AngleAdjuster fx:id="sunAzimuth" />
     <AngleAdjuster fx:id="sunAltitude" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Sun color:" />
       <LuxColorPicker fx:id="sunColor" />
     </HBox>
+    <CheckBox fx:id="modifySunTexture" mnemonicParsing="false" text="Modify sun texture by color" />
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>


### PR DESCRIPTION
Fixes #1471.
Fixes #1472.
Fixes #1317.
Closes #54.

- Added a `Sky exposure` control, which changes both the sky brightness and the apparent sky brightness.
- The controls `Sky brightness` and `Apparent sky brightness` modify the values separately.
- Fixed `Apparent sky brightness` changing the apparent brightness of the sun in the path-traced render.
- Added an `Apparent sun brightness` control, which changes the apparent brightness of the texture of the sun. `Sun Intensity` and `Sun Luminosity` no longer change the apparent brightness of the sun.
- Fixed `Draw sun` disabling sunlight.
- Added `Modify sun texture by color`, which changes whether `Apparent sun color` has an effect on the texture of the sun.
- Added `Apparent sun color`, which has an effect on the sun texture if `Modify sun texture by color is enabled.
- Added a `Sun radius` control.

**GUI:**
![image](https://user-images.githubusercontent.com/92183530/196270495-b327cfe7-dc5a-4432-aef5-60a38daa879c.png)

**Sunlight works with `Draw sun` disabled:**
![image](https://user-images.githubusercontent.com/92183530/196170961-e65b307d-fb11-4e9e-9ba7-caf0de9815f8.png)

**Sun color is unchanged when `Modify sun texture by color` is disabled:**
![image](https://user-images.githubusercontent.com/92183530/196173426-0bb21db3-4ab1-4b25-bdf1-1d306f02ce9b.png)

**Custom sun color modifier specified by `Apparent sun color` used when `Modify sun texture by color` is enabled:**
**`Sun radius`: 10:**
![image](https://user-images.githubusercontent.com/92183530/196270272-8f3e5e97-f726-431a-9084-99d90a844f81.png)


