### PR TITLE
Implement entity regions

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1027,8 +1027,9 @@ public class Scene implements JsonSerializable, Refreshable {
                 // Before 1.12 paintings had id=Painting.
                 // After 1.12 paintings had id=minecraft:painting.
                 float yaw = tag.get("Rotation").get(0).floatValue();
-                entities.add(
-                        new PaintingEntity(new Vector3(x, y, z), tag.get("Motive").stringValue(), yaw));
+
+                Tag paintingVariant = NbtUtil.getTagFromNames(tag, "Motive", "variant");
+                entities.add(new PaintingEntity(new Vector3(x, y, z), paintingVariant.stringValue(), yaw));
               } else if (id.equals("minecraft:armor_stand") && entityLoadingPreferences.shouldLoadClass(ArmorStand.class)) {
                 actors.add(new ArmorStand(new Vector3(x, y, z), tag));
               }

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -59,6 +59,7 @@ public class Chunk {
   public static final String LEVEL_SECTIONS = ".Level.Sections";
   public static final String LEVEL_BIOMES = ".Level.Biomes";
   public static final String LEVEL_ENTITIES = ".Level.Entities";
+  public static final String ENTITIES_POST_20W45A = ".Entities";
   public static final String LEVEL_TILEENTITIES = ".Level.TileEntities";
   public static final String BLOCK_ENTITIES_POST_21W43A = ".block_entities";
 
@@ -79,6 +80,7 @@ public class Chunk {
   private static final int CHUNK_BYTES = X_MAX * Y_MAX * Z_MAX;
 
   public static final int DATAVERSION_20W17A = 2529;
+  public static final int DATAVERSION_20W45A = 2681; // entities moved into separate region files
 
   protected final ChunkPosition position;
   protected volatile AbstractLayer surface = IconLayer.UNKNOWN;
@@ -119,6 +121,15 @@ public class Chunk {
     Map<String, Tag> chunkTags = region.getChunkTags(this.position, request, timestamp);
     this.dataTimestamp = timestamp.get();
     return chunkTags;
+  }
+
+  /**
+   * @param request fresh request set
+   * @return loaded data, or null if something went wrong
+   */
+  private Map<String, Tag> getEntityTags(Set<String> request) throws ChunkLoadingException {
+    MCRegion region = (MCRegion) world.getRegion(position.getRegionPosition());
+    return region.getEntityTags(this.position, request);
   }
 
   /**
@@ -449,8 +460,9 @@ public class Chunk {
     }
     Tag data = tagFromMap(dataMap);
 
+    int dataVersion = data.get(DATAVERSION).intValue();
     if(reuseChunkData.get() == null || reuseChunkData.get() instanceof EmptyChunkData) {
-      reuseChunkData.set(world.createChunkData(reuseChunkData.get(), data.get(DATAVERSION).intValue()));
+      reuseChunkData.set(world.createChunkData(reuseChunkData.get(), dataVersion));
     } else {
       reuseChunkData.get().clear();
     }
@@ -476,6 +488,23 @@ public class Chunk {
         for (SpecificTag tag : (ListTag) tileEntitiesTag) {
           if (tag.isCompoundTag())
             chunkData.addTileEntity((CompoundTag) tag);
+        }
+      }
+    }
+
+    // post 20w45A entities
+    if (dataVersion >= DATAVERSION_20W45A) {
+      Set<String> entitiesRequest = new HashSet<>();
+      entitiesRequest.add(ENTITIES_POST_20W45A);
+
+      Map<String, Tag> entitiesMap = getEntityTags(entitiesRequest);
+      if (entitiesMap != null) {
+        entitiesTag = entitiesMap.get(".Entities");
+        if (entitiesTag.isList()) {
+          for (SpecificTag tag : (ListTag) entitiesTag) {
+            if (tag.isCompoundTag())
+              chunkData.addEntity((CompoundTag) tag);
+          }
         }
       }
     }


### PR DESCRIPTION
Previously I'd wanted to wait until I'd moved CubicChunks support out, and could rewrite the region parsing altogether.

This implementation isn't ideal but should be fine for now.

Ideally the first three commits should be squashed with the last being separate, let me know if I should do that or if it'll be done in the merge

![image](https://user-images.githubusercontent.com/16853282/210154426-50c55424-7d5c-49c7-9b37-f899780e5f64.png)
