### PR TITLE
Use more intuitive sun controls; refactor code

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/SunSamplingStrategy.java
@@ -20,7 +20,6 @@ import se.llbit.util.Registerable;
 
 public enum SunSamplingStrategy implements Registerable {
     OFF("Off", "Sun is not sampled with next event estimation.", false, true, false, true),
-    NON_LUMINOUS("Non-Luminous", "Sun is drawn on the skybox but it does not contribute to the lighting of the scene.", false, false, false, false),
     FAST("Fast", "Fast sun sampling algorithm. Lower noise but does not correctly model some visual effects.", true, false, false, false),
     HIGH_QUALITY("High Quality", "High quality sun sampling. More noise but correctly models visual effects such as caustics.", true, true, true, true);
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -73,18 +73,18 @@ public class PathTracer implements RayTracer {
         } else if (ray.depth == 0) {
           // Direct sky hit.
           if (!scene.transparentSky()) {
-            scene.sky.getSkyColorInterpolated(ray);
+            scene.sky.getSkyColor(ray, true, false);
             addSkyFog(scene, ray, state, ox, od);
             hit = true;
           }
         } else if (ray.specular) {
           // Indirect sky hit - specular color.
-          scene.sky.getSkyColor(ray, true);
+          scene.sky.getSkyColor(ray, true, false);
           addSkyFog(scene, ray, state, ox, od);
           hit = true;
         } else {
           // Indirect sky hit - diffuse color.
-          scene.sky.getSkyColorDiffuseSun(ray, scene.getSunSamplingStrategy().isDiffuseSun());
+          scene.sky.getSkyColor(ray, false, scene.getSunSamplingStrategy().isDiffuseSun());
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
         }
@@ -201,7 +201,7 @@ public class PathTracer implements RayTracer {
               }
             }
 
-            if (scene.getSunSamplingStrategy().doSunSampling()) {
+            if (scene.getSunSamplingStrategy().doSunSampling() && scene.sun.sunlightEnabled()) {
               reflected.set(ray);
               scene.sun.getRandomSunDirection(reflected, random);
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -54,7 +54,7 @@ public class PreviewRayTracer implements RayTracer {
     }
 
     if (ray.getCurrentMaterial() == Air.INSTANCE) {
-      scene.sky.getApparentSkyColor(ray, true);
+      scene.sky.getSkyColor(ray, true, false);
     } else {
       scene.sun.flatShading(ray);
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3016,15 +3016,7 @@ public class Scene implements JsonSerializable, Refreshable {
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
 
     if (json.get("sunSamplingStrategy").isUnknown()) {
-      boolean sunSampling = json.get("sunEnabled").boolValue(false);
-      boolean drawSun = json.get("sun").asObject().get("drawTexture").boolValue(false);
-      if (drawSun) {
-        if (sunSampling) {
-          sunSamplingStrategy = SunSamplingStrategy.FAST;
-        } else {
-          sunSamplingStrategy = SunSamplingStrategy.NON_LUMINOUS;
-        }
-      } else {
+      if (json.get("sunEnabled").boolValue(false)) {
         sunSamplingStrategy = SunSamplingStrategy.FAST;
       }
     } else {
@@ -3033,6 +3025,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
     if (json.get("sunEnabled").boolValue(false)) {
       sunSamplingStrategy = SunSamplingStrategy.FAST;
+      sun.setEnableSunlight(true);
     } else {
       sunSamplingStrategy = SunSamplingStrategy.valueOf(json.get("sunSamplingStrategy").asString(SunSamplingStrategy.FAST.getId()));
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -281,33 +281,18 @@ public class Sun implements JsonSerializable {
    * @return <code>true</code> if the ray intersects the sun model
    */
   public boolean intersect(Ray ray) {
-    if (!drawTexture || ray.d.dot(sw) < .5) {
-      return false;
-    }
-
-    double width = radius * 4;
-    double width2 = width * 2;
-    double a;
-    a = Math.PI / 2 - FastMath.acos(ray.d.dot(su)) + width;
-    if (a >= 0 && a < width2) {
-      double b = Math.PI / 2 - FastMath.acos(ray.d.dot(sv)) + width;
-      if (b >= 0 && b < width2) {
-        texture.getColor(a / width2, b / width2, ray.color);
-        ray.color.x *= apparentTextureBrightness.x * 10;
-        ray.color.y *= apparentTextureBrightness.y * 10;
-        ray.color.z *= apparentTextureBrightness.z * 10;
-        return true;
-      }
-    }
-
-    return false;
+    return doIntersect(ray, apparentTextureBrightness);
   }
 
   /**
    * Used with <code>SSS: OFF</code> and <code>SSS: HIGH_QUALITY</code>.
    */
   public boolean intersectDiffuse(Ray ray) {
-    if (ray.d.dot(sw) < .5) {
+    return doIntersect(ray, color);
+  }
+
+  private boolean doIntersect(Ray ray, Vector3 color) {
+    if (!drawTexture || ray.d.dot(sw) < .5) {
       return false;
     }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Sun.java
@@ -160,6 +160,8 @@ public class Sun implements JsonSerializable {
 
   private final Vector3 apparentColor = new Vector3(1, 1, 1);
 
+  private boolean enableSunlight = true;
+
   private boolean drawTexture = true;
 
   private double chroma(double turb, double turb2, double sunTheta, double[][] matrix) {
@@ -195,6 +197,7 @@ public class Sun implements JsonSerializable {
     altitude = other.altitude;
     color.set(other.color);
     apparentColor.set(other.apparentColor);
+    enableSunlight = other.enableSunlight;
     drawTexture = other.drawTexture;
     intensity = other.intensity;
     luminosity = other.luminosity;
@@ -281,18 +284,18 @@ public class Sun implements JsonSerializable {
    * @return <code>true</code> if the ray intersects the sun model
    */
   public boolean intersect(Ray ray) {
-    return doIntersect(ray, apparentTextureBrightness);
+    return doIntersect(ray, apparentTextureBrightness, false);
   }
 
   /**
    * Used with <code>SSS: OFF</code> and <code>SSS: HIGH_QUALITY</code>.
    */
   public boolean intersectDiffuse(Ray ray) {
-    return doIntersect(ray, color);
+    return doIntersect(ray, color, true);
   }
 
-  private boolean doIntersect(Ray ray, Vector3 color) {
-    if (!drawTexture || ray.d.dot(sw) < .5) {
+  private boolean doIntersect(Ray ray, Vector3 color, boolean isDiffuse) {
+    if ((isDiffuse && !enableSunlight) || (!isDiffuse && !drawTexture) || ray.d.dot(sw) < .5) {
       return false;
     }
 
@@ -460,6 +463,7 @@ public class Sun implements JsonSerializable {
     apparentColorObj.add("green", apparentColor.y);
     apparentColorObj.add("blue", apparentColor.z);
     sun.add("apparentColor", apparentColorObj);
+    sun.add("enableSunlight", enableSunlight);
     sun.add("drawTexture", drawTexture);
     return sun;
   }
@@ -487,6 +491,10 @@ public class Sun implements JsonSerializable {
       apparentColor.z = apparentColorObj.get("blue").doubleValue(1);
     }
 
+    if (!json.get("enableSunlight").isUnknown()) {
+      enableSunlight = json.get("enableSunlight").boolValue(enableSunlight);
+    }
+
     drawTexture = json.get("drawTexture").boolValue(drawTexture);
 
     initSun();
@@ -501,6 +509,17 @@ public class Sun implements JsonSerializable {
 
   public Vector3 getApparentColor() {
     return apparentColor;
+  }
+
+  public void setEnableSunlight(boolean value) {
+    if (value != enableSunlight) {
+      enableSunlight = value;
+      scene.refresh();
+    }
+  }
+
+  public boolean sunlightEnabled() {
+    return enableSunlight;
   }
 
   public void setDrawTexture(boolean value) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -67,6 +67,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private Button mergeRenderDump;
   @FXML private CheckBox shutdown;
   @FXML private CheckBox fastFog;
+  @FXML private CheckBox enableSkymapInterpolation;
   @FXML private IntegerAdjuster cacheResolution;
   @FXML private DoubleAdjuster animationTime;
   @FXML private ChoiceBox<PictureExportFormat> outputMode;
@@ -141,6 +142,8 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     fastFog.setTooltip(new Tooltip("Enable faster fog rendering algorithm."));
     fastFog.selectedProperty()
             .addListener((observable, oldValue, newValue) -> scene.setFastFog(newValue));
+    enableSkymapInterpolation.setTooltip(new Tooltip("Enable interpolation of the skymap / skybox texture, if a skymap / skybox is being used."));
+    enableSkymapInterpolation.selectedProperty().addListener((observable, oldValue, newValue) -> scene.sky().setEnableSkymapInterpolation(newValue));
     cacheResolution.setName("Sky cache resolution");
     cacheResolution.setTooltip("Resolution of the sky cache. Lower values will use less memory and improve performance but can cause sky artifacts.");
     cacheResolution.setRange(1, 4096);
@@ -301,6 +304,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   public void update(Scene scene) {
     outputMode.getSelectionModel().select(scene.getOutputMode());
     fastFog.setSelected(scene.fog.fastFog());
+    enableSkymapInterpolation.setSelected(scene.sky().getEnableSkymapInterpolation());
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -54,6 +54,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private DoubleAdjuster emitterIntensity;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
+  @FXML private CheckBox enableSunlight;
   @FXML private ComboBox<SunSamplingStrategy> sunSamplingStrategy;
   @FXML private DoubleAdjuster sunLuminosity;
   @FXML private DoubleAdjuster apparentSunBrightness;
@@ -129,6 +130,9 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
       });
     emitterSamplingStrategy.setTooltip(new Tooltip("Determine how emitters are sampled at each bounce."));
 
+    enableSunlight.selectedProperty().addListener((observable, oldValue, newValue) -> scene.sun().setEnableSunlight(newValue));
+    enableSunlight.setTooltip(new Tooltip("Changes whether the sun emits light."));
+
     drawSun.selectedProperty().addListener((observable, oldValue, newValue) -> scene.sun().setDrawTexture(newValue));
     drawSun.setTooltip(new Tooltip("Draws the sun texture on top of the skymap."));
 
@@ -203,6 +207,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     sunAltitude.set(QuickMath.radToDeg(scene.sun().getAltitude()));
     enableEmitters.setSelected(scene.getEmittersEnabled());
     sunSamplingStrategy.getSelectionModel().select(scene.getSunSamplingStrategy());
+    enableSunlight.setSelected(scene.sun().sunlightEnabled());
     drawSun.setSelected(scene.sun().drawTexture());
     sunColor.colorProperty().removeListener(sunColorListener);
     sunColor.setColor(ColorUtil.toFx(scene.sun().getColor()));

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -23,6 +23,7 @@
     <Separator prefWidth="200.0" />
     <CheckBox fx:id="shutdown" mnemonicParsing="false" text="Shutdown computer when render completes" />
     <CheckBox fx:id="fastFog" mnemonicParsing="false" text="Fast fog" />
+    <CheckBox fx:id="enableSkymapInterpolation" mnemonicParsing="false" text="Enable skymap interpolation" />
     <IntegerAdjuster fx:id="cacheResolution" />
     <DoubleAdjuster fx:id="animationTime" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -26,6 +26,7 @@
       <ChoiceBox fx:id="emitterSamplingStrategy" />
     </HBox>
     <Separator />
+    <CheckBox fx:id="enableSunlight" mnemonicParsing="false" text="Enable sunlight" />
     <CheckBox fx:id="drawSun" mnemonicParsing="false" text="Draw sun" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Sun Sampling Strategy:" />


### PR DESCRIPTION
- Re-added an `Enable sunlight` control, which replaces `Sun Sampling Strategy`: `NON_LUMINOUS`.
- Added a control to enable and disable skymap interpolation.
- Refactored code that returns sky color.

![image](https://user-images.githubusercontent.com/92183530/232230310-8914868e-2fed-4376-af28-ab4c008c8e0d.png)
![image](https://user-images.githubusercontent.com/92183530/232230372-1c32cb4d-bc50-4aaf-8aaf-763dff12e1e9.png)

