### PR TITLE
Carry energy through specular reflection, metallic reflection, and transmission.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -140,6 +140,10 @@ public class PathTracer implements RayTracer {
           reflected.specularReflection(ray, random);
 
           if (pathTrace(scene, reflected, state, 1, false)) {
+            ray.emittance.x = ray.color.x * reflected.emittance.x;
+            ray.emittance.y = ray.color.y * reflected.emittance.y;
+            ray.emittance.z = ray.color.z * reflected.emittance.z;
+
             if (doMetal) {
               // use the albedo color as specular color
               ray.color.x *= reflected.color.x;
@@ -308,6 +312,10 @@ public class PathTracer implements RayTracer {
                 Ray reflected = new Ray();
                 reflected.specularReflection(ray, random);
                 if (pathTrace(scene, reflected, state, 1, false)) {
+                  ray.emittance.x = ray.color.x * reflected.emittance.x;
+                  ray.emittance.y = ray.color.x * reflected.emittance.y;
+                  ray.emittance.z = ray.color.x * reflected.emittance.z;
+
                   ray.color.x = reflected.color.x;
                   ray.color.y = reflected.color.y;
                   ray.color.z = reflected.color.z;
@@ -346,6 +354,11 @@ public class PathTracer implements RayTracer {
                   ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
                   ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
                   ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
+
+                  ray.emittance.x = ray.color.x * refracted.emittance.x;
+                  ray.emittance.y = ray.color.x * refracted.emittance.y;
+                  ray.emittance.z = ray.color.x * refracted.emittance.z;
+
                   ray.color.x *= refracted.color.x;
                   ray.color.y *= refracted.color.y;
                   ray.color.z *= refracted.color.z;
@@ -365,6 +378,11 @@ public class PathTracer implements RayTracer {
             ray.color.x = ray.color.x * pDiffuse + (1 - pDiffuse);
             ray.color.y = ray.color.y * pDiffuse + (1 - pDiffuse);
             ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
+
+            ray.emittance.x = ray.color.x * transmitted.emittance.x;
+            ray.emittance.y = ray.color.x * transmitted.emittance.y;
+            ray.emittance.z = ray.color.x * transmitted.emittance.z;
+
             ray.color.x *= transmitted.color.x;
             ray.color.y *= transmitted.color.y;
             ray.color.z *= transmitted.color.z;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -313,8 +313,8 @@ public class PathTracer implements RayTracer {
                 reflected.specularReflection(ray, random);
                 if (pathTrace(scene, reflected, state, 1, false)) {
                   ray.emittance.x = ray.color.x * reflected.emittance.x;
-                  ray.emittance.y = ray.color.x * reflected.emittance.y;
-                  ray.emittance.z = ray.color.x * reflected.emittance.z;
+                  ray.emittance.y = ray.color.y * reflected.emittance.y;
+                  ray.emittance.z = ray.color.z * reflected.emittance.z;
 
                   ray.color.x = reflected.color.x;
                   ray.color.y = reflected.color.y;
@@ -356,8 +356,8 @@ public class PathTracer implements RayTracer {
                   ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
 
                   ray.emittance.x = ray.color.x * refracted.emittance.x;
-                  ray.emittance.y = ray.color.x * refracted.emittance.y;
-                  ray.emittance.z = ray.color.x * refracted.emittance.z;
+                  ray.emittance.y = ray.color.y * refracted.emittance.y;
+                  ray.emittance.z = ray.color.z * refracted.emittance.z;
 
                   ray.color.x *= refracted.color.x;
                   ray.color.y *= refracted.color.y;
@@ -380,8 +380,8 @@ public class PathTracer implements RayTracer {
             ray.color.z = ray.color.z * pDiffuse + (1 - pDiffuse);
 
             ray.emittance.x = ray.color.x * transmitted.emittance.x;
-            ray.emittance.y = ray.color.x * transmitted.emittance.y;
-            ray.emittance.z = ray.color.x * transmitted.emittance.z;
+            ray.emittance.y = ray.color.y * transmitted.emittance.y;
+            ray.emittance.z = ray.color.z * transmitted.emittance.z;
 
             ray.color.x *= transmitted.color.x;
             ray.color.y *= transmitted.color.y;


### PR DESCRIPTION
Fixes #1512.
Fixes #608.
Fixes #1231.

Test scene reflects emitters off a 100% specular floor:
![2022-12-10_17 34 23](https://user-images.githubusercontent.com/42661490/206882390-917fedd6-0964-43a8-82cd-0a7a23a7b65e.png)

Master:
![image](https://user-images.githubusercontent.com/42661490/206882286-9a7b364d-15d3-47a7-8233-a2c3aa9c86a4.png)
PR:
![image](https://user-images.githubusercontent.com/42661490/206882343-a0ff4dd4-cbbc-467d-afcd-66350a7160f6.png)
Equivalent scene in Blender:
![untitled](https://user-images.githubusercontent.com/42661490/206882299-2ec8eb41-e88f-483d-92fa-b39ba76fd205.png)
