### PR TITLE
Simple optimisation for Map View in CubicChunks worlds

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/MapTile.java
+++ b/chunky/src/java/se/llbit/chunky/map/MapTile.java
@@ -70,7 +70,7 @@ public class MapTile {
         }
       }
     } else {
-      boolean isValid = mapLoader.getWorld().regionExists(pos);
+      boolean isValid = mapLoader.getWorld().regionExistsWithinRange(pos, view.yMin, view.yMax);
       Region region = mapLoader.getWorld().getRegionWithinRange(pos, view.yMin, view.yMax);
       int pixelOffset = 0;
       for (int z = 0; z < 32; ++z) {

--- a/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
@@ -119,6 +119,7 @@ public class CubicWorld extends World {
     }
   }
 
+  @Override
   public boolean regionExistsWithinRange(ChunkPosition pos, int minY, int maxY) {
     int cubicRegionX = pos.x << 1;
     int cubicRegionZ = pos.z << 1;

--- a/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicWorld.java
@@ -126,7 +126,7 @@ public class CubicWorld extends World {
 
     File regionDirectory = getRegionDirectory();
     int minRegionY = cubeToCubicRegion(blockToCube(minY));
-    int maxRegionY = cubeToCubicRegion(blockToCube(maxY));
+    int maxRegionY = cubeToCubicRegion(blockToCube(maxY - 1));
     for (int y = minRegionY; y <= maxRegionY; y++) {
       for (int localX = 0; localX < ImposterCubicRegion.DIAMETER_IN_CUBIC_REGIONS; localX++) {
         for (int localZ = 0; localZ < ImposterCubicRegion.DIAMETER_IN_CUBIC_REGIONS; localZ++) {

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -340,16 +340,22 @@ public class World implements Comparable<World> {
     return regionFile.exists();
   }
 
+  /**
+   * @param pos Position of the region to load
+   * @param minY Minimum block Y (inclusive)
+   * @param maxY Maximum block Y (exclusive)
+   * @return Whether the region exists
+   */
   public boolean regionExistsWithinRange(ChunkPosition pos, int minY, int maxY) {
     return this.regionExists(pos);
   }
 
-    /**
-     * Get the data directory for the given dimension.
-     *
-     * @param dimension the dimension
-     * @return File object pointing to the data directory
-     */
+  /**
+   * Get the data directory for the given dimension.
+   *
+   * @param dimension the dimension
+   * @return File object pointing to the data directory
+   */
   protected synchronized File getDataDirectory(int dimension) {
     return dimension == 0 ?
         worldDirectory :

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -340,12 +340,16 @@ public class World implements Comparable<World> {
     return regionFile.exists();
   }
 
-  /**
-   * Get the data directory for the given dimension.
-   *
-   * @param dimension the dimension
-   * @return File object pointing to the data directory
-   */
+  public boolean regionExistsWithinRange(ChunkPosition pos, int minY, int maxY) {
+    return this.regionExists(pos);
+  }
+
+    /**
+     * Get the data directory for the given dimension.
+     *
+     * @param dimension the dimension
+     * @return File object pointing to the data directory
+     */
   protected synchronized File getDataDirectory(int dimension) {
     return dimension == 0 ?
         worldDirectory :


### PR DESCRIPTION
`regionExists` is an expensive call in a cubic chunks world, as it must check for any 3d region in the entire column. The only choice being to iterate over all files in the directory which is very expensive for large worlds.

This PR specifies a Y range to check for regions, simplifying this massively.

`CubicWorld` already had this api, it's now moved into `World` and overridden.