### PR TITLE
Replace SimplexNoise license link with CC0 instead of Unlicense

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/CreditsController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/CreditsController.java
@@ -171,7 +171,7 @@ public class CreditsController implements Initializable {
     simplexnoise.setBorder(Border.EMPTY);
     simplexnoise.setOnAction(e -> launchAndReset(simplexnoise, "https://github.com/keijiro/sketches2016/blob/master/Simplex2/SimplexNoise.java"));
     simplexnoiseLicense.setBorder(Border.EMPTY);
-    simplexnoiseLicense.setOnAction(e -> launchAndReset(simplexnoiseLicense, "https://unlicense.org/"));
+    simplexnoiseLicense.setOnAction(e -> launchAndReset(simplexnoiseLicense, "https://creativecommons.org/publicdomain/zero/1.0/"));
 
     semver4j.setBorder(Border.EMPTY);
     semver4j.setOnAction(e -> launchAndReset(semver4j, "https://github.com/vdurmont/semver4j"));

--- a/chunky/src/res/se/llbit/chunky/ui/dialogs/Credits.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/dialogs/Credits.fxml
@@ -213,7 +213,7 @@
                          <Insets/>
                        </padding>
                      </Hyperlink>
-                     <Hyperlink fx:id="simplexnoiseLicense" text="Public domain / Unlicense">
+                     <Hyperlink fx:id="simplexnoiseLicense" text="Public domain / CC0">
                         <font>
                            <Font size="10.0" />
                         </font>


### PR DESCRIPTION
The linked source code did not state Unlicense, but is released as public domain software. While I do not know the legal aspects in detail, I'll assume that CC0 is a better description of the library author's intents. 
also see https://chrismorgan.info/blog/unlicense/