### PR TITLE
Hide broken entity gear fields

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/EntitiesTab.java
@@ -554,6 +554,11 @@ public class EntitiesTab extends ScrollPane implements RenderControlsTab, Initia
         });
         gearField.setText(geared.getGear(slot).get("id").stringValue(""));
         slotBox.getChildren().addAll(new Label(slot + ":"), gearField);
+        // Hide these fields to avoid user confusion because they do not actually work.
+        if (slot.equals("leftHand") || slot.equals("rightHand")) {
+          slotBox.setVisible(false);
+          slotBox.setManaged(false);
+        }
         controls.getChildren().add(slotBox);
       }
     }


### PR DESCRIPTION
Since the `leftHand` and `rightHand` entity gear fields do not actually have any effect, they have been hidden to avoid user confusion.