### PR TITLE
Improve Refraction

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -725,12 +725,18 @@ public class Scene implements JsonSerializable, Refreshable {
       }
     } else {
       r = new Ray(start);
-      r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
+      Material mat = start.getPrevMaterial();
+      int data = start.getPrevData();
+      if (mat != Air.INSTANCE && !mat.isWater()) {
+        r.setCurrentMaterial(Air.INSTANCE, data);
+      } else {
+        r.setCurrentMaterial(mat, data);
+      }
       if (waterOctree.enterBlock(this, r, palette) && r.distance < ray.t) {
         ray.t = r.distance;
         ray.setNormal(r.getNormal());
         ray.color.set(r.color);
-        ray.setPrevMaterial(r.getPrevMaterial(), r.getPrevData());
+        ray.setPrevMaterial(mat, r.getPrevData());
         ray.setCurrentMaterial(r.getCurrentMaterial(), r.getCurrentData());
         hit = true;
       }

--- a/chunky/src/java/se/llbit/math/Octree.java
+++ b/chunky/src/java/se/llbit/math/Octree.java
@@ -556,7 +556,7 @@ public class Octree {
           offsetZ = -ray.o.z * invDz;
           continue;
         }
-      } else if (!currentBlock.isSameMaterial(prevBlock) && currentBlock != Air.INSTANCE) {
+      } else if (!currentBlock.isSameMaterial(prevBlock)) {
         // Origin and distance of ray need to be updated
         ray.o.scaleAdd(distance, ray.d);
         ray.distance += distance;


### PR DESCRIPTION
Fixes #1515
There was a check in the octree intersection code ignoring intersections with air. Removing this broke the water octree. I put a hack that coerces the ray's current block to be air if it isn't water when intersecting with the water octree. This seems to work for now but probably needs more testing.