### PR TITLE
more resilient error handling in AsynchronousSceneManager

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -375,7 +375,6 @@ public class Chunky {
         SceneProvider sceneProvider = sceneManager.getSceneProvider();
         renderManager.setSceneProvider(sceneProvider);
         renderManager.start();
-        sceneManager.start();
         renderController = new RenderController(context, renderManager, sceneManager, sceneProvider);
       }
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1841,7 +1841,7 @@ public class Scene implements JsonSerializable, Refreshable {
    * Set the scene name.
    */
   public void setName(String newName) {
-    newName = AsynchronousSceneManager.sanitizedSceneName(newName);
+    newName = SceneUtils.sanitizedSceneName(newName);
     if (newName.length() > 0) {
       name = newName;
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SceneUtils.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SceneUtils.java
@@ -1,0 +1,75 @@
+package se.llbit.chunky.renderer.scene;
+
+public class SceneUtils {
+
+  /**
+   * Remove problematic characters from scene name.
+   *
+   * @return sanitized scene name
+   */
+  public static String sanitizedSceneName(String name, String fallbackName) {
+    name = name.trim();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < name.length(); ++i) {
+      char c = name.charAt(i);
+      if (isValidSceneNameChar(c)) {
+        sb.append(c);
+      } else if (c >= '\u0020' && c <= '\u007e') {
+        sb.append('_');
+      }
+    }
+    String stripped = sb.toString().trim();
+    if (stripped.isEmpty()) {
+      return fallbackName;
+    } else {
+      return stripped;
+    }
+  }
+
+  /**
+   * Remove problematic characters from scene name.
+   *
+   * @return sanitized scene name
+   */
+  public static String sanitizedSceneName(String name) {
+    return sanitizedSceneName(name, "Scene");
+  }
+
+  /**
+   * @return <code>false</code> if the character can cause problems on any
+   * supported platform.
+   */
+  public static boolean isValidSceneNameChar(char c) {
+    switch (c) {
+      case '/':
+      case ':':
+      case ';':
+      case '\\': // Windows file separator.
+      case '*':
+      case '?':
+      case '"':
+      case '<':
+      case '>':
+      case '|':
+        return false;
+    }
+    if (c < '\u0020') {
+      return false;
+    }
+    return c <= '\u007e' || c >= '\u00a0';
+  }
+
+  /**
+   * Check for scene name validity.
+   *
+   * @return <code>true</code> if the scene name contains only legal characters
+   */
+  public static boolean sceneNameIsValid(String name) {
+    for (int i = 0; i < name.length(); ++i) {
+      if (!isValidSceneNameChar(name.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -385,10 +385,10 @@ public class ChunkyFxController
     saveScene.setOnAction(e -> asyncSceneManager.saveScene());
 
     saveSceneAs.setOnAction((e) -> {
-      ValidatingTextInputDialog sceneNameDialog = new ValidatingTextInputDialog(scene.name(), AsynchronousSceneManager::sceneNameIsValid);
+      ValidatingTextInputDialog sceneNameDialog = new ValidatingTextInputDialog(scene.name(), SceneUtils::sceneNameIsValid);
       sceneNameDialog.setTitle("Save scene as…");
       sceneNameDialog.setHeaderText("Enter a scene name");
-      String newName = AsynchronousSceneManager.sanitizedSceneName(sceneNameDialog.showAndWait().orElse(""), "");
+      String newName = SceneUtils.sanitizedSceneName(sceneNameDialog.showAndWait().orElse(""), "");
       if (!newName.isEmpty() && this.promptSaveScene(newName)) {
         asyncSceneManager.saveSceneAs(newName);
         scene.setName(newName);
@@ -397,10 +397,10 @@ public class ChunkyFxController
     });
 
     saveSceneCopy.setOnAction((e) -> {
-      ValidatingTextInputDialog sceneNameDialog = new ValidatingTextInputDialog("Copy of " + scene.name(), AsynchronousSceneManager::sceneNameIsValid);
+      ValidatingTextInputDialog sceneNameDialog = new ValidatingTextInputDialog("Copy of " + scene.name(), SceneUtils::sceneNameIsValid);
       sceneNameDialog.setTitle("Save a copy…");
       sceneNameDialog.setHeaderText("Enter a scene name");
-      String newName = AsynchronousSceneManager.sanitizedSceneName(sceneNameDialog.showAndWait().orElse(""), "");
+      String newName = SceneUtils.sanitizedSceneName(sceneNameDialog.showAndWait().orElse(""), "");
       if (!newName.isEmpty() && this.promptSaveScene(newName)) {
         File sceneDirectory = SynchronousSceneManager.resolveSceneDirectory(newName);
         asyncSceneManager.enqueueTask(() -> {

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
@@ -30,9 +30,9 @@ public class SceneManagerTest {
 	 */
 	@Test
 	public void testSceneNameSanitizing_1() {
-		assertEquals("ab_cd", AsynchronousSceneManager.sanitizedSceneName("ab/cd"));
-		assertEquals("x___cd", AsynchronousSceneManager.sanitizedSceneName("x<>|cd"));
-		assertEquals("______#42", AsynchronousSceneManager.sanitizedSceneName(":*?\\\"/#42"));
+		assertEquals("ab_cd", SceneUtils.sanitizedSceneName("ab/cd"));
+		assertEquals("x___cd", SceneUtils.sanitizedSceneName("x<>|cd"));
+		assertEquals("______#42", SceneUtils.sanitizedSceneName(":*?\\\"/#42"));
 	}
 
 	/**
@@ -40,8 +40,8 @@ public class SceneManagerTest {
 	 */
 	@Test
 	public void testSceneNameSanitizing_2() {
-		assertEquals("foo bar", AsynchronousSceneManager.sanitizedSceneName(" foo bar   "));
-		assertEquals("foo bar", AsynchronousSceneManager.sanitizedSceneName(" \nfoo bar\t "));
+		assertEquals("foo bar", SceneUtils.sanitizedSceneName(" foo bar   "));
+		assertEquals("foo bar", SceneUtils.sanitizedSceneName(" \nfoo bar\t "));
 	}
 
 	/**
@@ -49,9 +49,9 @@ public class SceneManagerTest {
 	 */
 	@Test
 	public void testSceneNameSanitizing_3() {
-		assertEquals("xyzabc", AsynchronousSceneManager.sanitizedSceneName("xyz\u007fabc"));
-		assertEquals("12", AsynchronousSceneManager.sanitizedSceneName("1\u009f2"));
-		assertEquals("AZ", AsynchronousSceneManager.sanitizedSceneName("A\u0000\u0001\u001fZ"));
+		assertEquals("xyzabc", SceneUtils.sanitizedSceneName("xyz\u007fabc"));
+		assertEquals("12", SceneUtils.sanitizedSceneName("1\u009f2"));
+		assertEquals("AZ", SceneUtils.sanitizedSceneName("A\u0000\u0001\u001fZ"));
 	}
 
 	/**
@@ -59,12 +59,12 @@ public class SceneManagerTest {
 	 */
 	@Test
 	public void testSceneNameSanitizing_4() {
-		assertEquals("Scene", AsynchronousSceneManager.sanitizedSceneName(""));
-		assertEquals("Scene", AsynchronousSceneManager.sanitizedSceneName("   "));
-		assertEquals("Scene", AsynchronousSceneManager.sanitizedSceneName("\t\n\b\r"));
-		assertEquals("Scene", AsynchronousSceneManager.sanitizedSceneName("\u0080"));
+		assertEquals("Scene", SceneUtils.sanitizedSceneName(""));
+		assertEquals("Scene", SceneUtils.sanitizedSceneName("   "));
+		assertEquals("Scene", SceneUtils.sanitizedSceneName("\t\n\b\r"));
+		assertEquals("Scene", SceneUtils.sanitizedSceneName("\u0080"));
 
 		// test that whitespace is stripped after removing control chars
-		assertEquals("Scene", AsynchronousSceneManager.sanitizedSceneName("\u0085 \u0085"));
+		assertEquals("Scene", SceneUtils.sanitizedSceneName("\u0085 \u0085"));
 	}
 }


### PR DESCRIPTION
- use an single thread ExecutorService instead of self-made thread handling
- also move scene name sanitization out into separate class
