### PR TITLE
Fix issue where `PluginApiTest.testSetSceneResetListener` could fail randomly.

### DIFF
--- a/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
@@ -27,6 +27,7 @@ import se.llbit.chunky.ui.render.RenderControlsTabTransformer;
 import se.llbit.util.Mutable;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.BiConsumer;
 
@@ -122,7 +123,9 @@ public class PluginApiTest {
     Mutable<Scene> cbScene = new Mutable<>(null);
 
     Chunky chunky = new Chunky(ChunkyOptions.getDefaults());
-    chunky.getRenderController().getRenderManager().shutdown();
+    DefaultRenderManager rm = (DefaultRenderManager) chunky.getRenderController().getRenderManager();
+    rm.shutdown();
+    rm.join();
 
     SceneProvider provider = chunky.getSceneManager().getSceneProvider();
 


### PR DESCRIPTION
When the test fails, the render manager stack trace generally looks like:
```
[java.base@17/java.lang.Object.wait(Native Method), java.base@17/java.lang.Object.wait(Object.java:338), app//se.llbit.chunky.renderer.scene.SynchronousSceneManager.awaitSceneStateChange(SynchronousSceneManager.java:291), app//se.llbit.chunky.renderer.DefaultRenderManager.run(DefaultRenderManager.java:247)]
```

This ensures that the render manager has properly shut down before starting the test.

Closes #1532 