### PR TITLE
Allow render threads to be changed without restarting

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -17,7 +17,6 @@
  */
 package se.llbit.chunky.renderer;
 
-import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.postprocessing.PixelPostProcessingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilter;
@@ -106,13 +105,10 @@ public class DefaultRenderManager extends Thread implements RenderManager {
   /**
    * This is the render worker pool {@code Renderer}s should use.
    *
-   * {@code Renderer}s should submit small work-units to this pool. CPU usage is limited automatically, but if
-   * each work-unit can take a long time, they should call {@code RenderWorkerPool.RenderWorker.workSleep()}
-   * periodically to manage CPU usage.
+   * {@code Renderer}s should submit small work-units to this pool.
    */
   public final RenderWorkerPool pool;
 
-  protected int cpuLoad = 100;
 
   /**
    * The render canvas. This is redrawn on every frame (if applicable).
@@ -187,7 +183,6 @@ public class DefaultRenderManager extends Thread implements RenderManager {
 
     // Create a new pool. Set the seed to the current time in milliseconds.
     this.pool = context.renderPoolFactory.create(context.numRenderThreads(), System.currentTimeMillis());
-    this.setCPULoad(PersistentSettings.getCPULoad());
 
     // Initialize callbacks here since java will complain `bufferedScene` is not initialized yet.
     // (nothing important in the rest of the constructor)
@@ -300,11 +295,8 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         if (mode == RenderMode.PREVIEW) {
           // Bail early if the preview is not visible
           if (finalizeAllFrames) {
-            // Preview with no CPU limit
-            pool.setCpuLoad(100);
             render.setPostRender(previewCallback);
             render.render(this);
-            pool.setCpuLoad(cpuLoad);
           }
         } else {
           // Bail early if render is already done
@@ -537,17 +529,6 @@ public class DefaultRenderManager extends Thread implements RenderManager {
 
   public TaskTracker.Task getRenderTask() {
     return renderTask;
-  }
-
-  /**
-   * Set CPU load percentage.
-   *
-   * @param value new load percentage.
-   */
-  @Override
-  public void setCPULoad(int value) {
-    this.cpuLoad = value;
-    pool.setCpuLoad(value);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -17,6 +17,7 @@
  */
 package se.llbit.chunky.renderer;
 
+import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.postprocessing.PixelPostProcessingFilter;
 import se.llbit.chunky.renderer.postprocessing.PostProcessingFilter;
@@ -109,6 +110,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
    */
   public final RenderWorkerPool pool;
 
+  protected int renderThreads = RenderConstants.NUM_RENDER_THREADS_DEFAULT;
 
   /**
    * The render canvas. This is redrawn on every frame (if applicable).
@@ -183,6 +185,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
 
     // Create a new pool. Set the seed to the current time in milliseconds.
     this.pool = context.renderPoolFactory.create(context.numRenderThreads(), System.currentTimeMillis());
+    this.setRenderThreads(PersistentSettings.getNumThreads());
 
     // Initialize callbacks here since java will complain `bufferedScene` is not initialized yet.
     // (nothing important in the rest of the constructor)
@@ -529,6 +532,12 @@ public class DefaultRenderManager extends Thread implements RenderManager {
 
   public TaskTracker.Task getRenderTask() {
     return renderTask;
+  }
+
+  @Override
+  public void setRenderThreads(int value) {
+    this.renderThreads = value;
+    pool.setRenderThreads(value);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
@@ -47,6 +47,11 @@ public interface RenderManager {
   Collection<? extends Registerable> getPreviewRenderers();
 
   /**
+   * Instructs the renderer to change its number of render threads.
+   */
+  void setRenderThreads(int loadPercent);
+
+  /**
    * Set a listener for render completion.
    *
    * @param listener a listener which is passed the total rendering

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderManager.java
@@ -47,11 +47,6 @@ public interface RenderManager {
   Collection<? extends Registerable> getPreviewRenderers();
 
   /**
-   * Instructs the renderer to change its CPU load.
-   */
-  void setCPULoad(int loadPercent);
-
-  /**
    * Set a listener for render completion.
    *
    * @param listener a listener which is passed the total rendering

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -62,7 +62,6 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   private Scene scene;
 
   @FXML private IntegerAdjuster renderThreads;
-  @FXML private IntegerAdjuster cpuLoad;
   @FXML private IntegerAdjuster rayDepth;
   @FXML private Button mergeRenderDump;
   @FXML private CheckBox shutdown;
@@ -92,14 +91,6 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   public void initialize(URL location, ResourceBundle resources) {
     outputMode.getItems().addAll(PictureExportFormats.getFormats());
     outputMode.getSelectionModel().select(PictureExportFormats.PNG);
-    cpuLoad.setName("CPU utilization");
-    cpuLoad.setTooltip("CPU utilization percentage per render thread.");
-    cpuLoad.setRange(1, 100);
-    cpuLoad.clampBoth();
-    cpuLoad.onValueChange(value -> {
-      PersistentSettings.setCPULoad(value);
-      controller.getRenderManager().setCPULoad(value);
-    });
     rayDepth.setName("Ray depth");
     rayDepth.setTooltip("Sets the minimum recursive ray depth.");
     rayDepth.setRange(1, 25);
@@ -302,7 +293,6 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     outputMode.getSelectionModel().select(scene.getOutputMode());
     fastFog.setSelected(scene.fog.fastFog());
     renderThreads.set(PersistentSettings.getNumThreads());
-    cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());
     octreeImplementation.getSelectionModel().select(scene.getOctreeImplementation());
     bvhMethod.getSelectionModel().select(scene.getBvhImplementation());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -28,6 +28,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.launcher.LauncherSettings;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.renderer.EmitterSamplingStrategy;
+import se.llbit.chunky.renderer.RenderConstants;
 import se.llbit.chunky.renderer.RenderController;
 import se.llbit.chunky.renderer.RenderManager;
 import se.llbit.chunky.renderer.export.PictureExportFormat;
@@ -150,11 +151,11 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     });
     renderThreads.setName("Render threads");
     renderThreads.setTooltip("Number of rendering threads.");
-    renderThreads.setRange(1, 20);
+    renderThreads.setRange(1, 2 * RenderConstants.NUM_RENDER_THREADS_DEFAULT);
     renderThreads.clampMin();
     renderThreads.onValueChange(value -> {
       PersistentSettings.setNumRenderThreads(value);
-      renderControls.showPopup("This change takes effect after restarting Chunky.", renderThreads);
+      controller.getRenderManager().setRenderThreads(value);
     });
 
     ArrayList<String> octreeNames = new ArrayList<>();

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -15,7 +15,6 @@
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <IntegerAdjuster fx:id="renderThreads" />
-    <IntegerAdjuster fx:id="cpuLoad" />
     <Separator prefWidth="200.0" />
     <IntegerAdjuster fx:id="rayDepth" />
     <Separator layoutX="20.0" layoutY="90.0" prefWidth="200.0" />

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -179,23 +179,6 @@ public final class PersistentSettings {
     return settings.getInt("yClipMin", 0);
   }
 
-  /**
-   * @return CPU load setting
-   */
-  public static int getCPULoad() {
-    return settings.getInt("cpuLoad", RenderConstants.CPU_LOAD_DEFAULT);
-  }
-
-  /**
-   * Change the default CPU load.
-   */
-  public static void setCPULoad(int cpuLoad) {
-    cpuLoad = Math.max(1, cpuLoad);
-    cpuLoad = Math.min(100, cpuLoad);
-    settings.setInt("cpuLoad", cpuLoad);
-    save();
-  }
-
   public static void setLastWorld(File worldDirectory) {
     settings.setString("lastWorld", worldDirectory.getAbsolutePath());
     save();

--- a/lib/src/se/llbit/chunky/renderer/RenderConstants.java
+++ b/lib/src/se/llbit/chunky/renderer/RenderConstants.java
@@ -30,11 +30,6 @@ public interface RenderConstants {
   int NUM_RENDER_THREADS_DEFAULT = Runtime.getRuntime().availableProcessors();
 
   /**
-   * Default CPU load
-   */
-  int CPU_LOAD_DEFAULT = 100;
-
-  /**
    * Minimum number of worker threads
    */
   int NUM_RENDER_THREADS_MIN = 1;


### PR DESCRIPTION
I also removed the `CPU Load` option, as it wasn't accurate. This is a better replacement

Render threads changing from `1 -> 3 -> 6 -> 9 -> 12 -> 9 -> 6 -> 3 -> 1`
![image](https://user-images.githubusercontent.com/16853282/232235719-2746b148-543d-4a7f-8868-2ddce53711dc.png)
(The drops around 12 are from the brief period I had `1` typed in when typing `12`)