### PR TITLE
Simplify emitter logic and make it more correct

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -346,10 +346,10 @@ public class BlockPalette {
       }
     });
     materialProperties.put("minecraft:torch", block -> {
-      block.emittance = 50.0f;
+      block.emittance = 1.0f;
     });
     materialProperties.put("minecraft:wall_torch", block -> {
-      block.emittance = 50.0f;
+      block.emittance = 1.0f;
     });
     materialProperties.put("minecraft:fire", block -> {
       block.emittance = 1.0f;
@@ -447,16 +447,16 @@ public class BlockPalette {
       block.emittance = 0.6f;
     });
     materialProperties.put("minecraft:soul_fire_torch", block -> { // MC 20w06a-20w16a
-      block.emittance = 35.0f;
+      block.emittance = 0.6f;
     });
     materialProperties.put("minecraft:soul_torch", block -> { // MC >= 20w17a
-      block.emittance = 35.0f;
+      block.emittance = 0.6f;
     });
     materialProperties.put("minecraft:soul_fire_wall_torch", block -> { // MC 20w06a-20w16a
-      block.emittance = 35.0f;
+      block.emittance = 0.6f;
     });
     materialProperties.put("minecraft:soul_wall_torch", block -> { // MC >= 20w17a
-      block.emittance = 35.0f;
+      block.emittance = 0.6f;
     });
     materialProperties.put("minecraft:soul_fire", block -> {
       block.emittance = 0.6f;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -45,7 +45,7 @@ public class PathTracer implements RayTracer {
     } else {
       ray.setCurrentMaterial(Air.INSTANCE);
     }
-    pathTrace(scene, ray, state, 1, true);
+    pathTrace(scene, ray, state, true);
   }
 
   /**
@@ -54,7 +54,7 @@ public class PathTracer implements RayTracer {
    * @param firstReflection {@code true} if the ray has not yet hit the first
    * diffuse or specular reflection
    */
-  public static boolean pathTrace(Scene scene, Ray ray, WorkerState state, int addEmitted,
+  public static boolean pathTrace(Scene scene, Ray ray, WorkerState state,
                                   boolean firstReflection) {
 
     boolean hit = false;
@@ -141,7 +141,7 @@ public class PathTracer implements RayTracer {
         if (doMetal || (pSpecular > Ray.EPSILON && random.nextFloat() < pSpecular)) {
           hit |= doSpecularReflection(ray, next, cumulativeColor, doMetal, random, state, scene);
         } else if(random.nextFloat() < pDiffuse) {
-          hit |= doDiffuseReflection(ray, next, currentMat, cumulativeColor, addEmitted, random, state, scene);
+          hit |= doDiffuseReflection(ray, next, currentMat, cumulativeColor, random, state, scene);
         } else if (n1 != n2) {
           hit |= doRefraction(ray, next, currentMat, prevMat, cumulativeColor, n1, n2, pDiffuse, random, state, scene);
         } else {
@@ -204,10 +204,7 @@ public class PathTracer implements RayTracer {
   private static boolean doSpecularReflection(Ray ray, Ray next, Vector4 cumulativeColor, boolean doMetal, Random random, WorkerState state, Scene scene) {
     boolean hit = false;
     next.specularReflection(ray, random);
-    if (pathTrace(scene, next, state, 1, false)) {
-      ray.emittance.x = ray.color.x * next.emittance.x;
-      ray.emittance.y = ray.color.y * next.emittance.y;
-      ray.emittance.z = ray.color.z * next.emittance.z;
+    if (pathTrace(scene, next, state, false)) {
 
       if (doMetal) {
         // use the albedo color as specular color
@@ -224,20 +221,15 @@ public class PathTracer implements RayTracer {
     return hit;
   }
 
-  private static boolean doDiffuseReflection(Ray ray, Ray next, Material currentMat, Vector4 cumulativeColor, int addEmitted, Random random, WorkerState state, Scene scene) {
+  private static boolean doDiffuseReflection(Ray ray, Ray next, Material currentMat, Vector4 cumulativeColor, Random random, WorkerState state, Scene scene) {
     boolean hit = false;
-    float emittance = 0;
+    Vector3 emittance = new Vector3();
     Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
     if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-      emittance = addEmitted;
-      ray.emittance.x = ray.color.x * ray.color.x *
-        currentMat.emittance * scene.emitterIntensity;
-      ray.emittance.y = ray.color.y * ray.color.y *
-        currentMat.emittance * scene.emitterIntensity;
-      ray.emittance.z = ray.color.z * ray.color.z *
-        currentMat.emittance * scene.emitterIntensity;
+      emittance = new Vector3(ray.color.x, ray.color.y, ray.color.z);
+      emittance.scale(currentMat.emittance * scene.emitterIntensity);
 
       hit = true;
     } else if (scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() != null) {
@@ -294,14 +286,11 @@ public class PathTracer implements RayTracer {
       }
 
       next.diffuseReflection(ray, random);
-      hit = pathTrace(scene, next, state, 0, false) || hit;
+      hit = pathTrace(scene, next, state, false) || hit;
       if (hit) {
-        cumulativeColor.x += ray.color.x * (emittance + directLightR * scene.sun.emittance.x + (
-          next.color.x + next.emittance.x) + (indirectEmitterColor.x));
-        cumulativeColor.y += ray.color.y * (emittance + directLightG * scene.sun.emittance.y + (
-          next.color.y + next.emittance.y) + (indirectEmitterColor.y));
-        cumulativeColor.z += ray.color.z * (emittance + directLightB * scene.sun.emittance.z + (
-          next.color.z + next.emittance.z) + (indirectEmitterColor.z));
+        cumulativeColor.x += ray.color.x * (emittance.x + directLightR * scene.sun.emittance.x + next.color.x + (indirectEmitterColor.x));
+        cumulativeColor.y += ray.color.y * (emittance.y + directLightG * scene.sun.emittance.y + next.color.y + (indirectEmitterColor.y));
+        cumulativeColor.z += ray.color.z * (emittance.z + directLightB * scene.sun.emittance.z + next.color.z + (indirectEmitterColor.z));
       } else if (indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
         hit = true;
         cumulativeColor.x += ray.color.x * indirectEmitterColor.x;
@@ -312,11 +301,11 @@ public class PathTracer implements RayTracer {
     } else {
       next.diffuseReflection(ray, random);
 
-      hit = pathTrace(scene, next, state, 0, false) || hit;
+      hit = pathTrace(scene, next, state, false) || hit;
       if (hit) {
-        cumulativeColor.x += ray.color.x * (emittance + (next.color.x + next.emittance.x) + (indirectEmitterColor.x));
-        cumulativeColor.y += ray.color.y * (emittance + (next.color.y + next.emittance.y) + (indirectEmitterColor.y));
-        cumulativeColor.z += ray.color.z * (emittance + (next.color.z + next.emittance.z) + (indirectEmitterColor.z));
+        cumulativeColor.x += ray.color.x * (emittance.x + next.color.x + (indirectEmitterColor.x));
+        cumulativeColor.y += ray.color.y * (emittance.y + next.color.y + (indirectEmitterColor.y));
+        cumulativeColor.z += ray.color.z * (emittance.z + next.color.z + (indirectEmitterColor.z));
       } else if (indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
         hit = true;
         cumulativeColor.x += ray.color.x * indirectEmitterColor.x;
@@ -338,10 +327,7 @@ public class PathTracer implements RayTracer {
     if (doRefraction && radicand < Ray.EPSILON) {
       // Total internal reflection.
       next.specularReflection(ray, random);
-      if (pathTrace(scene, next, state, 1, false)) {
-        ray.emittance.x = ray.color.x * next.emittance.x;
-        ray.emittance.y = ray.color.y * next.emittance.y;
-        ray.emittance.z = ray.color.z * next.emittance.z;
+      if (pathTrace(scene, next, state, false)) {
 
         cumulativeColor.x += next.color.x;
         cumulativeColor.y += next.color.y;
@@ -362,10 +348,7 @@ public class PathTracer implements RayTracer {
 
       if (random.nextFloat() < Rtheta) {
         next.specularReflection(ray, random);
-        if (pathTrace(scene, next, state, 1, false)) {
-          ray.emittance.x = ray.color.x * next.emittance.x;
-          ray.emittance.y = ray.color.y * next.emittance.y;
-          ray.emittance.z = ray.color.z * next.emittance.z;
+        if (pathTrace(scene, next, state, false)) {
 
           cumulativeColor.x += next.color.x;
           cumulativeColor.y += next.color.y;
@@ -401,7 +384,7 @@ public class PathTracer implements RayTracer {
           next.o.scaleAdd(Ray.OFFSET, next.d);
         }
 
-        if (pathTrace(scene, next, state, 1, false)) {
+        if (pathTrace(scene, next, state, false)) {
           // Calculate the color and emittance of the refracted ray
           translucentRayColor(scene, ray, next, cumulativeColor, pDiffuse);
           hit = true;
@@ -416,7 +399,7 @@ public class PathTracer implements RayTracer {
     next.set(ray);
     next.o.scaleAdd(Ray.OFFSET, next.d);
 
-    if (pathTrace(scene, next, state, 1, false)) {
+    if (pathTrace(scene, next, state, false)) {
       // Calculate the color and emittance of the refracted ray
       translucentRayColor(scene, ray, next, cumulativeColor, pDiffuse);
       hit = true;
@@ -474,8 +457,6 @@ public class PathTracer implements RayTracer {
     Vector4 outputColor = new Vector4(0, 0, 0, 0);
     outputColor.multiplyEntrywise(new Vector4(rgbTrans, 1), next.color);
     cumulativeColor.add(outputColor);
-    // Use emittance from next ray
-    ray.emittance.multiplyEntrywise(rgbTrans, next.emittance);
   }
 
   private static double reassignTransmissivity(double from, double to, double other, double trans, double cap) {

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -70,11 +70,6 @@ public class Ray {
   public Vector4 color = new Vector4();
 
   /**
-   * Emittance of previously intersected surface.
-   */
-  public Vector3 emittance = new Vector3();
-
-  /**
    * Previous material.
    */
   private Material prevMaterial = Air.INSTANCE;
@@ -150,7 +145,6 @@ public class Ray {
     currentMaterial = Air.INSTANCE;
     depth = 0;
     color.set(0, 0, 0, 0);
-    emittance.set(0, 0, 0);
     specular = true;
   }
 
@@ -167,7 +161,6 @@ public class Ray {
     n.set(other.n);
     geomN.set(other.geomN);
     color.set(0, 0, 0, 0);
-    emittance.set(0, 0, 0);
     specular = other.specular;
   }
 


### PR DESCRIPTION
### The problem
As has been discussed previously (#1555, #1549), the apparent brightness of emitters when viewed directly does not scale with their emittance. While investigating this, it became clear that there was a deeper issue here. See this render done on master:
![image](https://github.com/chunky-dev/chunky/assets/46458276/201fb3eb-9ee8-4e7f-ad9e-b211154cbc53)
Emitter intensity is set to 0, so the blocks themselves shouldn't be lit up at all. But not only are they lit up, they are somehow slightly illuminating the scene. To simplify things, consider the case where all surfaces are diffuse. Looking at the relevant code:
![image](https://github.com/chunky-dev/chunky/assets/46458276/a066b76c-88b1-42a1-a4db-6f3843756bce)
`indirectEmitterColor` and `next.emittance` will always be zero, and `emittance` is forced to be zero after the first diffuse reflection (which as far as I can tell is just a workaround that makes things look less wrong). Thus, everything but the emitters themselves should be dark, and sure enough, even at 100x exposure:
![image](https://github.com/chunky-dev/chunky/assets/46458276/92413301-8e68-4ea8-837b-c9ae0a99a0f9)
A hint to where the light is coming from is that it is only noticeable near the back wall when it is a metallic/specular surface. Specular reflections aren't nearly as complicated, and don't have the same special case for handling reflected emitter light that diffuse surfaces do. From here, I tried making the back wall metallic, but extremely rough (0% smoothness). This should be virtually identical to what the diffuse surface from before looked like, but it's not:
![image](https://github.com/chunky-dev/chunky/assets/46458276/f2118b6b-9677-4ab1-a7d6-faf1f164ddd6)
You'll notice that this looks a lot like you'd expect a diffuse surface to look if emitters were enabled. That led me to this solution:
### The solution
First, I tried making the floor and other walls metallic with zero smoothness (same as the back wall):
![image](https://github.com/chunky-dev/chunky/assets/46458276/598757bd-d521-434d-ac6a-dde1fb51ec6a)
As expected, it looks like a completely normal render of some emitters in a diffuse room. I then began implementing this in code by changing the diffuse reflection logic to be more similar to the specular reflection logic, which basically boiled down to removing the `next.emittance` term while also removing the special case that handles emitter contributions differently after the first bounce. The main result is that now, "apparent emitter brightness" and "emitter light intensity" (terminology from #1555) are intrinsically linked rather than being related by a completely arbitrary factor of 13 - this is the "making it more correct" part. Additionally, these changes result in simpler code, most importantly by completely removing `ray.emittance` which is no longer needed. Not only does this make things a bit easier to read, it also improves performance slightly, because that's one less `public Vector3` being allocated for each `Ray`.
### Comparisons
After changes (328/328/328 seconds, **12% faster**):
![image](https://github.com/chunky-dev/chunky/assets/46458276/5f0b4bc0-e5c5-471c-b150-b007a09e3b96)
Before changes (368/369/368 seconds):
![image](https://github.com/chunky-dev/chunky/assets/46458276/dd789048-9832-426f-b71c-efd75fc7cc07)
After changes (303/302/303 seconds, **11% faster**):
![image](https://github.com/chunky-dev/chunky/assets/46458276/4a5443cc-762c-487b-8c58-c9794f5d1cdf)
Before changes (335/336/336 seconds):
![image](https://github.com/chunky-dev/chunky/assets/46458276/84316352-77be-41d4-8b12-106f67f7d35e)
