### PR TITLE
Make `Vertical resolution` box use no space when `Sky mode` is set to `Skymap (angular)`

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/settings/SkymapSettings.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/settings/SkymapSettings.java
@@ -54,6 +54,7 @@ public class SkymapSettings extends VBox implements Initializable {
 
   public void setPanoramic(boolean pano) {
     panoSpecific.setVisible(pano);
+    panoSpecific.setManaged(pano);
   }
 
   @Override public void initialize(URL location, ResourceBundle resources) {


### PR DESCRIPTION
**Previous:**
![image](https://user-images.githubusercontent.com/92183530/203574360-08809264-3c72-47fe-bc5c-1881476cb531.png)

**New:**
![image](https://user-images.githubusercontent.com/92183530/203574739-3612a3d2-2b40-4862-be47-3173b29357e2.png)
