### PR TITLE
Make emitter texture brightness depend on emittance

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -171,7 +171,7 @@ public class PathTracer implements RayTracer {
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              emittance = addEmitted;
+              emittance = addEmitted * currentMat.emittance;
               ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterIntensity;
               ray.emittance.y = ray.color.y * ray.color.y *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -165,13 +165,17 @@ public class PathTracer implements RayTracer {
           if (!scene.kill(ray.depth + 1, random)) {
             Ray reflected = new Ray();
 
-            float emittance = 0;
+            Vector3 emittance = new Vector3();
 
             Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              emittance = (float) (addEmitted * Math.sqrt(currentMat.emittance));
+              emittance.set(
+                addEmitted * ray.color.x * currentMat.emittance * scene.emitterIntensity,
+                addEmitted * ray.color.y * currentMat.emittance * scene.emitterIntensity,
+                addEmitted * ray.color.z * currentMat.emittance * scene.emitterIntensity
+              );
               ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterIntensity;
               ray.emittance.y = ray.color.y * ray.color.y *
@@ -235,11 +239,11 @@ public class PathTracer implements RayTracer {
               reflected.diffuseReflection(ray, random);
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
-                ray.color.x = ray.color.x * (emittance + directLightR * scene.sun.emittance.x + (
+                ray.color.x = ray.color.x * (emittance.x + directLightR * scene.sun.emittance.x + (
                     reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
-                ray.color.y = ray.color.y * (emittance + directLightG * scene.sun.emittance.y + (
+                ray.color.y = ray.color.y * (emittance.y + directLightG * scene.sun.emittance.y + (
                     reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
-                ray.color.z = ray.color.z * (emittance + directLightB * scene.sun.emittance.z + (
+                ray.color.z = ray.color.z * (emittance.z + directLightB * scene.sun.emittance.z + (
                     reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
@@ -254,11 +258,11 @@ public class PathTracer implements RayTracer {
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
                 ray.color.x =
-                    ray.color.x * (emittance + (reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
+                    ray.color.x * (emittance.x + (reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
                 ray.color.y =
-                    ray.color.y * (emittance + (reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
+                    ray.color.y * (emittance.y + (reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
                 ray.color.z =
-                    ray.color.z * (emittance + (reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
+                    ray.color.z * (emittance.z + (reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
                 ray.color.x *= indirectEmitterColor.x;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -165,17 +165,10 @@ public class PathTracer implements RayTracer {
           if (!scene.kill(ray.depth + 1, random)) {
             Ray reflected = new Ray();
 
-            Vector3 emittance = new Vector3();
-
             Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              emittance.set(
-                addEmitted * ray.color.x * currentMat.emittance * scene.emitterIntensity,
-                addEmitted * ray.color.y * currentMat.emittance * scene.emitterIntensity,
-                addEmitted * ray.color.z * currentMat.emittance * scene.emitterIntensity
-              );
               ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterIntensity;
               ray.emittance.y = ray.color.y * ray.color.y *
@@ -239,11 +232,11 @@ public class PathTracer implements RayTracer {
               reflected.diffuseReflection(ray, random);
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
-                ray.color.x = ray.color.x * (emittance.x + directLightR * scene.sun.emittance.x + (
+                ray.color.x = (addEmitted * ray.emittance.x) + ray.color.x * (directLightR * scene.sun.emittance.x + (
                     reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
-                ray.color.y = ray.color.y * (emittance.y + directLightG * scene.sun.emittance.y + (
+                ray.color.y = (addEmitted * ray.emittance.y) + ray.color.y * (directLightG * scene.sun.emittance.y + (
                     reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
-                ray.color.z = ray.color.z * (emittance.z + directLightB * scene.sun.emittance.z + (
+                ray.color.z = (addEmitted * ray.emittance.z) + ray.color.z * (directLightB * scene.sun.emittance.z + (
                     reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
@@ -258,11 +251,11 @@ public class PathTracer implements RayTracer {
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
                 ray.color.x =
-                    ray.color.x * (emittance.x + (reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
+                  (addEmitted * ray.emittance.x) + ray.color.x * ((reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
                 ray.color.y =
-                    ray.color.y * (emittance.y + (reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
+                  (addEmitted * ray.emittance.y) + ray.color.y * ((reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
                 ray.color.z =
-                    ray.color.z * (emittance.z + (reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
+                  (addEmitted * ray.emittance.z) + ray.color.z * ((reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
                 ray.color.x *= indirectEmitterColor.x;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -171,7 +171,7 @@ public class PathTracer implements RayTracer {
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              emittance = addEmitted * currentMat.emittance;
+              emittance = (float) (addEmitted * Math.sqrt(currentMat.emittance));
               ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterIntensity;
               ray.emittance.y = ray.color.y * ray.color.y *


### PR DESCRIPTION
Fixes #1258. Just a one-line change to take into account `currentMat.emittance` when determining how bright to render the texture
Edit - Redox made a few more changes so that the brightness is also multiplied by the color treating each channel separately for improved accuracy/consistency

Before, with all light sources set to 0.1 emittance
![image](https://user-images.githubusercontent.com/46458276/219560025-67c0bb16-73ca-49bd-a4b2-9f0c1ee8c121.png)
After, with all light sources set to 0.1 emittance
![image](https://user-images.githubusercontent.com/46458276/219842689-93fd8d2c-d16a-45a7-b87e-b721ed3e4da7.png)

Before, with all light sources set to 10.0 emittance
![image](https://user-images.githubusercontent.com/46458276/219560116-3c1d50b1-3661-4104-9678-c5172c7e82ec.png)
After, with all light sources set to 10.0 emittance
![image](https://user-images.githubusercontent.com/46458276/219842635-018a8024-d4e0-428a-9687-5afe9a0cabda.png)