### PR TITLE
Workaround for some potential drawbacks of ray branching

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
@@ -71,7 +71,7 @@ public class PathTracingRenderer extends TileBasedRenderer {
 
     while (scene.spp < scene.getTargetSpp()) {
       int spp = scene.spp;
-      int branchCount = (tracer instanceof PathTracer) ? scene.getBranchCount() : 1;
+      int branchCount = (tracer instanceof PathTracer) ? scene.getBranchCount(true) : 1;
       double sinv = 1.0 / (sppPerPass * branchCount + spp);
 
       submitTiles(manager, (state, pixel) -> {

--- a/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
@@ -71,7 +71,7 @@ public class PathTracingRenderer extends TileBasedRenderer {
 
     while (scene.spp < scene.getTargetSpp()) {
       int spp = scene.spp;
-      int branchCount = (tracer instanceof PathTracer) ? scene.getBranchCount(true) : 1;
+      int branchCount = (tracer instanceof PathTracer) ? scene.getCurrentBranchCount() : 1;
       double sinv = 1.0 / (sppPerPass * branchCount + spp);
 
       submitTiles(manager, (state, pixel) -> {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -135,7 +135,7 @@ public class PathTracer implements RayTracer {
       // The main caveat is that antialiasing is achieved by varying the starting rays at the subpixel level (see PathTracingRenderer.java)
       // Therefore, it's still necessary to have a decent amount (20 is ok, 50 is better) of distinct starting rays for each pixel
       // scene.branchCount is the number of times we use the same first ray before casting a new one
-      int count = firstReflection ? scene.getBranchCount(true) : 1;
+      int count = firstReflection ? scene.getCurrentBranchCount() : 1;
       for (int i = 0; i < count; i++) {
         boolean doMetal = pMetal > Ray.EPSILON && random.nextFloat() < pMetal;
         if (doMetal || (pSpecular > Ray.EPSILON && random.nextFloat() < pSpecular)) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -135,7 +135,7 @@ public class PathTracer implements RayTracer {
       // The main caveat is that antialiasing is achieved by varying the starting rays at the subpixel level (see PathTracingRenderer.java)
       // Therefore, it's still necessary to have a decent amount (20 is ok, 50 is better) of distinct starting rays for each pixel
       // scene.branchCount is the number of times we use the same first ray before casting a new one
-      int count = firstReflection ? scene.getBranchCount() : 1;
+      int count = firstReflection ? scene.getBranchCount(true) : 1;
       for (int i = 0; i < count; i++) {
         boolean doMetal = pMetal > Ray.EPSILON && random.nextFloat() < pMetal;
         if (doMetal || (pSpecular > Ray.EPSILON && random.nextFloat() < pSpecular)) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1920,11 +1920,19 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
-   * @param modified Whether to alter the branch count based on current spp
-   * @return The branch count
+   * @return The "nominal" value of the branch count.
    */
-  public int getBranchCount(boolean modified) {
-    if(modified && spp < branchCount) {
+  public int getBranchCount() {
+      return branchCount;
+  }
+
+  /**
+   * Usually the same as getBranchCount, but reduces branch count to 1 for first few SPP.
+   *
+   * @return The current "true" branch count
+   */
+  public int getCurrentBranchCount() {
+    if(spp < branchCount) {
       if(spp <= Math.sqrt(branchCount)) { // This is arbitrary, but should be a good compromise in most cases
         return 1;
       } else {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1920,10 +1920,19 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * @param modified Whether to alter the branch count based on current spp
    * @return The branch count
    */
-  public int getBranchCount() {
-    return branchCount;
+  public int getBranchCount(boolean modified) {
+    if(modified && spp < branchCount) {
+      if(spp <= Math.sqrt(branchCount)) { // This is arbitrary, but should be a good compromise in most cases
+        return 1;
+      } else {
+        return branchCount - spp;
+      }
+    } else {
+      return branchCount;
+    }
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -326,7 +326,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());
-    branchCount.set(scene.getBranchCount());
+    branchCount.set(scene.getBranchCount(false));
     octreeImplementation.getSelectionModel().select(scene.getOctreeImplementation());
     bvhMethod.getSelectionModel().select(scene.getBvhImplementation());
     biomeStructureImplementation.getSelectionModel().select(scene.getBiomeStructureImplementation());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -326,7 +326,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());
-    branchCount.set(scene.getBranchCount(false));
+    branchCount.set(scene.getBranchCount());
     octreeImplementation.getSelectionModel().select(scene.getOctreeImplementation());
     bvhMethod.getSelectionModel().select(scene.getBvhImplementation());
     biomeStructureImplementation.getSelectionModel().select(scene.getBiomeStructureImplementation());

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -64,7 +64,7 @@ public final class PersistentSettings {
   public static final double DEFAULT_FOG_BLUE = 1;
 
   public static final int DEFAULT_RAY_DEPTH = 5;
-  public static final int DEFAULT_BRANCH_COUNT = 5;
+  public static final int DEFAULT_BRANCH_COUNT = 10;
   public static final int DEFAULT_SPP_TARGET = 1000;
 
   public static final int DEFAULT_DIMENSION = 0;


### PR DESCRIPTION
Don't branch on the first few SPP to avoid some potential performance-related issues (such as pointed out [here](https://discord.com/channels/541221265512464394/1144538849582792847/1144538849582792847) on Discord) based on the square root of the branch count (arbitrary, but seems to work fine)

Examples:
If BC=5, sequence will be 1, 1, 1, 2, 5, 5, 5, ...
If BC=10, sequence will be 1, 1, 1, 1, 6, 10, 10, 10, ...
If BC=20, sequence will be 1, 1, 1, 1, 1, 15, 20, 20, 20, ...

Also, this sets the default branch count to 10 instead of 5 (since there are now fewer issues with that.)