### PR TITLE
Improve how translucent materials handle color

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -343,9 +343,23 @@ public class PathTracer implements RayTracer {
                 }
 
                 if (pathTrace(scene, refracted, state, 1, false)) {
-                  ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
-                  ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
-                  ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
+                  // Color-based transmission value
+                  double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
+                  // Total amount of light we want to transmit (overall transparency of texture)
+                  double shouldTrans = 1 - pDiffuse;
+                  // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
+                  double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
+                  if(colorTrans > 0) {
+                    // Amount to transmit of each color is scaled so the total transmitted amount matches the texture's transparency
+                    rTrans = ray.color.x * shouldTrans / colorTrans;
+                    gTrans = ray.color.y * shouldTrans / colorTrans;
+                    bTrans = ray.color.z * shouldTrans / colorTrans;
+                  }
+                  // Set transparent and opaque components of each color channel
+                  ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
+                  ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
+                  ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
+                  // Scale by results from refracted ray
                   ray.color.x *= refracted.color.x;
                   ray.color.y *= refracted.color.y;
                   ray.color.z *= refracted.color.z;
@@ -362,9 +376,23 @@ public class PathTracer implements RayTracer {
           transmitted.o.scaleAdd(Ray.OFFSET, transmitted.d);
 
           if (pathTrace(scene, transmitted, state, 1, false)) {
-            ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
-            ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
-            ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
+            // Color-based transmission value
+            double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
+            // Total amount of light we want to transmit (overall transparency of texture)
+            double shouldTrans = 1 - pDiffuse;
+            // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
+            double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
+            if(colorTrans > 0) {
+              // Amount to transmit of each color is scaled so the total transmitted amount matches the texture's transparency
+              rTrans = ray.color.x * shouldTrans / colorTrans;
+              gTrans = ray.color.y * shouldTrans / colorTrans;
+              bTrans = ray.color.z * shouldTrans / colorTrans;
+            }
+            // Set transparent and opaque components of each color channel
+            ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
+            ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
+            ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
+            // Scale by results from transmitted ray
             ray.color.x *= transmitted.color.x;
             ray.color.y *= transmitted.color.y;
             ray.color.z *= transmitted.color.z;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -360,9 +360,13 @@ public class PathTracer implements RayTracer {
                   ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
                   ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
                   // Scale by results from refracted ray
+                  ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
                   ray.color.x *= refracted.color.x;
                   ray.color.y *= refracted.color.y;
                   ray.color.z *= refracted.color.z;
+                  ray.emittance.x *= refracted.emittance.x;
+                  ray.emittance.y *= refracted.emittance.y;
+                  ray.emittance.z *= refracted.emittance.z;
                   hit = true;
                 }
               }
@@ -393,9 +397,13 @@ public class PathTracer implements RayTracer {
             ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
             ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
             // Scale by results from transmitted ray
+            ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
             ray.color.x *= transmitted.color.x;
             ray.color.y *= transmitted.color.y;
             ray.color.z *= transmitted.color.z;
+            ray.emittance.x *= transmitted.emittance.x;
+            ray.emittance.y *= transmitted.emittance.y;
+            ray.emittance.z *= transmitted.emittance.z;
             hit = true;
           }
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -343,23 +343,9 @@ public class PathTracer implements RayTracer {
                 }
 
                 if (pathTrace(scene, refracted, state, 1, false)) {
-                  // Color-based transmission value
-                  double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
-                  // Total amount of light we want to transmit (overall transparency of texture)
-                  double shouldTrans = 1 - pDiffuse;
-                  // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
-                  double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
-                  if(colorTrans > 0) {
-                    // Amount to transmit of each color is scaled so the total transmitted amount matches the texture's transparency
-                    rTrans = ray.color.x * shouldTrans / colorTrans;
-                    gTrans = ray.color.y * shouldTrans / colorTrans;
-                    bTrans = ray.color.z * shouldTrans / colorTrans;
-                  }
-                  // Set transparent and opaque components of each color channel
-                  ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
-                  ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
-                  ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
-                  // Scale by results from refracted ray
+                  // Calculate the color of the refracted ray
+                  translucentRayColor(ray, pDiffuse);
+                  // Set ray emittance and color based on its own color and the next ray's properties
                   ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
                   ray.color.x *= refracted.color.x;
                   ray.color.y *= refracted.color.y;
@@ -380,23 +366,9 @@ public class PathTracer implements RayTracer {
           transmitted.o.scaleAdd(Ray.OFFSET, transmitted.d);
 
           if (pathTrace(scene, transmitted, state, 1, false)) {
-            // Color-based transmission value
-            double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
-            // Total amount of light we want to transmit (overall transparency of texture)
-            double shouldTrans = 1 - pDiffuse;
-            // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
-            double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
-            if(colorTrans > 0) {
-              // Amount to transmit of each color is scaled so the total transmitted amount matches the texture's transparency
-              rTrans = ray.color.x * shouldTrans / colorTrans;
-              gTrans = ray.color.y * shouldTrans / colorTrans;
-              bTrans = ray.color.z * shouldTrans / colorTrans;
-            }
-            // Set transparent and opaque components of each color channel
-            ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
-            ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
-            ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
-            // Scale by results from transmitted ray
+            // Calculate the color of the transmitted ray
+            translucentRayColor(ray, pDiffuse);
+            // Set ray emittance and color based on its own color and the next ray's properties
             ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
             ray.color.x *= transmitted.color.x;
             ray.color.y *= transmitted.color.y;
@@ -475,6 +447,25 @@ public class PathTracer implements RayTracer {
     }
 
     return hit;
+  }
+
+  private static void translucentRayColor(Ray ray, double pDiffuse) {
+    // Color-based transmission value
+    double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
+    // Total amount of light we want to transmit (overall transparency of texture)
+    double shouldTrans = 1 - pDiffuse;
+    // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
+    double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
+    if(colorTrans > 0) {
+      // Amount to transmit of each color is scaled so the total transmitted amount matches the texture's transparency
+      rTrans = ray.color.x * shouldTrans / colorTrans;
+      gTrans = ray.color.y * shouldTrans / colorTrans;
+      bTrans = ray.color.z * shouldTrans / colorTrans;
+    }
+    // Set transparent and opaque components of each color channel
+    ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
+    ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
+    ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
   }
 
   private static void sampleEmitterFace(Scene scene, Ray ray, Grid.EmitterPosition pos, int face, Vector4 result, double scaler, Random random) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -343,16 +343,8 @@ public class PathTracer implements RayTracer {
                 }
 
                 if (pathTrace(scene, refracted, state, 1, false)) {
-                  // Calculate the color of the refracted ray
-                  translucentRayColor(ray, pDiffuse);
-                  // Set ray emittance and color based on its own color and the next ray's properties
-                  ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
-                  ray.color.x *= refracted.color.x;
-                  ray.color.y *= refracted.color.y;
-                  ray.color.z *= refracted.color.z;
-                  ray.emittance.x *= refracted.emittance.x;
-                  ray.emittance.y *= refracted.emittance.y;
-                  ray.emittance.z *= refracted.emittance.z;
+                  // Calculate the color and emittance of the refracted ray
+                  translucentRayColor(ray, refracted, pDiffuse);
                   hit = true;
                 }
               }
@@ -366,16 +358,8 @@ public class PathTracer implements RayTracer {
           transmitted.o.scaleAdd(Ray.OFFSET, transmitted.d);
 
           if (pathTrace(scene, transmitted, state, 1, false)) {
-            // Calculate the color of the transmitted ray
-            translucentRayColor(ray, pDiffuse);
-            // Set ray emittance and color based on its own color and the next ray's properties
-            ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
-            ray.color.x *= transmitted.color.x;
-            ray.color.y *= transmitted.color.y;
-            ray.color.z *= transmitted.color.z;
-            ray.emittance.x *= transmitted.emittance.x;
-            ray.emittance.y *= transmitted.emittance.y;
-            ray.emittance.z *= transmitted.emittance.z;
+            // Calculate the color and emittance of the transmitted ray
+            translucentRayColor(ray, transmitted, pDiffuse);
             hit = true;
           }
         }
@@ -449,11 +433,11 @@ public class PathTracer implements RayTracer {
     return hit;
   }
 
-  private static void translucentRayColor(Ray ray, double pDiffuse) {
+  private static void translucentRayColor(Ray ray, Ray next, double opacity) {
     // Color-based transmission value
     double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
     // Total amount of light we want to transmit (overall transparency of texture)
-    double shouldTrans = 1 - pDiffuse;
+    double shouldTrans = 1 - opacity;
     // Amount of each color to transmit - default to overall transparency if RGB values add to 0 (e.g. regular glass)
     double rTrans = shouldTrans, gTrans = shouldTrans, bTrans = shouldTrans;
     if(colorTrans > 0) {
@@ -466,6 +450,13 @@ public class PathTracer implements RayTracer {
     ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
     ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
     ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
+    ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
+    ray.color.x *= next.color.x;
+    ray.color.y *= next.color.y;
+    ray.color.z *= next.color.z;
+    ray.emittance.x *= next.emittance.x;
+    ray.emittance.y *= next.emittance.y;
+    ray.emittance.z *= next.emittance.z;
   }
 
   private static void sampleEmitterFace(Scene scene, Ray ray, Grid.EmitterPosition pos, int face, Vector4 result, double scaler, Random random) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -450,13 +450,9 @@ public class PathTracer implements RayTracer {
     ray.color.x = (1 - rTrans) * ray.color.x + rTrans;
     ray.color.y = (1 - gTrans) * ray.color.y + gTrans;
     ray.color.z = (1 - bTrans) * ray.color.z + bTrans;
-    ray.emittance.set(ray.color.x, ray.color.y, ray.color.z);
     ray.color.x *= next.color.x;
     ray.color.y *= next.color.y;
     ray.color.z *= next.color.z;
-    ray.emittance.x *= next.emittance.x;
-    ray.emittance.y *= next.emittance.y;
-    ray.emittance.z *= next.emittance.z;
   }
 
   private static void sampleEmitterFace(Scene scene, Ray ray, Grid.EmitterPosition pos, int face, Vector4 result, double scaler, Random random) {


### PR DESCRIPTION
Instead of using the texture's opacity directly to determine how much to filter the inbound ray color, the path tracer should first determine how much total light would be transmitted out of white inbound light if each color channel were simply multiplied, that is, transmitted light = (R + G + B)/3. Then, this is scaled based on the desired opacity as given by the texture. The result is that at least for white light, the total proportion of light that is transmitted is equal to 1 minus the alpha value of the texture. For example, a pure red texture with 33% transparency (alpha = 0.67) would transmit 100% of red light and 0% of other light. The way Chunky currently works, it would transmit 100% of red light and 33% of green and blue light, which is less accurate since 33% total transparency is already achieved by allowing the red light to pass.

One caveat is that when a texture has an unusually low opacity but a high color saturation, it could result in that color being amplified as it passes through while the others are blocked. This could be realistic in some situations, i.e. absorbing light at one frequency and re-emitting it at another, but depending on whether this has unwanted effects within Minecraft's block palette, the algorithm could be modified to better handle such cases.

@ThatRedox also wrote a potential fix to #608 which I originally included in my fork but isn't currently included in this PR due to it needing more testing. However, I have included examples both with and without this fix. For reference, [here](https://github.com/chunky-dev/chunky/commit/72aecbe51b3925991bb2cd51a69e4c29cbbdf3d1) is the commit where this fix was removed.

[default_2022-12-10_13-57-28.zip](https://github.com/chunky-dev/chunky/files/10200843/default_2022-12-10_13-57-28.zip)
Before:
![image](https://user-images.githubusercontent.com/46458276/206872958-7ad6446f-3623-4ec2-a5c0-2f908e5e4c4a.png)
After:
![image](https://user-images.githubusercontent.com/46458276/206875364-baa848e2-2f43-4d77-bb73-adfd4017b226.png)
After (with Redox's fix):
![image](https://user-images.githubusercontent.com/46458276/206873390-60a62db6-4a20-4749-bf42-58f962315525.png)

[default_2022-12-10_01-27-54.zip](https://github.com/chunky-dev/chunky/files/10200845/default_2022-12-10_01-27-54.zip)
Before:
![image](https://user-images.githubusercontent.com/46458276/206873055-e1bad4c8-f5cb-44ff-aeec-5f674d05fb2f.png)
After:
![image](https://user-images.githubusercontent.com/46458276/206875491-373e28e8-cf0a-46a1-a958-f942e317cedc.png)
After (with Redox's fix):
![image](https://user-images.githubusercontent.com/46458276/206873302-823a1676-ead5-4a84-942d-004855a8577c.png)

(scene is too big to upload)
Before:
![image](https://user-images.githubusercontent.com/46458276/206874796-a97c8809-9cab-457b-9f14-fb4b0fdc0951.png)
After:
![image](https://user-images.githubusercontent.com/46458276/206875629-d404c561-6b85-467b-88c0-3f34649c2c7a.png)
After (with Redox's fix):
![image](https://user-images.githubusercontent.com/46458276/206874993-557b4a87-b3bd-483d-99e2-3e0f50d1dffc.png)
