### PR TITLE
Allow empty chunks to be selected if their region exists

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/MapTile.java
+++ b/chunky/src/java/se/llbit/chunky/map/MapTile.java
@@ -64,7 +64,7 @@ public class MapTile {
     if (scale >= 16) {
       Chunk chunk = mapLoader.getWorld().currentDimension().getChunk(pos);
       renderChunk(chunk);
-      if (!(chunk instanceof EmptyChunk) && selection.isSelected(pos)) {
+      if (!(chunk instanceof EmptyRegionChunk) && selection.isSelected(pos)) {
         for (int i = 0; i < tileWidth * tileWidth; ++i) {
           pixels[i] = selectionTint(pixels[i]);
         }
@@ -76,8 +76,11 @@ public class MapTile {
       for (int z = 0; z < 32; ++z) {
         for (int x = 0; x < 32; ++x) {
           Chunk chunk = region.getChunk(x, z);
+          //Calculate the chunk position as empty chunks are (0, 0)
+          ChunkPosition pos = region.getPosition().chunkPositionFromRegion(x, z);
+
           pixels[pixelOffset] = chunk.biomeColor();
-          if (isValid && !(chunk instanceof EmptyChunk) && selection.isSelected(chunk.getPosition())) {
+          if (isValid && !(chunk instanceof EmptyRegionChunk) && selection.isSelected(pos)) {
             pixels[pixelOffset] = selectionTint(pixels[pixelOffset]);
           }
           pixelOffset += 1;

--- a/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkPosition.java
@@ -55,6 +55,10 @@ public class ChunkPosition {
     return new ChunkPosition(x >> 5, z >> 5);
   }
 
+  public ChunkPosition chunkPositionFromRegion(int localX, int localZ) {
+    return new ChunkPosition((this.x << 5) | (localX & 0x1f), (this.z << 5) | (localZ & 0x1f));
+  }
+
   /**
    * @return The packed {@code long} chunk position for the x and z
    */

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -64,7 +64,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
   private boolean setChunk(Dimension dimension, ChunkPosition pos, boolean selected) {
     //Only need to check if the chunk isn't empty on selecting a chunk, as it must exist if it's already selected
     Chunk chunk = dimension.getChunk(pos);
-    if(selected && (chunk == EmptyRegionChunk.INSTANCE || chunk == EmptyChunk.INSTANCE)) {
+    if(selected && (chunk == EmptyRegionChunk.INSTANCE)) {
       return false;
     }
     return setChunk(pos, selected);
@@ -87,7 +87,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
         if(previousValue != selected) {
           ChunkPosition chunkPos = new ChunkPosition(chunkX, chunkZ);
           Chunk chunk = dimension.getChunk(chunkPos);
-          if(chunk != EmptyRegionChunk.INSTANCE && chunk != EmptyChunk.INSTANCE) {
+          if(chunk != EmptyRegionChunk.INSTANCE) {
             selectionChanged = true;
             selectedChunksForRegion.set(bitIndex, selected);
 


### PR DESCRIPTION
On slower computers loading very large maps can take a long time, this PR allows chunks to be selected even if they're empty.

To clarify: `EmptyChunk`s only exist if the region they're within exists. `EmptyRegionChunk`s still cannot be selected.
