### PR TITLE
Prevent spurious refresh from the octree implementation control.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -180,8 +180,10 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     octreeImplementation.getSelectionModel().selectedItemProperty()
             .addListener((observable, oldvalue, newvalue) -> {
               PersistentSettings.setOctreeImplementation(newvalue);
-              scene.setOctreeImplementation(newvalue);
-              scene.softRefresh();
+              if (!scene.getOctreeImplementation().equals(newvalue)) {
+                scene.setOctreeImplementation(newvalue);
+                scene.softRefresh();
+              }
             });
     octreeImplementation.setTooltip(new Tooltip(tooltipTextBuilder.toString()));
 


### PR DESCRIPTION
Addresses #1594 in snapshot.
Initializing the `Advanced` tab was causing the octree implmentation control callback to be fired. This adds a check if the octree implementation actually changed before refreshing.