### PR TITLE
Use a constant multiplier on `Parallel` projection

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Camera.java
@@ -445,7 +445,8 @@ public class Camera implements JsonSerializable {
    * Rotate the camera
    */
   public synchronized void rotateView(double yaw, double pitch) {
-    double fovRad = QuickMath.degToRad(fov / 2);
+    double fovRad = (this.projectionMode == ProjectionMode.PARALLEL) ? 0.5 : QuickMath.degToRad(fov / 2);
+
     this.yaw += yaw * fovRad;
     this.pitch += pitch * fovRad;
 


### PR DESCRIPTION
Fixes #1584.

This change should prevent view speed from scaling with "FOV" in `Parallel` projection. The value of *0.5* which I used corresponds to a "FOV" value of about *57*.