### PR TITLE
Reduce size of light block model

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/LightBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/LightBlock.java
@@ -41,7 +41,6 @@ public class LightBlock extends AbstractModelBlock {
             || ray.depth >= scene.getRayDepth() - 1 || ray.specular)) {
       return false;
     }
-    ray.color.set(1, 1, 1, 1);
     return this.model.intersect(ray, scene);
   }
 

--- a/chunky/src/java/se/llbit/chunky/block/LightBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/LightBlock.java
@@ -1,12 +1,14 @@
 package se.llbit.chunky.block;
 
+import se.llbit.chunky.model.LightBlockModel;
 import se.llbit.chunky.model.TexturedBlockModel;
 import se.llbit.chunky.renderer.RenderMode;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Ray;
+import se.llbit.math.Vector4;
 
-public class LightBlock extends MinecraftBlockTranslucent {
+public class LightBlock extends AbstractModelBlock {
 
   private static final TexturedBlockModel previewBlockModel = new TexturedBlockModel(
       Texture.light, Texture.light, Texture.light,
@@ -15,9 +17,12 @@ public class LightBlock extends MinecraftBlockTranslucent {
 
   private final int level;
 
+  private final Vector4 color = new Vector4(1, 1, 1, 1);
+
   public LightBlock(String name, int level) {
-    super(name, Texture.EMPTY_TEXTURE);
+    super(name, Texture.light);
     this.level = level;
+    this.model = new LightBlockModel(color);
     localIntersect = true;
     solid = false;
   }
@@ -37,7 +42,7 @@ public class LightBlock extends MinecraftBlockTranslucent {
       return false;
     }
     ray.color.set(1, 1, 1, 1);
-    return true;
+    return this.model.intersect(ray, scene);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -562,7 +562,7 @@ public class BlockPalette {
     });
     materialProperties.put("minecraft:light", block -> {
       if (block instanceof LightBlock) {
-        block.emittance = 1.0f / 15f * ((LightBlock) block).getLevel();
+        block.emittance = 1.0f / 15f * 4 * ((LightBlock) block).getLevel();
       }
     });
     materialProperties.put("minecraft:ochre_froglight", block -> {

--- a/chunky/src/java/se/llbit/chunky/model/LightBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/LightBlockModel.java
@@ -1,0 +1,47 @@
+package se.llbit.chunky.model;
+
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.AABB;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector4;
+
+public class LightBlockModel extends AABBModel {
+  public static final AABB[] aabb = { new AABB(0.125, 0.875, 0.125, 0.875, 0.125, 0.875) };
+
+  private final AABB[] box = aabb;
+
+  private final Texture[][] textures = new Texture[][] {{
+    Texture.light, Texture.light, Texture.light,
+    Texture.light, Texture.light, Texture.light
+  }};
+
+  private final Vector4 color;
+
+  public LightBlockModel(Vector4 color) {
+    this.color = color;
+  }
+
+  @Override
+  public AABB[] getBoxes() {
+    return box;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    boolean hit = false;
+    AABB[] boxes = getBoxes();
+    ray.t = Double.POSITIVE_INFINITY;
+    if (boxes[0].intersect(ray)) {
+      ray.color.set(color);
+      hit = true;
+      ray.t = ray.tNext;
+    }
+    return hit;
+  }
+
+  @Override
+  public Texture[][] getTextures() {
+    return textures;
+  }
+}


### PR DESCRIPTION
- Reduced the size of the light block model from a full block to 1/2 block length cubed.
- Quadrupled default emittance values for light blocks to compensate.

Previously, light blocks would unnaturally fully illuminate any texture directly adjacent to it. By reducing the size of the model, this effect is eliminated.

**Old:**
![light_block_test-32](https://user-images.githubusercontent.com/92183530/209876514-1e53d0eb-fdff-4208-a4e8-cd43e68128df.png)

**New: (actual results are similar; this is an older render)**
![light_block_test-32 2](https://user-images.githubusercontent.com/92183530/209876531-e66601ec-5a44-4ab0-9894-0d392b368426.png)
