### PR TITLE
Add "Beacon beam" entity toggle checkbox

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/EntityLoadingPreferences.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/EntityLoadingPreferences.java
@@ -19,6 +19,7 @@ public class EntityLoadingPreferences {
         loadingPreferences.put(ArmorStand.class, PersistentSettings.getLoadArmorStands());
         loadingPreferences.put(Book.class, PersistentSettings.getLoadBooks());
         loadingPreferences.put(PaintingEntity.class, PersistentSettings.getLoadPaintings());
+        loadingPreferences.put(BeaconBeam.class, PersistentSettings.getLoadBeaconBeams());
         loadOtherEntities = PersistentSettings.getLoadOtherEntities();
     }
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -34,6 +34,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.entity.ArmorStand;
 import se.llbit.chunky.entity.Book;
 import se.llbit.chunky.entity.PaintingEntity;
+import se.llbit.chunky.entity.BeaconBeam;
 import se.llbit.chunky.entity.PlayerEntity;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.renderer.RenderController;
@@ -94,6 +95,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
   @FXML private CheckBox loadArmorStands;
   @FXML private CheckBox loadBooks;
   @FXML private CheckBox loadPaintings;
+  @FXML private CheckBox loadBeaconBeams;
   @FXML private CheckBox loadOtherEntities;
   @FXML private CheckBox saveDumps;
   @FXML private CheckBox saveSnapshots;
@@ -142,6 +144,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       loadArmorStands.setSelected(preferences.shouldLoadClass(ArmorStand.class));
       loadBooks.setSelected(preferences.shouldLoadClass(Book.class));
       loadPaintings.setSelected(preferences.shouldLoadClass(PaintingEntity.class));
+      loadBeaconBeams.setSelected(preferences.shouldLoadClass(BeaconBeam.class));
       loadOtherEntities.setSelected(preferences.shouldLoadClass(null));
     }
 
@@ -275,6 +278,16 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       renderControls.showPopup(
               "This takes effect the next time a new scene is created.", loadPaintings);
     });
+    loadBeaconBeams.setTooltip(new Tooltip("Enable/disable beacon beam entity loading. "
+      + "Takes effect on next scene creation."));
+    loadBeaconBeams.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      scene.getEntityLoadingPreferences().setPreference(BeaconBeam.class, newValue);
+      PersistentSettings.setLoadBeaconBeams(newValue);
+    });
+    loadBeaconBeams.setOnAction(event -> {
+      renderControls.showPopup(
+        "This takes effect the next time a new scene is created.", loadBeaconBeams);
+    });
     loadOtherEntities.setTooltip(new Tooltip("Enable/disable other entity loading. "
             + "Takes effect on next scene creation."));
     loadOtherEntities.selectedProperty().addListener((observable, oldValue, newValue) -> {
@@ -290,6 +303,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       loadArmorStands.setSelected(true);
       loadBooks.setSelected(true);
       loadPaintings.setSelected(true);
+      loadBeaconBeams.setSelected(true);
       loadOtherEntities.setSelected(true);
     });
     loadNoEntity.setOnAction(event -> {
@@ -297,6 +311,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       loadArmorStands.setSelected(false);
       loadBooks.setSelected(false);
       loadPaintings.setSelected(false);
+      loadBeaconBeams.setSelected(false);
       loadOtherEntities.setSelected(false);
     });
 

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -76,6 +76,7 @@
               <CheckBox fx:id="loadArmorStands" mnemonicParsing="false" text="Armor stands" />
               <CheckBox fx:id="loadBooks" mnemonicParsing="false" text="Books" />
               <CheckBox fx:id="loadPaintings" mnemonicParsing="false" text="Paintings" />
+              <CheckBox fx:id="loadBeaconBeams" mnemonicParsing="false" text="Beacon beams" />
               <CheckBox fx:id="loadOtherEntities" mnemonicParsing="false" text="Other" />
             </VBox>
           </TitledPane>

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -493,6 +493,15 @@ public final class PersistentSettings {
     save();
   }
 
+  public static boolean getLoadBeaconBeams() {
+    return settings.getBool("loadBeaconBeams", true);
+  }
+
+  public static void setLoadBeaconBeams(boolean value) {
+    settings.setBool("loadBeaconBeams", value);
+    save();
+  }
+
   public static boolean getLoadOtherEntities() {
     return settings.getBool("loadOtherEntities", true);
   }


### PR DESCRIPTION
This is pretty trivial but since beacon beams are some of the most visually intrusive entities, it is often desirable to disable rendering them e.g. in a survival world. But currently they are lumped under "Other" which means that you would have to either disable rendering those other entities, or manually remove each beacon beam from the list, which is tedious in the case of my world where there are dozens to cover a 300 block radius.

Let me know if there are any other files that need to be changed, but in a quick test it seems to work.
![image](https://user-images.githubusercontent.com/46458276/219846316-e58ae003-1708-4b2a-af5d-81330196ff8d.png)
![image](https://user-images.githubusercontent.com/46458276/219846330-9fb58ded-5e29-4304-899f-35c6bbdeb850.png)