### PR TITLE
Add vertically stacked omni-directional stereo projector

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
@@ -29,7 +29,7 @@ public enum ProjectionMode {
   PANORAMIC_SLOT("Panoramic (slot)"),
   ODS_LEFT("Omni‐directional Stereo (left eye)"),
   ODS_RIGHT("Omni‐directional Stereo (right eye)"),
-  ODS_SPLIT("Omni‐directional Stereo (both eyes, vertically split)");
+  ODS_STACKED("Omni‐directional Stereo (both eyes, vertically stacked)");
 
   private final String niceName;
 

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/ProjectionMode.java
@@ -1,4 +1,5 @@
 /* Copyright (c) 2014 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2022 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -27,7 +28,8 @@ public enum ProjectionMode {
   PANORAMIC("Panoramic (equirectangular)"),
   PANORAMIC_SLOT("Panoramic (slot)"),
   ODS_LEFT("Omni‐directional Stereo (left eye)"),
-  ODS_RIGHT("Omni‐directional Stereo (right eye)");
+  ODS_RIGHT("Omni‐directional Stereo (right eye)"),
+  ODS_SPLIT("Omni‐directional Stereo (both eyes, vertically split)");
 
   private final String niceName;
 

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSSinglePerspectiveProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSSinglePerspectiveProjector.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2016-2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.renderer.projection.stereo;
+
+import se.llbit.math.Vector3;
+
+/**
+ * An Omni-Directional Stereo projector implementation which projects only one of both eyes' perspectives.
+ *
+ * <p>The canvas must have an aspect ratio of 2:1 for a full 360° range.
+ */
+public class ODSSinglePerspectiveProjector extends OmniDirectionalStereoProjector {
+  private final Eye eye;
+
+  public ODSSinglePerspectiveProjector(Eye eye) {
+    this.eye = eye;
+  }
+
+  @Override
+  public void apply(double x, double y, Vector3 pos, Vector3 direction) {
+    switch (eye) {
+      case LEFT:
+        applyLeftEye(x + 0.5, y + 0.5, pos, direction);
+        break;
+      case RIGHT:
+        applyRightEye(x + 0.5, y + 0.5, pos, direction);
+        break;
+    }
+  }
+
+  public enum Eye {
+    LEFT,
+    RIGHT
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSVerticalSplitProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSVerticalSplitProjector.java
@@ -1,0 +1,38 @@
+/* Copyright (c) 2022 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.renderer.projection.stereo;
+
+import se.llbit.math.Vector3;
+
+/**
+ * An Omni-Directional Stereo projector implementation which aligns both eye's perspectives vertically stacked.
+ * The left eye will be in the upper image half, the right eye in the lower half.
+ *
+ * <p>The canvas must have an aspect ratio of 1:1 for a full 360° range.
+ */
+public class ODSVerticalSplitProjector extends OmniDirectionalStereoProjector {
+  @Override
+  public void apply(double x, double y, Vector3 pos, Vector3 direction) {
+    if(y < 0) {
+      // -0.5 - 0.0
+      applyLeftEye(x*2 + 1, y*2 + 1, pos, direction);
+    } else {
+      // 0.0 - 0.5
+      applyRightEye(x*2 + 1, y*2, pos, direction);
+    }
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSVerticalStackedProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/ODSVerticalStackedProjector.java
@@ -24,7 +24,7 @@ import se.llbit.math.Vector3;
  *
  * <p>The canvas must have an aspect ratio of 1:1 for a full 360° range.
  */
-public class ODSVerticalSplitProjector extends OmniDirectionalStereoProjector {
+public class ODSVerticalStackedProjector extends OmniDirectionalStereoProjector {
   @Override
   public void apply(double x, double y, Vector3 pos, Vector3 direction) {
     if(y < 0) {

--- a/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/OmniDirectionalStereoProjector.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/projection/stereo/OmniDirectionalStereoProjector.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Chunky contributors
+/* Copyright (c) 2016-2022 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -14,9 +14,11 @@
  * You should have received a copy of the GNU General Public License
  * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
  */
-package se.llbit.chunky.renderer.projection;
+package se.llbit.chunky.renderer.projection.stereo;
 
 import org.apache.commons.math3.util.FastMath;
+import se.llbit.chunky.renderer.projection.PanoramicProjector;
+import se.llbit.chunky.renderer.projection.Projector;
 import se.llbit.math.Constants;
 import se.llbit.math.Vector3;
 
@@ -30,23 +32,16 @@ import java.util.Random;
  * viewing angle to account for the inter-pupillary distance. This allows to create panoramic
  * stereo images that are perfect for viewing on VR devices.
  *
+ * <p>The resulting image will have a complete 360° range, if and only if the canvas' aspect ratio matches the target format.
+ * See the implementing classes for details.
+ *
  * @see <a href="https://developers.google.com/vr/jump/rendering-ods-content.pdf">Rendering Omni‐directional Stereo Content</a>
  */
-public class OmniDirectionalStereoProjector implements Projector {
+public abstract class OmniDirectionalStereoProjector implements Projector {
   /**
    * The inter-pupillary distance of the viewer, in meters.
    */
-  private static final double interPupillaryDistance = 0.069;
-
-  private final double scale;
-
-  public OmniDirectionalStereoProjector(Eye eye) {
-    if (eye == Eye.LEFT) {
-      scale = -interPupillaryDistance / 2;
-    } else {
-      scale = interPupillaryDistance / 2;
-    }
-  }
+  private static final double INTERPUPILLARY_DISTANCE = 0.069;
 
   @Override
   public void apply(double x, double y, Random random, Vector3 pos, Vector3 direction) {
@@ -54,13 +49,42 @@ public class OmniDirectionalStereoProjector implements Projector {
   }
 
   @Override
-  public void apply(double x, double y, Vector3 pos, Vector3 direction) {
-    double theta = (x + 0.5) * Math.PI - Constants.HALF_PI;
-    double phi = Constants.HALF_PI - (y + 0.5) * Math.PI;
+  public abstract void apply(double x, double y, Vector3 pos, Vector3 direction);
 
-    pos.set(FastMath.cos(theta) * scale, 0, FastMath.sin(theta) * scale);
-    direction.set(FastMath.sin(theta) * FastMath.cos(phi), -FastMath.sin(phi),
-        FastMath.cos(theta) * FastMath.cos(phi));
+  /**
+   * @param x 0-1
+   * @param y 0-1
+   */
+  protected void applyLeftEye(double x, double y, Vector3 pos, Vector3 direction) {
+    apply(x, y, -INTERPUPILLARY_DISTANCE / 2, pos, direction);
+  }
+
+  /**
+   * @param x 0-1
+   * @param y 0-1
+   */
+  protected void applyRightEye(double x, double y, Vector3 pos, Vector3 direction) {
+    apply(x, y, INTERPUPILLARY_DISTANCE / 2, pos, direction);
+  }
+
+  /**
+   * @param x 0-1
+   * @param y 0-1
+   */
+  private void apply(double x, double y, double scale, Vector3 pos, Vector3 direction) {
+    double theta = x * Math.PI - Constants.HALF_PI;
+    double phi = Constants.HALF_PI - y * Math.PI;
+
+    pos.set(
+      FastMath.cos(theta) * scale,
+      0,
+      FastMath.sin(theta) * scale
+    );
+    direction.set(
+      FastMath.sin(theta) * FastMath.cos(phi),
+      -FastMath.sin(phi),
+      FastMath.cos(theta) * FastMath.cos(phi)
+    );
   }
 
   @Override
@@ -76,10 +100,5 @@ public class OmniDirectionalStereoProjector implements Projector {
   @Override
   public double getDefaultFoV() {
     return 180;
-  }
-
-  public enum Eye {
-    LEFT,
-    RIGHT
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
@@ -1,4 +1,5 @@
 /* Copyright (c) 2012-2015 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016-2022 Chunky contributors
  *
  * This file is part of Chunky.
  *
@@ -23,8 +24,9 @@ import se.llbit.chunky.renderer.Refreshable;
 import se.llbit.chunky.renderer.projection.ApertureProjector;
 import se.llbit.chunky.renderer.projection.FisheyeProjector;
 import se.llbit.chunky.renderer.projection.ForwardDisplacementProjector;
-import se.llbit.chunky.renderer.projection.OmniDirectionalStereoProjector;
-import se.llbit.chunky.renderer.projection.OmniDirectionalStereoProjector.Eye;
+import se.llbit.chunky.renderer.projection.stereo.ODSSinglePerspectiveProjector;
+import se.llbit.chunky.renderer.projection.stereo.ODSSinglePerspectiveProjector.Eye;
+import se.llbit.chunky.renderer.projection.stereo.ODSVerticalSplitProjector;
 import se.llbit.chunky.renderer.projection.PanoramicProjector;
 import se.llbit.chunky.renderer.projection.PanoramicSlotProjector;
 import se.llbit.chunky.renderer.projection.ParallelProjector;
@@ -36,7 +38,6 @@ import se.llbit.chunky.renderer.projection.SphericalApertureProjector;
 import se.llbit.chunky.renderer.projection.StereographicProjector;
 import se.llbit.chunky.world.Chunk;
 import se.llbit.json.JsonObject;
-import se.llbit.json.JsonValue;
 import se.llbit.log.Log;
 import se.llbit.math.Matrix3;
 import se.llbit.math.QuickMath;
@@ -244,9 +245,11 @@ public class Camera implements JsonSerializable {
       case STEREOGRAPHIC:
         return new StereographicProjector(fov);
       case ODS_LEFT:
-        return new OmniDirectionalStereoProjector(Eye.LEFT);
+        return new ODSSinglePerspectiveProjector(Eye.LEFT);
       case ODS_RIGHT:
-        return new OmniDirectionalStereoProjector(Eye.RIGHT);
+        return new ODSSinglePerspectiveProjector(Eye.RIGHT);
+      case ODS_SPLIT:
+        return new ODSVerticalSplitProjector();
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
@@ -26,7 +26,7 @@ import se.llbit.chunky.renderer.projection.FisheyeProjector;
 import se.llbit.chunky.renderer.projection.ForwardDisplacementProjector;
 import se.llbit.chunky.renderer.projection.stereo.ODSSinglePerspectiveProjector;
 import se.llbit.chunky.renderer.projection.stereo.ODSSinglePerspectiveProjector.Eye;
-import se.llbit.chunky.renderer.projection.stereo.ODSVerticalSplitProjector;
+import se.llbit.chunky.renderer.projection.stereo.ODSVerticalStackedProjector;
 import se.llbit.chunky.renderer.projection.PanoramicProjector;
 import se.llbit.chunky.renderer.projection.PanoramicSlotProjector;
 import se.llbit.chunky.renderer.projection.ParallelProjector;
@@ -248,8 +248,8 @@ public class Camera implements JsonSerializable {
         return new ODSSinglePerspectiveProjector(Eye.LEFT);
       case ODS_RIGHT:
         return new ODSSinglePerspectiveProjector(Eye.RIGHT);
-      case ODS_SPLIT:
-        return new ODSVerticalSplitProjector();
+      case ODS_STACKED:
+        return new ODSVerticalStackedProjector();
     }
   }
 


### PR DESCRIPTION
Adds a vertically split ODS projector which contains both eye's perspectives of a 360° image in a vertically split image.
This matches the way Google documented the 360° media format: [rendering documentation](https://developers.google.com/vr/jump/rendering-ods-content.pdf#page=7), [WebVR library documentation](https://developers.google.com/vr/discover/360-degree-media).