### PR TITLE
Fix Javadoc for Quad constructors

### DIFF
--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -16,6 +16,7 @@ import java.util.Random;
 @PluginApi
 public abstract class QuadModel implements BlockModel {
 
+  // For some visualizations, see this PR: https://github.com/chunky-dev/chunky/pull/1603
   public static final Quad FULL_BLOCK_NORTH_SIDE = new Quad(
     new Vector3(1, 0, 0),
     new Vector3(0, 0, 0),

--- a/chunky/src/java/se/llbit/math/Quad.java
+++ b/chunky/src/java/se/llbit/math/Quad.java
@@ -100,6 +100,8 @@ public class Quad {
 
   /**
    * Create a new single sided quad
+   * <br>
+   * For some visualizations, see this PR: <a href="https://github.com/chunky-dev/chunky/pull/1603">#1603</a>
    *
    * @param v0 Bottom left vector
    * @param v1 Bottom right vector
@@ -113,6 +115,8 @@ public class Quad {
 
   /**
    * Create new quad
+   * <br>
+   * For some visualizations, see this PR: <a href="https://github.com/chunky-dev/chunky/pull/1603">#1603</a>
    *
    * @param v0 Bottom left vector
    * @param v1 Bottom right vector

--- a/chunky/src/java/se/llbit/math/Quad.java
+++ b/chunky/src/java/se/llbit/math/Quad.java
@@ -102,8 +102,8 @@ public class Quad {
    * Create a new single sided quad
    *
    * @param v0 Bottom left vector
-   * @param v1 Top right vector
-   * @param v2 Bottom right vector
+   * @param v1 Bottom right vector
+   * @param v2 Top left vector
    * @param uv Minimum and maximum U/V texture coordinates (x0,y0 bottom left)
    */
   public Quad(Vector3 v0, Vector3 v1, Vector3 v2, Vector4 uv) {
@@ -115,8 +115,8 @@ public class Quad {
    * Create new quad
    *
    * @param v0 Bottom left vector
-   * @param v1 Top right vector
-   * @param v2 Bottom right vector
+   * @param v1 Bottom right vector
+   * @param v2 Top left vector
    * @param uv Minimum and maximum U/V texture coordinates (x0,y0 bottom left)
    * @param doubleSided True to make this quad double-sided
    */


### PR DESCRIPTION
When I was working on the Decorated Pot model (#1602), I noticed that the Javadocs for the Quad constructors seem wrong, since as far as I can tell, the first three arguments are the bottom left, bottom right, and top left coordinates of the quad, respectively. Hopefully this helps explain - these are `Quad`s defined in `QuadModel`:

```
public static final Quad FULL_BLOCK_NORTH_SIDE = new Quad(
    new Vector3(1, 0, 0),
    new Vector3(0, 0, 0),
    new Vector3(1, 1, 0),
    new Vector4(0, 1, 0, 1));
```
![image](https://github.com/chunky-dev/chunky/assets/46458276/68b952e4-5632-4129-a0ed-13faa081b3cb)

```
public static final Quad FULL_BLOCK_EAST_SIDE = new Quad(
    new Vector3(1, 0, 1),
    new Vector3(1, 0, 0),
    new Vector3(1, 1, 1),
    new Vector4(0, 1, 0, 1));
```
![image](https://github.com/chunky-dev/chunky/assets/46458276/7b99c3b3-9ce8-4927-add1-03cd611ce445)

```
public static final Quad FULL_BLOCK_TOP_SIDE = new Quad(
    new Vector3(1, 1, 0),
    new Vector3(0, 1, 0),
    new Vector3(1, 1, 1),
    new Vector4(1, 0, 1, 0));
```
![image](https://github.com/chunky-dev/chunky/assets/46458276/c80816c6-1caf-46bb-8d62-eb8f0f7745ac)

I confirmed that the other sides work the same way although I don't think more pictures are needed.

While I'm pretty sure something is wrong with the Javadocs, it is also possible that I'm wrong in which case I'd like to know how I am misunderstanding this.