### PR TITLE
Add UE4 filmic tone mapping and make Hable tone mapping configurable.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
@@ -2,6 +2,8 @@ package se.llbit.chunky.renderer.postprocessing;
 
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.json.JsonObject;
+import se.llbit.util.Configurable;
 
 /**
  * Implementation of Hable (i.e. Uncharted 2) tone mapping
@@ -9,7 +11,7 @@ import se.llbit.chunky.renderer.scene.Scene;
  * @link http://filmicworlds.com/blog/filmic-tonemapping-operators/
  * @link https://www.gdcvault.com/play/1012351/Uncharted-2-HDR
  */
-public class HableToneMappingFilter extends SimplePixelPostProcessingFilter {
+public class HableToneMappingFilter extends SimplePixelPostProcessingFilter implements Configurable {
   public enum Preset {
     /**
      * Parameters from <a href="http://filmicworlds.com/blog/filmic-tonemapping-operators/">John Hable's blog post</a>
@@ -148,5 +150,29 @@ public class HableToneMappingFilter extends SimplePixelPostProcessingFilter {
   @Override
   public String getId() {
     return "TONEMAP3";
+  }
+
+  @Override
+  public void loadConfiguration(JsonObject json) {
+    reset();
+    hA = json.get("shoulderStrength").floatValue(hA);
+    hB = json.get("linearStrength").floatValue(hB);
+    hC = json.get("linearAngle").floatValue(hC);
+    hD = json.get("toeStrength").floatValue(hD);
+    hE = json.get("toeNumerator").floatValue(hE);
+    hF = json.get("toeDenominator").floatValue(hF);
+    hW = json.get("linearWhitePointValue").floatValue(hW);
+    recalculateWhiteScale();
+  }
+
+  @Override
+  public void storeConfiguration(JsonObject json) {
+    json.add("shoulderStrength", hA);
+    json.add("linearStrength", hB);
+    json.add("linearAngle", hC);
+    json.add("toeStrength", hD);
+    json.add("toeNumerator", hE);
+    json.add("toeDenominator", hF);
+    json.add("linearWhitePointValue", hW);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
@@ -1,8 +1,13 @@
 package se.llbit.chunky.renderer.postprocessing;
 
+import org.apache.commons.math3.util.FastMath;
+import se.llbit.chunky.renderer.scene.Scene;
+
 /**
  * Implementation of Hable tone mapping
+ *
  * @link http://filmicworlds.com/blog/filmic-tonemapping-operators/
+ * @link https://www.gdcvault.com/play/1012351/Uncharted-2-HDR
  */
 public class HableToneMappingFilter extends SimplePixelPostProcessingFilter {
   private static final float hA = 0.15f;
@@ -16,12 +21,11 @@ public class HableToneMappingFilter extends SimplePixelPostProcessingFilter {
   
   @Override
   public void processPixel(double[] pixel) {
-    // This adjusts the exposure by a factor of 16 so that the resulting exposure approximately matches the other
-    // post-processing methods. Without this, the image would be very dark.
-    for(int i = 0; i < 3; ++i) {
-      pixel[i] *= 16;
+    for (int i = 0; i < 3; ++i) {
+      pixel[i] *= 2; // exposure bias
       pixel[i] = ((pixel[i] * (hA * pixel[i] + hC * hB) + hD * hE) / (pixel[i] * (hA * pixel[i] + hB) + hD * hF)) - hE / hF;
       pixel[i] *= whiteScale;
+      pixel[i] = FastMath.pow(pixel[i], 1 / Scene.DEFAULT_GAMMA);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/HableToneMappingFilter.java
@@ -4,21 +4,132 @@ import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
 
 /**
- * Implementation of Hable tone mapping
+ * Implementation of Hable (i.e. Uncharted 2) tone mapping
  *
  * @link http://filmicworlds.com/blog/filmic-tonemapping-operators/
  * @link https://www.gdcvault.com/play/1012351/Uncharted-2-HDR
  */
 public class HableToneMappingFilter extends SimplePixelPostProcessingFilter {
-  private static final float hA = 0.15f;
-  private static final float hB = 0.50f;
-  private static final float hC = 0.10f;
-  private static final float hD = 0.20f;
-  private static final float hE = 0.02f;
-  private static final float hF = 0.30f;
-  private static final float hW = 11.2f;
-  private static final float whiteScale = 1.0f / (((hW * (hA * hW + hC * hB) + hD * hE) / (hW * (hA * hW + hB) + hD * hF)) - hE / hF);
-  
+  public enum Preset {
+    /**
+     * Parameters from <a href="http://filmicworlds.com/blog/filmic-tonemapping-operators/">John Hable's blog post</a>
+     */
+    FILMIC_WORLDS,
+
+    /**
+     * Parameters from <a href="https://www.gdcvault.com/play/1012351/Uncharted-2-HDR">John Hable's GDC talk</a>
+     */
+    GDC
+  }
+
+  private float hA;
+  private float hB;
+  private float hC;
+  private float hD;
+  private float hE;
+  private float hF;
+  private float hW;
+  private float whiteScale;
+
+  public HableToneMappingFilter() {
+    reset();
+  }
+
+  private void recalculateWhiteScale() {
+    whiteScale = 1.0f / (((hW * (hA * hW + hC * hB) + hD * hE) / (hW * (hA * hW + hB) + hD * hF)) - hE / hF);
+  }
+
+  public float getShoulderStrength() {
+    return hA;
+  }
+
+  public void setShoulderStrength(float hA) {
+    this.hA = hA;
+    recalculateWhiteScale();
+  }
+
+  public float getLinearStrength() {
+    return hB;
+  }
+
+  public void setLinearStrength(float hB) {
+    this.hB = hB;
+    recalculateWhiteScale();
+  }
+
+  public float getLinearAngle() {
+    return hC;
+  }
+
+  public void setLinearAngle(float hC) {
+    this.hC = hC;
+    recalculateWhiteScale();
+  }
+
+  public float getToeStrength() {
+    return hD;
+  }
+
+  public void setToeStrength(float hD) {
+    this.hD = hD;
+    recalculateWhiteScale();
+  }
+
+  public float getToeNumerator() {
+    return hE;
+  }
+
+  public void setToeNumerator(float hE) {
+    this.hE = hE;
+    recalculateWhiteScale();
+  }
+
+  public float getToeDenominator() {
+    return hF;
+  }
+
+  public void setToeDenominator(float hF) {
+    this.hF = hF;
+    recalculateWhiteScale();
+  }
+
+  public float getLinearWhitePointValue() {
+    return hW;
+  }
+
+  public void setLinearWhitePointValue(float hW) {
+    this.hW = hW;
+    recalculateWhiteScale();
+  }
+
+  public void reset() {
+    applyPreset(Preset.FILMIC_WORLDS);
+  }
+
+  public void applyPreset(Preset preset) {
+    switch (preset) {
+      case FILMIC_WORLDS:
+        hA = 0.15f;
+        hB = 0.50f;
+        hC = 0.10f;
+        hD = 0.20f;
+        hE = 0.02f;
+        hF = 0.30f;
+        hW = 11.2f;
+        break;
+      case GDC:
+        hA = 0.22f;
+        hB = 0.30f;
+        hC = 0.10f;
+        hD = 0.20f;
+        hE = 0.01f;
+        hF = 0.30f;
+        hW = 11.2f;
+        break;
+    }
+    recalculateWhiteScale();
+  }
+
   @Override
   public void processPixel(double[] pixel) {
     for (int i = 0; i < 3; ++i) {

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilter.java
@@ -2,6 +2,7 @@ package se.llbit.chunky.renderer.postprocessing;
 
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.util.Registerable;
 import se.llbit.util.TaskTracker;
 
 /**
@@ -14,7 +15,7 @@ import se.llbit.util.TaskTracker;
  * PixelPostProcessingFilter} instead.
  */
 @PluginApi
-public interface PostProcessingFilter {
+public interface PostProcessingFilter extends Registerable {
   /**
    * Post process the entire frame
    * @param width The width of the image
@@ -27,22 +28,11 @@ public interface PostProcessingFilter {
   void processFrame(int width, int height, double[] input, BitmapImage output, double exposure, TaskTracker.Task task);
 
   /**
-   * Get name of the post processing filter
-   * @return The name of the post processing filter
-   */
-  String getName();
-
-  /**
    * Get description of the post processing filter
    * @return The description of the post processing filter
    */
+  @Override
   default String getDescription() {
     return null;
   }
-
-  /**
-   * Get id of the post processing filter
-   * @return The id of the post processing filter
-   */
-  String getId();
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilters.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/PostProcessingFilters.java
@@ -18,6 +18,7 @@ public abstract class PostProcessingFilters {
     addPostProcessingFilter(new Tonemap1Filter());
     addPostProcessingFilter(new ACESFilmicFilter());
     addPostProcessingFilter(new HableToneMappingFilter());
+    addPostProcessingFilter(new UE4ToneMappingFilter());
   }
 
   public static Optional<PostProcessingFilter> getPostProcessingFilterFromId(String id) {

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/UE4ToneMappingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/UE4ToneMappingFilter.java
@@ -2,7 +2,9 @@ package se.llbit.chunky.renderer.postprocessing;
 
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.json.JsonObject;
 import se.llbit.math.QuickMath;
+import se.llbit.util.Configurable;
 
 /**
  * Implementation of the Unreal Engine 4 Filmic Tone Mapper.
@@ -10,7 +12,7 @@ import se.llbit.math.QuickMath;
  * @link https://docs.unrealengine.com/4.26/en-US/RenderingAndGraphics/PostProcessEffects/ColorGrading/
  * @link https://www.desmos.com/calculator/h8rbdpawxj?lang=de
  */
-public class UE4ToneMappingFilter extends SimplePixelPostProcessingFilter {
+public class UE4ToneMappingFilter extends SimplePixelPostProcessingFilter implements Configurable {
   public enum Preset {
     /**
      * ACES curve parameters
@@ -148,5 +150,27 @@ public class UE4ToneMappingFilter extends SimplePixelPostProcessingFilter {
   @Override
   public String getId() {
     return "UE4_FILMIC";
+  }
+
+  @Override
+  public void loadConfiguration(JsonObject json) {
+    reset();
+    saturation = json.get("saturation").floatValue(saturation);
+    slope = json.get("slope").floatValue(slope);
+    toe = json.get("toe").floatValue(toe);
+    shoulder = json.get("shoulder").floatValue(shoulder);
+    blackClip = json.get("blackClip").floatValue(blackClip);
+    whiteClip = json.get("whiteClip").floatValue(whiteClip);
+    recalculateConstants();
+  }
+
+  @Override
+  public void storeConfiguration(JsonObject json) {
+    json.add("saturation", saturation);
+    json.add("slope", slope);
+    json.add("toe", toe);
+    json.add("shoulder", shoulder);
+    json.add("blackClip", blackClip);
+    json.add("whiteClip", whiteClip);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/postprocessing/UE4ToneMappingFilter.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/postprocessing/UE4ToneMappingFilter.java
@@ -1,0 +1,152 @@
+package se.llbit.chunky.renderer.postprocessing;
+
+import org.apache.commons.math3.util.FastMath;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.math.QuickMath;
+
+/**
+ * Implementation of the Unreal Engine 4 Filmic Tone Mapper.
+ *
+ * @link https://docs.unrealengine.com/4.26/en-US/RenderingAndGraphics/PostProcessEffects/ColorGrading/
+ * @link https://www.desmos.com/calculator/h8rbdpawxj?lang=de
+ */
+public class UE4ToneMappingFilter extends SimplePixelPostProcessingFilter {
+  public enum Preset {
+    /**
+     * ACES curve parameters
+     **/
+    ACES,
+    /**
+     * UE4 legacy tone mapping style
+     **/
+    LEGACY_UE4
+  }
+
+  private float saturation;
+  private float slope; // ga
+  private float toe; // t0
+  private float shoulder; // s0
+  private float blackClip; // t1
+  private float whiteClip; // s1
+
+  private float ta;
+  private float sa;
+
+  public UE4ToneMappingFilter() {
+    reset();
+  }
+
+  private void recalculateConstants() {
+    ta = (1f - toe - 0.18f) / slope - 0.733f;
+    sa = (shoulder - 0.18f) / slope - 0.733f;
+  }
+
+  public float getSaturation() {
+    return saturation;
+  }
+
+  public void setSaturation(float saturation) {
+    this.saturation = saturation;
+  }
+
+  public float getSlope() {
+    return slope;
+  }
+
+  public void setSlope(float slope) {
+    this.slope = slope;
+    this.recalculateConstants();
+  }
+
+  public float getToe() {
+    return toe;
+  }
+
+  public void setToe(float toe) {
+    this.toe = toe;
+    recalculateConstants();
+  }
+
+  public float getShoulder() {
+    return shoulder;
+  }
+
+  public void setShoulder(float shoulder) {
+    this.shoulder = shoulder;
+    recalculateConstants();
+  }
+
+  public float getBlackClip() {
+    return blackClip;
+  }
+
+  public void setBlackClip(float blackClip) {
+    this.blackClip = blackClip;
+  }
+
+  public float getWhiteClip() {
+    return whiteClip;
+  }
+
+  public void setWhiteClip(float whiteClip) {
+    this.whiteClip = whiteClip;
+  }
+
+  public void applyPreset(Preset preset) {
+    switch (preset) {
+      case ACES:
+        saturation = 1f;
+        slope = 0.88f;
+        toe = 0.55f;
+        shoulder = 0.26f;
+        blackClip = 0.0f;
+        whiteClip = 0.04f;
+        break;
+      case LEGACY_UE4:
+        saturation = 1f;
+        slope = 0.98f;
+        toe = 0.3f;
+        shoulder = 0.22f;
+        blackClip = 0.0f;
+        whiteClip = 0.025f;
+        break;
+    }
+    recalculateConstants();
+  }
+
+  public void reset() {
+    applyPreset(Preset.ACES);
+  }
+
+  private float processComponent(float c) {
+    float logc = (float) Math.log10(c);
+
+    if (logc >= ta && logc <= sa) {
+      return (float) (saturation * (slope * (logc + 0.733) + 0.18));
+    }
+    if (logc > sa) {
+      return (float) (saturation * (1 + whiteClip - (2 * (1 + whiteClip - shoulder)) / (1 + Math.exp(((2 * slope) / (1 + whiteClip - shoulder)) * (logc - sa)))));
+    }
+    // if (logc < ta) {
+    return (float) (saturation * ((2 * (1 + blackClip - toe)) / (1 + Math.exp(-((2 * slope) / (1 + blackClip - toe)) * (logc - ta))) - blackClip));
+    // }
+  }
+
+  @Override
+  public void processPixel(double[] pixel) {
+    for (int i = 0; i < 3; ++i) {
+      pixel[i] = QuickMath.max(QuickMath.min(processComponent((float) pixel[i] * 1.25f), 1), 0);
+      pixel[i] = FastMath.pow(pixel[i], 1 / Scene.DEFAULT_GAMMA);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "Unreal Engine 4 Filmic tone mapping";
+  }
+
+  @Override
+  public String getId() {
+    return "UE4_FILMIC";
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
@@ -16,17 +16,21 @@
  */
 package se.llbit.chunky.ui.render.tabs;
 
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
-import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.Separator;
-import javafx.scene.control.Tooltip;
+import javafx.scene.control.*;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
+import se.llbit.chunky.renderer.RenderMode;
+import se.llbit.chunky.renderer.postprocessing.HableToneMappingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
+import se.llbit.chunky.renderer.postprocessing.UE4ToneMappingFilter;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.ui.DoubleAdjuster;
@@ -48,6 +52,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
   @FXML private DoubleAdjuster exposure;
   @FXML private ChoiceBox<PostProcessingFilter> postprocessingFilter;
 
+  @FXML private VBox hableCurveSettings;
   @FXML private DoubleTextField hableShoulderStrength;
   @FXML private DoubleTextField hableLinearStrength;
   @FXML private DoubleTextField hableLinearAngle;
@@ -55,13 +60,18 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
   @FXML private DoubleTextField hableToeNumerator;
   @FXML private DoubleTextField hableToeDenominator;
   @FXML private DoubleTextField hableLinearWhitePointValue;
+  @FXML private Button gdcPreset;
+  @FXML private Button fwPreset;
 
+  @FXML private VBox ue4CurveSettings;
   @FXML private DoubleTextField ue4Saturation;
   @FXML private DoubleTextField ue4Slope;
   @FXML private DoubleTextField ue4Toe;
   @FXML private DoubleTextField ue4Shoulder;
   @FXML private DoubleTextField ue4BlackClip;
   @FXML private DoubleTextField ue4WhiteClip;
+  @FXML private Button acesPreset;
+  @FXML private Button ue4LegacyPreset;
 
   public PostprocessingTab() throws IOException {
     FXMLLoader loader = new FXMLLoader(getClass().getResource("PostprocessingTab.fxml"));
@@ -77,7 +87,28 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
 
   @Override public void update(Scene scene) {
     postprocessingFilter.getSelectionModel().select(scene.getPostProcessingFilter());
+    hableCurveSettings.setVisible(scene.getPostProcessingFilter() instanceof HableToneMappingFilter);
+    ue4CurveSettings.setVisible(scene.getPostProcessingFilter() instanceof UE4ToneMappingFilter);
     exposure.set(scene.getExposure());
+
+    if (scene.getPostProcessingFilter() instanceof HableToneMappingFilter) {
+      HableToneMappingFilter filter = (HableToneMappingFilter) scene.getPostProcessingFilter();
+      hableShoulderStrength.valueProperty().set(filter.getShoulderStrength());
+      hableLinearStrength.valueProperty().set(filter.getLinearStrength());
+      hableLinearAngle.valueProperty().set(filter.getLinearAngle());
+      hableToeStrength.valueProperty().set(filter.getToeStrength());
+      hableToeNumerator.valueProperty().set(filter.getToeNumerator());
+      hableToeDenominator.valueProperty().set(filter.getToeDenominator());
+      hableLinearWhitePointValue.valueProperty().set(filter.getLinearWhitePointValue());
+    } else if (scene.getPostProcessingFilter() instanceof UE4ToneMappingFilter) {
+      UE4ToneMappingFilter filter = (UE4ToneMappingFilter) scene.getPostProcessingFilter();
+      ue4Saturation.valueProperty().set(filter.getSaturation());
+      ue4Slope.valueProperty().set(filter.getSlope());
+      ue4Toe.valueProperty().set(filter.getToe());
+      ue4Shoulder.valueProperty().set(filter.getShoulder());
+      ue4BlackClip.valueProperty().set(filter.getBlackClip());
+      ue4WhiteClip.valueProperty().set(filter.getWhiteClip());
+    }
   }
 
   @Override public String getTabTitle() {
@@ -101,8 +132,7 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
     postprocessingFilter.getSelectionModel().selectedItemProperty().addListener(
         (observable, oldValue, newValue) -> {
           scene.setPostprocess(newValue);
-          scene.postProcessFrame(new TaskTracker(ProgressListener.NONE));
-          controller.getCanvas().forceRepaint();
+          applyChangedSettings(false);
         });
     postprocessingFilter.setConverter(new StringConverter<PostProcessingFilter>() {
       @Override
@@ -122,9 +152,81 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
     exposure.clampMin();
     exposure.onValueChange(value -> {
       scene.setExposure(value);
-      scene.postProcessFrame(new TaskTracker(ProgressListener.NONE));
-      controller.getCanvas().forceRepaint();
+      applyChangedSettings(false);
     });
+    hableCurveSettings.managedProperty().bind(hableCurveSettings.visibleProperty());
+    gdcPreset.setOnAction((e) -> {
+      if (scene.postProcessingFilter instanceof HableToneMappingFilter) {
+        ((HableToneMappingFilter) scene.postProcessingFilter).applyPreset(HableToneMappingFilter.Preset.GDC);
+        applyChangedSettings(true);
+      }
+    });
+    fwPreset.setOnAction((e) -> {
+      if (scene.postProcessingFilter instanceof HableToneMappingFilter) {
+        ((HableToneMappingFilter) scene.postProcessingFilter).applyPreset(HableToneMappingFilter.Preset.FILMIC_WORLDS);
+        applyChangedSettings(true);
+      }
+    });
+    ue4CurveSettings.managedProperty().bind(ue4CurveSettings.visibleProperty());
+    acesPreset.setOnAction((e) -> {
+      if (scene.postProcessingFilter instanceof UE4ToneMappingFilter) {
+        ((UE4ToneMappingFilter) scene.postProcessingFilter).applyPreset(UE4ToneMappingFilter.Preset.ACES);
+        applyChangedSettings(true);
+      }
+    });
+    ue4LegacyPreset.setOnAction((e) -> {
+      if (scene.postProcessingFilter instanceof UE4ToneMappingFilter) {
+        ((UE4ToneMappingFilter) scene.postProcessingFilter).applyPreset(UE4ToneMappingFilter.Preset.LEGACY_UE4);
+        applyChangedSettings(true);
+      }
+    });
+
+    EventHandler<KeyEvent> postprocessingSettingsHandler = e -> {
+      if (e.getCode() == KeyCode.ENTER) {
+        if (scene.postProcessingFilter instanceof HableToneMappingFilter) {
+          HableToneMappingFilter filter = (HableToneMappingFilter) scene.postProcessingFilter;
+          filter.setShoulderStrength((float) hableShoulderStrength.valueProperty().get());
+          filter.setLinearStrength((float) hableLinearStrength.valueProperty().get());
+          filter.setLinearAngle((float) hableLinearAngle.valueProperty().get());
+          filter.setToeStrength((float) hableToeStrength.valueProperty().get());
+          filter.setToeNumerator((float) hableToeNumerator.valueProperty().get());
+          filter.setToeDenominator((float) hableToeDenominator.valueProperty().get());
+          filter.setLinearWhitePointValue((float) hableLinearWhitePointValue.valueProperty().get());
+        } else if (scene.postProcessingFilter instanceof UE4ToneMappingFilter) {
+          UE4ToneMappingFilter filter = (UE4ToneMappingFilter) scene.postProcessingFilter;
+          filter.setSaturation((float) ue4Saturation.valueProperty().get());
+          filter.setSlope((float) ue4Slope.valueProperty().get());
+          filter.setToe((float) ue4Toe.valueProperty().get());
+          filter.setShoulder((float) ue4Shoulder.valueProperty().get());
+          filter.setBlackClip((float) ue4BlackClip.valueProperty().get());
+          filter.setWhiteClip((float) ue4WhiteClip.valueProperty().get());
+        }
+        applyChangedSettings(true);
+      }
+    };
+    hableShoulderStrength.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableLinearStrength.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableLinearAngle.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableToeStrength.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableToeNumerator.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableToeDenominator.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    hableLinearWhitePointValue.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4Saturation.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4Slope.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4Toe.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4Shoulder.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4BlackClip.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+    ue4WhiteClip.addEventFilter(KeyEvent.KEY_PRESSED, postprocessingSettingsHandler);
+  }
+
+  private void applyChangedSettings(boolean refreshScene) {
+    if (refreshScene && scene.getMode() == RenderMode.PREVIEW) {
+      // Don't interrupt the render if we are currently rendering.
+      scene.refresh();
+    }
+    update(scene);
+    scene.postProcessFrame(new TaskTracker(ProgressListener.NONE));
+    controller.getCanvas().forceRepaint();
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
@@ -30,6 +30,7 @@ import se.llbit.chunky.renderer.postprocessing.PostProcessingFilters;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.ui.DoubleAdjuster;
+import se.llbit.chunky.ui.DoubleTextField;
 import se.llbit.chunky.ui.controller.RenderControlsFxController;
 import se.llbit.chunky.ui.render.RenderControlsTab;
 import se.llbit.util.ProgressListener;
@@ -46,6 +47,21 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
 
   @FXML private DoubleAdjuster exposure;
   @FXML private ChoiceBox<PostProcessingFilter> postprocessingFilter;
+
+  @FXML private DoubleTextField hableShoulderStrength;
+  @FXML private DoubleTextField hableLinearStrength;
+  @FXML private DoubleTextField hableLinearAngle;
+  @FXML private DoubleTextField hableToeStrength;
+  @FXML private DoubleTextField hableToeNumerator;
+  @FXML private DoubleTextField hableToeDenominator;
+  @FXML private DoubleTextField hableLinearWhitePointValue;
+
+  @FXML private DoubleTextField ue4Saturation;
+  @FXML private DoubleTextField ue4Slope;
+  @FXML private DoubleTextField ue4Toe;
+  @FXML private DoubleTextField ue4Shoulder;
+  @FXML private DoubleTextField ue4BlackClip;
+  @FXML private DoubleTextField ue4WhiteClip;
 
   public PostprocessingTab() throws IOException {
     FXMLLoader loader = new FXMLLoader(getClass().getResource("PostprocessingTab.fxml"));

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/PostprocessingTab.java
@@ -39,11 +39,11 @@ import se.llbit.chunky.ui.controller.RenderControlsFxController;
 import se.llbit.chunky.ui.render.RenderControlsTab;
 import se.llbit.util.ProgressListener;
 import se.llbit.util.TaskTracker;
+import se.llbit.util.TaskTracker.Task;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
-import se.llbit.util.TaskTracker.Task;
 
 public class PostprocessingTab extends ScrollPane implements RenderControlsTab, Initializable {
   private Scene scene;
@@ -185,21 +185,21 @@ public class PostprocessingTab extends ScrollPane implements RenderControlsTab, 
       if (e.getCode() == KeyCode.ENTER) {
         if (scene.postProcessingFilter instanceof HableToneMappingFilter) {
           HableToneMappingFilter filter = (HableToneMappingFilter) scene.postProcessingFilter;
-          filter.setShoulderStrength((float) hableShoulderStrength.valueProperty().get());
-          filter.setLinearStrength((float) hableLinearStrength.valueProperty().get());
-          filter.setLinearAngle((float) hableLinearAngle.valueProperty().get());
-          filter.setToeStrength((float) hableToeStrength.valueProperty().get());
-          filter.setToeNumerator((float) hableToeNumerator.valueProperty().get());
-          filter.setToeDenominator((float) hableToeDenominator.valueProperty().get());
-          filter.setLinearWhitePointValue((float) hableLinearWhitePointValue.valueProperty().get());
+          filter.setShoulderStrength(hableShoulderStrength.valueProperty().floatValue());
+          filter.setLinearStrength(hableLinearStrength.valueProperty().floatValue());
+          filter.setLinearAngle(hableLinearAngle.valueProperty().floatValue());
+          filter.setToeStrength(hableToeStrength.valueProperty().floatValue());
+          filter.setToeNumerator(hableToeNumerator.valueProperty().floatValue());
+          filter.setToeDenominator(hableToeDenominator.valueProperty().floatValue());
+          filter.setLinearWhitePointValue(hableLinearWhitePointValue.valueProperty().floatValue());
         } else if (scene.postProcessingFilter instanceof UE4ToneMappingFilter) {
           UE4ToneMappingFilter filter = (UE4ToneMappingFilter) scene.postProcessingFilter;
-          filter.setSaturation((float) ue4Saturation.valueProperty().get());
-          filter.setSlope((float) ue4Slope.valueProperty().get());
-          filter.setToe((float) ue4Toe.valueProperty().get());
-          filter.setShoulder((float) ue4Shoulder.valueProperty().get());
-          filter.setBlackClip((float) ue4BlackClip.valueProperty().get());
-          filter.setWhiteClip((float) ue4WhiteClip.valueProperty().get());
+          filter.setSaturation(ue4Saturation.valueProperty().floatValue());
+          filter.setSlope(ue4Slope.valueProperty().floatValue());
+          filter.setToe(ue4Toe.valueProperty().floatValue());
+          filter.setShoulder(ue4Shoulder.valueProperty().floatValue());
+          filter.setBlackClip(ue4BlackClip.valueProperty().floatValue());
+          filter.setWhiteClip(ue4WhiteClip.valueProperty().floatValue());
         }
         applyChangedSettings(true);
       }

--- a/chunky/src/java/se/llbit/util/Configurable.java
+++ b/chunky/src/java/se/llbit/util/Configurable.java
@@ -1,0 +1,29 @@
+package se.llbit.util;
+
+import se.llbit.json.JsonObject;
+
+/**
+ * This interface specifies an object that can be configured by the user.
+ * This would be, for example, a post processing method.
+ */
+public interface Configurable {
+  /**
+   * Load the configuration from the given JSON object that may have been created by {@link #storeConfiguration(JsonObject)}
+   * but may as well have been created by external tools.
+   *
+   * @param json Source object
+   */
+  void loadConfiguration(JsonObject json);
+
+  /**
+   * Store the configuration in the given JSON object such that it can be loaded later with {@link #loadConfiguration(JsonObject)}.
+   *
+   * @param json Destination object
+   */
+  void storeConfiguration(JsonObject json);
+
+  /**
+   * Restore the default configuration.
+   */
+  void reset();
+}

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/PostprocessingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/PostprocessingTab.fxml
@@ -1,23 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.ChoiceBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Text?>
-<?import javafx.scene.control.ScrollPane?>
-<?import se.llbit.chunky.ui.DoubleAdjuster?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+<?import se.llbit.chunky.ui.*?>
+<?import se.llbit.chunky.ui.elements.*?>
 
-<fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <DoubleAdjuster fx:id="exposure" />
     <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
       <Label text="Postprocessing filter:" />
       <ChoiceBox fx:id="postprocessingFilter" prefWidth="150.0" />
     </HBox>
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" wrappingWidth="275"
-      text="Postprocessing affects performance when Render Preview tab is visible. Switching to the Map tab mitigates this." />
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Hable tone mapping curve parameters:" wrappingWidth="275" />
+    <VBox prefWidth="250.0" spacing="5.0">
+      <TextFieldLabelWrapper labelText="Shoulder strength:">
+        <DoubleTextField fx:id="hableShoulderStrength" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Linear strength:">
+        <DoubleTextField fx:id="hableLinearStrength" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Linear angle:">
+        <DoubleTextField fx:id="hableLinearAngle" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Toe strength:">
+        <DoubleTextField fx:id="hableToeStrength" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Toe numerator:">
+        <DoubleTextField fx:id="hableToeNumerator" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Toe denominator:">
+        <DoubleTextField fx:id="hableToeDenominator" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Linear white point value:">
+        <DoubleTextField fx:id="hableLinearWhitePointValue" />
+      </TextFieldLabelWrapper>
+      <HBox alignment="TOP_RIGHT" prefWidth="200.0" spacing="5.0">
+        <children>
+          <Button mnemonicParsing="false" text="GDC preset" />
+          <Button mnemonicParsing="false" text="FW preset" />
+        </children>
+      </HBox>
+      <VBox.margin>
+        <Insets left="20.0" />
+      </VBox.margin>
+    </VBox>
+    <VBox prefWidth="250.0" spacing="5.0">
+      <TextFieldLabelWrapper labelText="Saturation:">
+        <DoubleTextField fx:id="ue4Saturation" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Slope:">
+        <DoubleTextField fx:id="ue4Slope" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Toe:">
+        <DoubleTextField fx:id="ue4Toe" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Shoulder:">
+        <DoubleTextField fx:id="ue4Shoulder" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="Black clip:">
+        <DoubleTextField fx:id="ue4BlackClip" />
+      </TextFieldLabelWrapper>
+      <TextFieldLabelWrapper labelText="White clip:">
+        <DoubleTextField fx:id="ue4WhiteClip" />
+      </TextFieldLabelWrapper>
+      <HBox alignment="TOP_RIGHT" prefWidth="200.0" spacing="5.0">
+        <children>
+          <Button mnemonicParsing="false" text="ACES preset" />
+          <Button mnemonicParsing="false" text="UE4 Legacy preset" />
+        </children>
+      </HBox>
+      <VBox.margin>
+        <Insets left="20.0" />
+      </VBox.margin>
+    </VBox>
+    <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Postprocessing affects performance when Render Preview tab is visible. Switching to the Map tab mitigates this." wrappingWidth="275" />
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/PostprocessingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/PostprocessingTab.fxml
@@ -14,8 +14,7 @@
       <Label text="Postprocessing filter:" />
       <ChoiceBox fx:id="postprocessingFilter" prefWidth="150.0" />
     </HBox>
-    <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Hable tone mapping curve parameters:" wrappingWidth="275" />
-    <VBox prefWidth="250.0" spacing="5.0">
+    <VBox prefWidth="250.0" spacing="5.0" fx:id="hableCurveSettings">
       <TextFieldLabelWrapper labelText="Shoulder strength:">
         <DoubleTextField fx:id="hableShoulderStrength" />
       </TextFieldLabelWrapper>
@@ -39,15 +38,15 @@
       </TextFieldLabelWrapper>
       <HBox alignment="TOP_RIGHT" prefWidth="200.0" spacing="5.0">
         <children>
-          <Button mnemonicParsing="false" text="GDC preset" />
-          <Button mnemonicParsing="false" text="FW preset" />
+          <Button mnemonicParsing="false" text="FW preset" fx:id="fwPreset" />
+          <Button mnemonicParsing="false" text="GDC preset" fx:id="gdcPreset" />
         </children>
       </HBox>
       <VBox.margin>
         <Insets left="20.0" />
       </VBox.margin>
     </VBox>
-    <VBox prefWidth="250.0" spacing="5.0">
+    <VBox prefWidth="250.0" spacing="5.0" fx:id="ue4CurveSettings" >
       <TextFieldLabelWrapper labelText="Saturation:">
         <DoubleTextField fx:id="ue4Saturation" />
       </TextFieldLabelWrapper>
@@ -68,8 +67,8 @@
       </TextFieldLabelWrapper>
       <HBox alignment="TOP_RIGHT" prefWidth="200.0" spacing="5.0">
         <children>
-          <Button mnemonicParsing="false" text="ACES preset" />
-          <Button mnemonicParsing="false" text="UE4 Legacy preset" />
+          <Button mnemonicParsing="false" text="ACES preset" fx:id="acesPreset" />
+          <Button mnemonicParsing="false" text="UE4 Legacy preset" fx:id="ue4LegacyPreset" />
         </children>
       </HBox>
       <VBox.margin>


### PR DESCRIPTION
I just wanted to render a few example images for the post-processing section of the docs, and somehow went down this rabbit hole.

1. [UE4 Filmic Tonemapping](https://docs.unrealengine.com/4.26/en-US/RenderingAndGraphics/PostProcessEffects/ColorGrading/) is now implemented; basically configurable ACES, defaults to matching the ACES curve (UE4 legacy tone mapping preset is also in the code already)
2. Hable was wrong (missing Gamma Correction and arbitrary x16 exposure)
3. Compared [Hable's GDC talk](https://dokumen.tips/documents/hable-john-uncharted2-hdr-lighting.html?page=1) with the [blog post](http://filmicworlds.com/blog/filmic-tonemapping-operators/) and noticed that there were different parameters; added presets for both
4. Hable and UE4 Filmic Tonemaps can now be configured ~~(JSON only until someone adds a UI)~~