### PR TITLE
Increase sea lantern light level

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -387,7 +387,7 @@ public class BlockPalette {
       block.specular = 0.04f;
     });
     materialProperties.put("minecraft:sea_lantern", block -> {
-      block.emittance = 0.5f;
+      block.emittance = 1.0f;
     });
     materialProperties.put("minecraft:magma", block -> {
       block.emittance = 0.6f;


### PR DESCRIPTION
As mentioned in the issue, sea lanterns are light level 15 and therefore should have an emittance of 1.0.