### PR TITLE
Fix sun radius control on sun sampling.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -206,6 +206,9 @@ public class Sun implements JsonSerializable {
   }
 
   private void initSun() {
+    radiusCos = FastMath.cos(radius);
+    radiusSin = FastMath.sin(radius);
+
     double theta = azimuth;
     double phi = altitude;
 
@@ -419,8 +422,6 @@ public class Sun implements JsonSerializable {
    */
   public void setSunRadius(double value) {
     radius = value;
-    radiusCos = FastMath.cos(radius);
-    radiusSin = FastMath.sin(radius);
     initSun();
     scene.refresh();
   }


### PR DESCRIPTION
Previously sun radius control was not properly updating in sun sampling. Moved sun radius initialization to `Sun.initSun()` to initialize the radius values properly.
![Untitled1](https://user-images.githubusercontent.com/42661490/229386283-cc346f3f-d656-476c-bfbb-5deab93e75ca.gif)
