### PR TITLE
Fix upper limit of "Render threads" slider

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -165,7 +165,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     });
     renderThreads.setName("Render threads");
     renderThreads.setTooltip("Number of rendering threads.");
-    renderThreads.setRange(1, 20);
+    renderThreads.setRange(1, Runtime.getRuntime().availableProcessors());
     renderThreads.clampMin();
     renderThreads.onValueChange(value -> {
       PersistentSettings.setNumRenderThreads(value);


### PR DESCRIPTION
Especially now that recent Intel and AMD processors have 24 (e.g. 13700K, 7900X) or even 32 (e.g. 13900K, 7950X) logical cores, the slider should probably match those numbers rather than its current hardcoded upper bound of 20. (Higher values could be entered with the text box, so really this is just a small "QOL" improvement.)

Before:
![image](https://github.com/chunky-dev/chunky/assets/46458276/c35ec928-c477-43f9-af0f-405d62f0c2e4)
![image](https://github.com/chunky-dev/chunky/assets/46458276/0507d750-4251-41aa-8d6b-0d23de5d8b4c)
After:
![image](https://github.com/chunky-dev/chunky/assets/46458276/d91a1be8-2e8c-4b87-b04a-121e863af28b)
![image](https://github.com/chunky-dev/chunky/assets/46458276/6ec829c5-1fd5-4523-b2d7-4d5f3a966f71)