### PR TITLE
Add dyed signs.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
@@ -253,22 +253,26 @@ public class HangingSignEntity extends Entity {
   private final boolean attached;
   private final SignTexture frontTexture;
   private final SignTexture backTexture;
+  private final SignEntity.Color frontDye;
+  private final SignEntity.Color backDye;
   private final Texture texture;
   private final String material;
 
   public HangingSignEntity(Vector3 position, CompoundTag entityTag, int rotation, boolean attached, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getBackTextLines(entityTag), rotation, attached, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), rotation, attached, material);
   }
 
-  public HangingSignEntity(Vector3 position, JsonArray[] frontText, JsonArray[] backText, int rotation, boolean attached, String material) {
+  public HangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, JsonArray[] backText, SignEntity.Color backDye, int rotation, boolean attached, String material) {
     super(position);
     Texture signTexture = HangingSignEntity.textureFromMaterial(material);
     this.frontText = frontText;
     this.backText = backText;
+    this.frontDye = frontDye;
+    this.backDye = backDye;
     this.angle = rotation;
     this.attached = attached;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -300,9 +304,11 @@ public class HangingSignEntity extends Entity {
     json.add("position", position.toJson());
     if (frontText != null) {
       json.add("text", SignEntity.textToJson(frontText));
+      json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
+      json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
     }
     json.add("direction", angle);
     json.add("attached", attached);
@@ -327,7 +333,9 @@ public class HangingSignEntity extends Entity {
     int direction = json.get("direction").intValue(0);
     boolean attached = json.get("attached").boolValue(false);
     String material = json.get("material").stringValue("oak");
-    return new HangingSignEntity(position, frontText, backText, direction, attached, material);
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("black"));
+    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue("black"));
+    return new HangingSignEntity(position, frontText, dye, backText, backDye, direction, attached, material);
   }
 
   public static Texture textureFromMaterial(String material) {

--- a/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
@@ -271,8 +271,8 @@ public class HangingSignEntity extends Entity {
     this.backDye = backDye;
     this.angle = rotation;
     this.attached = attached;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, backDye, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, false, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, false, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -304,11 +304,15 @@ public class HangingSignEntity extends Entity {
     json.add("position", position.toJson());
     if (frontText != null) {
       json.add("text", SignEntity.textToJson(frontText));
-      json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      if (frontDye != null) {
+        json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      }
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
-      json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      if (backDye != null) {
+        json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      }
     }
     json.add("direction", angle);
     json.add("attached", attached);
@@ -333,8 +337,8 @@ public class HangingSignEntity extends Entity {
     int direction = json.get("direction").intValue(0);
     boolean attached = json.get("attached").boolValue(false);
     String material = json.get("material").stringValue("oak");
-    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("black"));
-    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue("black"));
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
+    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     return new HangingSignEntity(position, frontText, dye, backText, backDye, direction, attached, material);
   }
 

--- a/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/HangingSignEntity.java
@@ -254,25 +254,29 @@ public class HangingSignEntity extends Entity {
   private final SignTexture frontTexture;
   private final SignTexture backTexture;
   private final SignEntity.Color frontDye;
+  private final boolean frontGlowing;
   private final SignEntity.Color backDye;
+  private final boolean backGlowing;
   private final Texture texture;
   private final String material;
 
   public HangingSignEntity(Vector3 position, CompoundTag entityTag, int rotation, boolean attached, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), rotation, attached, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getFrontGlowing(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), SignEntity.getBackGlowing(entityTag), rotation, attached, material);
   }
 
-  public HangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, JsonArray[] backText, SignEntity.Color backDye, int rotation, boolean attached, String material) {
+  public HangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, boolean frontGlowing, JsonArray[] backText, SignEntity.Color backDye, boolean backGlowing, int rotation, boolean attached, String material) {
     super(position);
     Texture signTexture = HangingSignEntity.textureFromMaterial(material);
     this.frontText = frontText;
     this.backText = backText;
     this.frontDye = frontDye;
+    this.frontGlowing = frontGlowing;
     this.backDye = backDye;
+    this.backGlowing = backGlowing;
     this.angle = rotation;
     this.attached = attached;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, false, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, backDye, false, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, frontGlowing, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, backGlowing, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -307,12 +311,14 @@ public class HangingSignEntity extends Entity {
       if (frontDye != null) {
         json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
       }
+      json.add("glowing", frontGlowing);
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
       if (backDye != null) {
         json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
       }
+      json.add("backGlowing", backGlowing);
     }
     json.add("direction", angle);
     json.add("attached", attached);
@@ -338,8 +344,10 @@ public class HangingSignEntity extends Entity {
     boolean attached = json.get("attached").boolValue(false);
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
+    boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
-    return new HangingSignEntity(position, frontText, dye, backText, backDye, direction, attached, material);
+    boolean backGlowing = json.get("backGlowing").boolValue(false);
+    return new HangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, attached, material);
   }
 
   public static Texture textureFromMaterial(String material) {

--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -352,13 +352,13 @@ public class SignEntity extends Entity {
         JsonValue value = parser.parse();
         if (value.isObject()) {
           JsonObject obj = value.object();
-          addText(array, obj.get("text").stringValue(""));
+          addText(array, obj.get("text").stringValue(""), obj.get("color").stringValue(""));
           JsonArray extraArray = obj.get("extra").array();
           for (JsonValue extra : extraArray) {
             if (extra.isObject()) {
               JsonObject extraObject = extra.object();
               addText(array, extraObject.get("text").stringValue(""),
-                extraObject.get("color").stringValue(""));
+                extraObject.get("color").stringValue(obj.get("color").stringValue("")));
             } else {
               addText(array, extra.stringValue(""));
             }

--- a/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/SignEntity.java
@@ -42,39 +42,56 @@ public class SignEntity extends Entity {
 
   public enum Color {
     // text colors
-    BLACK(0, 0xFF000000),
-    DARK_BLUE(1, 0xFF0000AA),
-    DARK_GREEN(2, 0xFF00AA00),
-    DARK_AQUA(3, 0xFF00AAAA),
-    DARK_RED(4, 0xFFAA0000),
-    DARK_PURPLE(5, 0xFFAA00AA),
-    GOLD(6, 0xFFFFAA00),
-    GRAY(7, 0xFFAAAAAA),
-    DARK_GRAY(8, 0xFF555555),
-    BLUE(9, 0xFF5555FF),
-    GREEN(10, 0xFF55FF55),
-    AQUA(11, 0xFF55FFFF),
-    RED(12, 0xFFFF5555),
-    LIGHT_PURPLE(13, 0xFFFF55FF),
-    YELLOW(14, 0xFFFFFF55),
-    WHITE(15, 0xFFFFFFFF),
+    BLACK(0, 0xFF000000, 1),
+    DARK_BLUE(1, 0xFF0000AA, 1),
+    DARK_GREEN(2, 0xFF00AA00, 1),
+    DARK_AQUA(3, 0xFF00AAAA, 1),
+    DARK_RED(4, 0xFFAA0000, 1),
+    DARK_PURPLE(5, 0xFFAA00AA, 1),
+    GOLD(6, 0xFFFFAA00, 1),
+    GRAY(7, 0xFFAAAAAA, 1),
+    DARK_GRAY(8, 0xFF555555, 1),
+    BLUE(9, 0xFF5555FF, 1),
+    GREEN(10, 0xFF55FF55, 1),
+    AQUA(11, 0xFF55FFFF, 1),
+    RED(12, 0xFFFF5555, 1),
+    LIGHT_PURPLE(13, 0xFFFF55FF, 1),
+    YELLOW(14, 0xFFFFFF55, 1),
+    WHITE(15, 0xFFFFFFFF, 1),
 
     // dyed sign text colors
-    DYE_WHITE(0xFF656565),
-    DYE_ORANGE(0xFF65280C),
-    DYE_MAGENTA(0xFF650065),
-    DYE_LIGHT_BLUE(0xFF3C4B51),
-    DYE_YELLOW(0xFF656500),
-    DYE_LIME(0xFF4B6500),
-    DYE_PINK(0xFF652947),
-    DYE_GRAY(0xFF323232),
-    DYE_LIGHT_GRAY(0xFF535353),
-    DYE_CYAN(0xFF006565),
-    DYE_PURPLE(0xFF3F0C5F),
-    DYE_BLUE(0xFF000065),
-    DYE_BROWN(0xFF361B07),
-    DYE_GREEN(0xFF006500),
-    DYE_RED(0xFF650000);
+    DYE_WHITE(0xFFFFFFFF, 0.4f),
+    DYE_ORANGE(0xFFFF681F, 0.4f),
+    DYE_MAGENTA(0xFFFF00FF, 0.4f),
+    DYE_LIGHT_BLUE(0xFF9AC0CD, 0.4f),
+    DYE_YELLOW(0xFFFFFF00, 0.4f),
+    DYE_LIME(0xFFBFFF00, 0.4f),
+    DYE_PINK(0xFFFF69B4, 0.4f),
+    DYE_GRAY(0xFF808080, 0.4f),
+    DYE_LIGHT_GRAY(0xFFD3D3D3, 0.4f),
+    DYE_CYAN(0xFF00FFFF, 0.4f),
+    DYE_PURPLE(0xFFA020F0, 0.4f),
+    DYE_BLUE(0xFF0000FF, 0.4f),
+    DYE_BROWN(0xFF8B4513, 0.4f),
+    DYE_GREEN(0xFF00FF00, 0.4f),
+    DYE_RED(0xFFFF0000, 0.4f),
+
+    // dyed sign text colors (glowing sign)
+    DYE_GLOWING_WHITE(0xFFFFFFFF),
+    DYE_GLOWING_ORANGE(0xFFFF681F),
+    DYE_GLOWING_MAGENTA(0xFFFF00FF),
+    DYE_GLOWING_LIGHT_BLUE(0xFF9AC0CD),
+    DYE_GLOWING_YELLOW(0xFFFFFF00),
+    DYE_GLOWING_LIME(0xFFBFFF00),
+    DYE_GLOWING_PINK(0xFFFF69B4),
+    DYE_GLOWING_GRAY(0xFF808080),
+    DYE_GLOWING_LIGHT_GRAY(0xFFD3D3D3),
+    DYE_GLOWING_CYAN(0xFF00FFFF),
+    DYE_GLOWING_PURPLE(0xFFA020F0),
+    DYE_GLOWING_BLUE(0xFF0000FF),
+    DYE_GLOWING_BROWN(0xFF8B4513),
+    DYE_GLOWING_GREEN(0xFF00FF00),
+    DYE_GLOWING_RED(0xFFFF0000);
 
     public final int id;
     public final int rgbColor;
@@ -136,12 +153,25 @@ public class SignEntity extends Entity {
     }
 
     Color(int color) {
-      this(-1, color);
+      this(-1, color, 1);
     }
 
-    Color(int id, int color) {
+    Color(int color, float multiplier) {
+      this(-1, color, multiplier);
+    }
+
+    Color(int id, int color, float multiplier) {
       this.id = id;
-      this.rgbColor = color;
+      if (multiplier != 1) {
+        float[] rgb = new float[3];
+        ColorUtil.getRGBComponents(color, rgb);
+        rgb[0] *= multiplier;
+        rgb[1] *= multiplier;
+        rgb[2] *= multiplier;
+        this.rgbColor = ColorUtil.getRGB(rgb);
+      } else {
+        this.rgbColor = color;
+      }
       this.linearColor = new float[4];
       ColorUtil.getRGBAComponentsGammaCorrected(rgbColor, linearColor);
     }
@@ -156,6 +186,51 @@ public class SignEntity extends Entity {
 
     public static Color getFromDyedSign(String color) {
       return dyedTextColorMap.getOrDefault(color, Color.BLACK);
+    }
+
+    public Color getGlowingDyeColor() {
+      switch (this) {
+        case DYE_WHITE:
+          return DYE_GLOWING_WHITE;
+        case DYE_ORANGE:
+          return DYE_GLOWING_ORANGE;
+        case DYE_MAGENTA:
+          return DYE_GLOWING_MAGENTA;
+        case DYE_LIGHT_BLUE:
+          return DYE_GLOWING_LIGHT_BLUE;
+        case DYE_YELLOW:
+          return DYE_GLOWING_YELLOW;
+        case DYE_LIME:
+          return DYE_GLOWING_LIME;
+        case DYE_PINK:
+          return DYE_GLOWING_PINK;
+        case DYE_GRAY:
+          return DYE_GLOWING_GRAY;
+        case DYE_LIGHT_GRAY:
+          return DYE_GLOWING_LIGHT_GRAY;
+        case DYE_CYAN:
+          return DYE_GLOWING_CYAN;
+        case DYE_PURPLE:
+          return DYE_GLOWING_PURPLE;
+        case DYE_BLUE:
+          return DYE_GLOWING_BLUE;
+        case DYE_BROWN:
+          return DYE_GLOWING_BROWN;
+        case DYE_GREEN:
+          return DYE_GLOWING_GREEN;
+        case DYE_RED:
+          return DYE_GLOWING_RED;
+        case BLACK:
+        default:
+          return BLACK;
+      }
+    }
+
+    public Color getGlowingOutlineColor() {
+      if (this == BLACK) {
+        return WHITE;
+      }
+      return this;
     }
   }
 
@@ -242,23 +317,27 @@ public class SignEntity extends Entity {
   private final SignTexture backTexture;
   private final Color frontDye;
   private final Color backDye;
+  private final boolean frontGlowing;
+  private final boolean backGlowing;
   private final Texture texture;
   private final String material;
 
   public SignEntity(Vector3 position, CompoundTag entityTag, int blockData, String material) {
-    this(position, getFrontTextLines(entityTag), getFrontDyeColor(entityTag), getBackTextLines(entityTag), getFrontDyeColor(entityTag), blockData & 0xF, material);
+    this(position, getFrontTextLines(entityTag), getFrontDyeColor(entityTag), getFrontGlowing(entityTag), getBackTextLines(entityTag), getBackDyeColor(entityTag), getBackGlowing(entityTag), blockData & 0xF, material);
   }
 
-  public SignEntity(Vector3 position, JsonArray[] frontText, Color frontDye, JsonArray[] backText, Color backDye, int direction, String material) {
+  public SignEntity(Vector3 position, JsonArray[] frontText, Color frontDye, boolean frontGlowing, JsonArray[] backText, Color backDye, boolean backGlowing, int direction, String material) {
     super(position);
     Texture signTexture = SignEntity.textureFromMaterial(material);
     this.frontText = frontText;
     this.backText = backText;
     this.frontDye = frontDye;
     this.backDye = backDye;
+    this.frontGlowing = frontGlowing;
+    this.backGlowing = backGlowing;
     this.angle = direction;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, backDye, signTexture, 24, 12, 28 / 64., 18 / 32., 52 / 64., 30 / 32., 4, 1, 10) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, frontGlowing, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, backGlowing, signTexture, 24, 12, 28 / 64., 18 / 32., 52 / 64., 30 / 32., 4, 1, 10) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -306,6 +385,18 @@ public class SignEntity extends Entity {
   }
 
   /**
+   * Extracts the front glowing boolean from a sign entity tag.
+   */
+  protected static boolean getFrontGlowing(CompoundTag entityTag) {
+    if (!entityTag.get("front_text").isError()) {
+      return entityTag.get("front_text").get("has_glowing_text").boolValue(false);
+    } else {
+      // < 1.20 sign
+      return entityTag.get("GlowingText").boolValue(false);
+    }
+  }
+
+  /**
    * Extracts the front text lines from a sign entity tag.
    *
    * @return array of text lines.
@@ -332,11 +423,23 @@ public class SignEntity extends Entity {
    * Extracts the back dye color from a sign entity tag.
    */
   protected static Color getBackDyeColor(CompoundTag entityTag) {
-    if (!entityTag.get("front_text").isError()) {
-      return Color.getFromDyedSign(entityTag.get("front_text").get("color").stringValue("black"));
+    if (!entityTag.get("back_text").isError()) {
+      return Color.getFromDyedSign(entityTag.get("back_text").get("color").stringValue("black"));
     } else {
       // < 1.20 sign
       return Color.BLACK;
+    }
+  }
+
+  /**
+   * Extracts the back glowing boolean from a sign entity tag.
+   */
+  protected static boolean getBackGlowing(CompoundTag entityTag) {
+    if (!entityTag.get("back_text").isError()) {
+      return entityTag.get("back_text").get("has_glowing_text").boolValue(false);
+    } else {
+      // < 1.20 sign
+      return false;
     }
   }
 
@@ -447,11 +550,17 @@ public class SignEntity extends Entity {
     json.add("position", position.toJson());
     if (frontText != null) {
       json.add("text", textToJson(frontText));
-      json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      if (frontDye != null) {
+        json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      }
+      json.add("glowing", frontGlowing);
     }
     if (backText != null) {
       json.add("backText", textToJson(backText));
-      json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      if (backDye != null) {
+        json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      }
+      json.add("backGlowing", backGlowing);
     }
     json.add("direction", angle);
     json.add("material", material);
@@ -474,9 +583,11 @@ public class SignEntity extends Entity {
     }
     int direction = json.get("direction").intValue(0);
     String material = json.get("material").stringValue("oak");
-    Color dye = Color.getFromDyedSign(json.get("dye").stringValue("black"));
-    Color backDye = Color.getFromDyedSign(json.get("backDye").stringValue("black"));
-    return new SignEntity(position, frontText, dye, backText, backDye, direction, material);
+    Color dye = Color.getFromDyedSign(json.get("dye").stringValue(null));
+    boolean glowing = json.get("glowing").boolValue(false);
+    Color backDye = Color.getFromDyedSign(json.get("backDye").stringValue(null));
+    boolean backGlowing = json.get("backGlowing").boolValue(false);
+    return new SignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
@@ -250,8 +250,8 @@ public class WallHangingSignEntity extends Entity {
     this.frontDye = frontDye;
     this.backDye = backDye;
     this.orientation = direction;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, backDye, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, false, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, false, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -283,11 +283,15 @@ public class WallHangingSignEntity extends Entity {
     json.add("position", position.toJson());
     if (frontText != null) {
       json.add("text", SignEntity.textToJson(frontText));
-      json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      if (frontDye != null) {
+        json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
+      }
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
-      json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      if (backDye != null) {
+        json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
+      }
     }
     json.add("direction", orientation.toString());
     json.add("material", material);
@@ -310,8 +314,8 @@ public class WallHangingSignEntity extends Entity {
     }
     WallHangingSign.Facing direction = WallHangingSign.Facing.fromString(json.get("direction").stringValue("north"));
     String material = json.get("material").stringValue("oak");
-    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("black"));
-    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue("black"));
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
+    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
     return new WallHangingSignEntity(position, frontText, dye, backText, backDye, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
@@ -235,23 +235,27 @@ public class WallHangingSignEntity extends Entity {
   private final SignTexture backTexture;
   private final SignEntity.Color frontDye;
   private final SignEntity.Color backDye;
+  private final boolean frontGlowing;
+  private final boolean backGlowing;
   private final Texture texture;
   private final String material;
 
   public WallHangingSignEntity(Vector3 position, CompoundTag entityTag, WallHangingSign.Facing direction, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), direction, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getFrontGlowing(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), SignEntity.getBackGlowing(entityTag), direction, material);
   }
 
-  public WallHangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, JsonArray[] backText, SignEntity.Color backDye, WallHangingSign.Facing direction, String material) {
+  public WallHangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, boolean frontGlowing, JsonArray[] backText, SignEntity.Color backDye, boolean backGlowing, WallHangingSign.Facing direction, String material) {
     super(position);
     Texture signTexture = HangingSignEntity.textureFromMaterial(material);
     this.frontText = frontText;
     this.backText = backText;
     this.frontDye = frontDye;
     this.backDye = backDye;
+    this.frontGlowing = frontGlowing;
+    this.backGlowing = backGlowing;
     this.orientation = direction;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, false, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, backDye, false, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, frontGlowing, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, backGlowing, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -286,12 +290,14 @@ public class WallHangingSignEntity extends Entity {
       if (frontDye != null) {
         json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
       }
+      json.add("glowing", frontGlowing);
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
       if (backDye != null) {
         json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
       }
+      json.add("backGlowing", backGlowing);
     }
     json.add("direction", orientation.toString());
     json.add("material", material);
@@ -315,7 +321,9 @@ public class WallHangingSignEntity extends Entity {
     WallHangingSign.Facing direction = WallHangingSign.Facing.fromString(json.get("direction").stringValue("north"));
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
+    boolean glowing = json.get("glowing").boolValue(false);
     SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue(null));
-    return new WallHangingSignEntity(position, frontText, dye, backText, backDye, direction, material);
+    boolean backGlowing = json.get("backGlowing").boolValue(false);
+    return new WallHangingSignEntity(position, frontText, dye, glowing, backText, backDye, backGlowing, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallHangingSignEntity.java
@@ -233,21 +233,25 @@ public class WallHangingSignEntity extends Entity {
   private final WallHangingSign.Facing orientation;
   private final SignTexture frontTexture;
   private final SignTexture backTexture;
+  private final SignEntity.Color frontDye;
+  private final SignEntity.Color backDye;
   private final Texture texture;
   private final String material;
 
   public WallHangingSignEntity(Vector3 position, CompoundTag entityTag, WallHangingSign.Facing direction, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getBackTextLines(entityTag), direction, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getBackTextLines(entityTag), SignEntity.getBackDyeColor(entityTag), direction, material);
   }
 
-  public WallHangingSignEntity(Vector3 position, JsonArray[] frontText, JsonArray[] backText, WallHangingSign.Facing direction, String material) {
+  public WallHangingSignEntity(Vector3 position, JsonArray[] frontText, SignEntity.Color frontDye, JsonArray[] backText, SignEntity.Color backDye, WallHangingSign.Facing direction, String material) {
     super(position);
     Texture signTexture = HangingSignEntity.textureFromMaterial(material);
     this.frontText = frontText;
     this.backText = backText;
+    this.frontDye = frontDye;
+    this.backDye = backDye;
     this.orientation = direction;
-    this.frontTexture = frontText != null ? new SignTexture(frontText, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
-    this.backTexture = backText != null ? new SignTexture(backText, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.frontTexture = frontText != null ? new SignTexture(frontText, frontDye, signTexture, 14, 10, 2 / 64., 1 - 24 / 32., 16 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
+    this.backTexture = backText != null ? new SignTexture(backText, backDye, signTexture, 14, 10, 18 / 64., 1 - 24 / 32., 32 / 64., 1 - 14 / 32., 4.5, 3, 9) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -279,9 +283,11 @@ public class WallHangingSignEntity extends Entity {
     json.add("position", position.toJson());
     if (frontText != null) {
       json.add("text", SignEntity.textToJson(frontText));
+      json.add("dye", frontDye.name().replace("DYE_", "").toLowerCase());
     }
     if (backText != null) {
       json.add("backText", SignEntity.textToJson(backText));
+      json.add("backDye", backDye.name().replace("DYE_", "").toLowerCase());
     }
     json.add("direction", orientation.toString());
     json.add("material", material);
@@ -304,6 +310,8 @@ public class WallHangingSignEntity extends Entity {
     }
     WallHangingSign.Facing direction = WallHangingSign.Facing.fromString(json.get("direction").stringValue("north"));
     String material = json.get("material").stringValue("oak");
-    return new WallHangingSignEntity(position, frontText, backText, direction, material);
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("black"));
+    SignEntity.Color backDye = SignEntity.Color.getFromDyedSign(json.get("backDye").stringValue("black"));
+    return new WallHangingSignEntity(position, frontText, dye, backText, backDye, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -17,13 +17,9 @@
  */
 package se.llbit.chunky.entity;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 import se.llbit.chunky.model.Model;
 import se.llbit.chunky.resources.SignTexture;
 import se.llbit.chunky.resources.Texture;
-import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.material.TextureMaterial;
 import se.llbit.json.JsonArray;
 import se.llbit.json.JsonObject;
@@ -34,6 +30,9 @@ import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 public class WallSignEntity extends Entity {
 
@@ -94,21 +93,23 @@ public class WallSignEntity extends Entity {
   }
 
   private final JsonArray[] text;
+  private final SignEntity.Color dye;
   private final int orientation;
   private final SignTexture frontTexture;
   private final Texture texture;
   private final String material;
 
   public WallSignEntity(Vector3 position, CompoundTag entityTag, int blockData, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), blockData % 6, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), blockData % 6, material);
   }
 
-  public WallSignEntity(Vector3 position, JsonArray[] text, int direction, String material) {
+  public WallSignEntity(Vector3 position, JsonArray[] text, SignEntity.Color dye, int direction, String material) {
     super(position);
     Texture signTexture = SignEntity.textureFromMaterial(material);
     this.orientation = direction;
     this.text = text;
-    this.frontTexture = text != null ? new SignTexture(text, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
+    this.dye = dye;
+    this.frontTexture = text != null ? new SignTexture(text, dye, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -138,6 +139,7 @@ public class WallSignEntity extends Entity {
     json.add("position", position.toJson());
     if (text != null) {
       json.add("text", SignEntity.textToJson(text));
+      json.add("dye", dye.name().replace("DYE_", "").toLowerCase());
     }
     json.add("direction", orientation);
     json.add("material", material);
@@ -156,6 +158,7 @@ public class WallSignEntity extends Entity {
     }
     int direction = json.get("direction").intValue(0);
     String material = json.get("material").stringValue("oak");
-    return new WallSignEntity(position, text, direction, material);
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("balck"));
+    return new WallSignEntity(position, text, dye, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -109,7 +109,7 @@ public class WallSignEntity extends Entity {
     this.orientation = direction;
     this.text = text;
     this.dye = dye;
-    this.frontTexture = text != null ? new SignTexture(text, dye, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
+    this.frontTexture = text != null ? new SignTexture(text, dye, false, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -139,7 +139,9 @@ public class WallSignEntity extends Entity {
     json.add("position", position.toJson());
     if (text != null) {
       json.add("text", SignEntity.textToJson(text));
-      json.add("dye", dye.name().replace("DYE_", "").toLowerCase());
+      if (dye != null) {
+        json.add("dye", dye.name().replace("DYE_", "").toLowerCase());
+      }
     }
     json.add("direction", orientation);
     json.add("material", material);
@@ -158,7 +160,7 @@ public class WallSignEntity extends Entity {
     }
     int direction = json.get("direction").intValue(0);
     String material = json.get("material").stringValue("oak");
-    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue("balck"));
+    SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
     return new WallSignEntity(position, text, dye, direction, material);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/WallSignEntity.java
@@ -94,22 +94,24 @@ public class WallSignEntity extends Entity {
 
   private final JsonArray[] text;
   private final SignEntity.Color dye;
+  private final boolean glowing;
   private final int orientation;
   private final SignTexture frontTexture;
   private final Texture texture;
   private final String material;
 
   public WallSignEntity(Vector3 position, CompoundTag entityTag, int blockData, String material) {
-    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), blockData % 6, material);
+    this(position, SignEntity.getFrontTextLines(entityTag), SignEntity.getFrontDyeColor(entityTag), SignEntity.getFrontGlowing(entityTag), blockData % 6, material);
   }
 
-  public WallSignEntity(Vector3 position, JsonArray[] text, SignEntity.Color dye, int direction, String material) {
+  public WallSignEntity(Vector3 position, JsonArray[] text, SignEntity.Color dye, boolean isGlowing, int direction, String material) {
     super(position);
     Texture signTexture = SignEntity.textureFromMaterial(material);
     this.orientation = direction;
     this.text = text;
     this.dye = dye;
-    this.frontTexture = text != null ? new SignTexture(text, dye, false, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
+    this.glowing = isGlowing;
+    this.frontTexture = text != null ? new SignTexture(text, dye, isGlowing, signTexture, 24, 12, 2 / 64., 18 / 32., 26 / 64., 30 / 32., 4, 1, 10) : null;
     this.texture = signTexture;
     this.material = material;
   }
@@ -142,6 +144,7 @@ public class WallSignEntity extends Entity {
       if (dye != null) {
         json.add("dye", dye.name().replace("DYE_", "").toLowerCase());
       }
+      json.add("glowing", glowing);
     }
     json.add("direction", orientation);
     json.add("material", material);
@@ -161,6 +164,7 @@ public class WallSignEntity extends Entity {
     int direction = json.get("direction").intValue(0);
     String material = json.get("material").stringValue("oak");
     SignEntity.Color dye = SignEntity.Color.getFromDyedSign(json.get("dye").stringValue(null));
-    return new WallSignEntity(position, text, dye, direction, material);
+    boolean glowing = json.get("glowing").boolValue(false);
+    return new WallSignEntity(position, text, dye, glowing, direction, material);
   }
 }


### PR DESCRIPTION
This PR adds dyed signs. Dyes can be different on the front and back side of a sign.

Note that the 16 dye colors are different from the usual sign text colors (except for black). This means that we can't use the existing 4-bit palette for the dye color. In order to not have to add more bits to the palette, I made it so that if the palette contains a `1` but the text mask is `0`, the sign texture treats the pixel as _dye color_, which requires only 32 or 64 bits (ie. an enum value) per sign texture.

I extracted the colors via screenshots from dyed signs. They may be incorrect.

Closes #1625 and related to #789.