### PR TITLE
Save sky color as an RGB object

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -643,7 +643,6 @@ public class Sky implements JsonSerializable {
     colorObj.add("green", color.y);
     colorObj.add("blue", color.z);
     sky.add("color", colorObj);
-    //sky.add("color", JsonUtil.vec3ToJson(color));
 
     switch (mode) {
       case SKYMAP_PANORAMIC:

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sky.java
@@ -638,7 +638,12 @@ public class Sky implements JsonSerializable {
     // Always save gradient.
     sky.add("gradient", gradientJson(gradient));
 
-    sky.add("color", JsonUtil.vec3ToJson(color));
+    JsonObject colorObj = new JsonObject();
+    colorObj.add("red", color.x);
+    colorObj.add("green", color.y);
+    colorObj.add("blue", color.z);
+    sky.add("color", colorObj);
+    //sky.add("color", JsonUtil.vec3ToJson(color));
 
     switch (mode) {
       case SKYMAP_PANORAMIC:
@@ -696,7 +701,15 @@ public class Sky implements JsonSerializable {
       }
     }
 
-    color.set(JsonUtil.vec3FromJsonArray(json.get("color")));
+    if (json.get("color").isObject()) {
+      JsonObject colorObj = json.get("color").object();
+      color.x = colorObj.get("red").doubleValue(1);
+      color.y = colorObj.get("green").doubleValue(1);
+      color.z = colorObj.get("blue").doubleValue(1);
+    } else {
+      // Maintain backwards-compatibility with scenes saved in older Chunky versions
+      color.set(JsonUtil.vec3FromJsonArray(json.get("color")));
+    }
 
     switch (mode) {
       case SKYMAP_PANORAMIC: {


### PR DESCRIPTION
Partial fix for #1069.

Save sky color as an RGB object while maintaining backwards-compatibility with scenes saved in older Chunky versions.

**Old:**
```json
    "color": [
      0.0,
      0.0,
      0.0
    ],
```

**New:**
```json
    "color": {
      "red": 0.671875,
      "green": 0.29656982421875,
      "blue": 0.29656982421875
    }
```