### PR TITLE
Add a `Metalness` control for beacon beams

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
@@ -343,6 +343,10 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         perceptualSmoothness.setName("Smoothness");
         perceptualSmoothness.setRange(0, 1);
 
+        DoubleAdjuster metalness = new DoubleAdjuster();
+        metalness.setName("Metalness");
+        metalness.setRange(0, 1);
+
         LuxColorPicker beamColorPicker = new LuxColorPicker();
 
         ObservableList<Integer> colorHeights = FXCollections.observableArrayList();
@@ -357,6 +361,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
               specular.set(beamMat.specular);
               ior.set(beamMat.ior);
               perceptualSmoothness.set(beamMat.getPerceptualSmoothness());
+              metalness.set(beamMat.metalness);
               beamColorPicker.setColor(ColorUtil.toFx(beamMat.getColorInt()));
 
               emittance.onValueChange(value -> {
@@ -373,6 +378,10 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
               });
               perceptualSmoothness.onValueChange(value -> {
                 beamMat.setPerceptualSmoothness(value);
+                scene.rebuildActorBvh();
+              });
+              metalness.onValueChange(value -> {
+                beamMat.metalness = value.floatValue();
                 scene.rebuildActorBvh();
               });
             }
@@ -411,7 +420,7 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         });
 
         listButtons.getChildren().addAll(deleteButton, layerInput, addButton);
-        propertyControls.getChildren().addAll(emittance, specular, perceptualSmoothness, ior, beamColorPicker);
+        propertyControls.getChildren().addAll(emittance, specular, perceptualSmoothness, ior, metalness, beamColorPicker);
         listControls.getChildren().addAll(new Label("Start Height:"), colorHeightList, listButtons);
         beamColor.getChildren().addAll(listControls, propertyControls);
         controls.getChildren().add(beamColor);

--- a/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
+++ b/chunky/src/java/se/llbit/chunky/world/material/BeaconBeamMaterial.java
@@ -61,6 +61,7 @@ public class BeaconBeamMaterial extends Material {
         json.add("specular", this.specular);
         json.add("emittance", this.emittance);
         json.add("roughness", this.roughness);
+        json.add("metalness", this.metalness);
         json.add("color", this.color);
     }
 }


### PR DESCRIPTION
Previously, there was no way to change the `Metalness` material property for beacon beams. This PR adds a control to change that.

**GUI:**
![image](https://user-images.githubusercontent.com/92183530/197363241-78820bcf-6d7b-4f7e-8416-db1bebc225e6.png)

**Effect:**
![image](https://user-images.githubusercontent.com/92183530/197363201-2d542986-7568-4195-8e62-f65e072dfb4e.png)
