### PR TITLE
Improve biome blending in 3D

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/AbstractModelBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/AbstractModelBlock.java
@@ -1,8 +1,6 @@
 package se.llbit.chunky.block;
 
-import se.llbit.chunky.model.AABBModel;
 import se.llbit.chunky.model.BlockModel;
-import se.llbit.chunky.model.Tint;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
@@ -49,7 +47,7 @@ public abstract class AbstractModelBlock extends MinecraftBlock implements Model
   }
 
   @Override
-  public boolean useBiomeTint() {
-    return super.useBiomeTint() || model.useBiomeTint();
+  public boolean isBiomeDependant() {
+    return super.isBiomeDependant() || model.isBiomeDependant();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/AbstractModelBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/AbstractModelBlock.java
@@ -1,6 +1,8 @@
 package se.llbit.chunky.block;
 
+import se.llbit.chunky.model.AABBModel;
 import se.llbit.chunky.model.BlockModel;
+import se.llbit.chunky.model.Tint;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
@@ -44,5 +46,10 @@ public abstract class AbstractModelBlock extends MinecraftBlock implements Model
   @Override
   public boolean intersect(Ray ray, Scene scene) {
     return model.intersect(ray, scene);
+  }
+
+  @Override
+  public boolean useBiomeTint() {
+    return super.useBiomeTint() || model.useBiomeTint();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -146,4 +146,11 @@ public abstract class Block extends Material {
   public Tag getNewTagWithBlockEntity(Tag blockTag, CompoundTag entityTag) {
     return null;
   }
+
+  /**
+   * Does this block use biome tint for its rendering
+   */
+  public boolean useBiomeTint() {
+    return isWaterFilled();
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -150,7 +150,7 @@ public abstract class Block extends Material {
   /**
    * Does this block use biome tint for its rendering
    */
-  public boolean useBiomeTint() {
+  public boolean isBiomeDependant() {
     return isWaterFilled();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
@@ -85,7 +85,7 @@ public class LegacyFlowerPot extends UnfinalizedLegacyBlock {
   }
 
   @Override
-  public boolean useBiomeTint() {
+  public boolean isBiomeDependant() {
     return true; // (in reality it is only used for fern)
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyFlowerPot.java
@@ -83,4 +83,9 @@ public class LegacyFlowerPot extends UnfinalizedLegacyBlock {
 
     return tag; // keep empty
   }
+
+  @Override
+  public boolean useBiomeTint() {
+    return true; // (in reality it is only used for fern)
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
@@ -29,7 +29,7 @@ public class LegacyVine extends UnfinalizedLegacyBlock {
   }
 
   @Override
-  public boolean useBiomeTint() {
+  public boolean isBiomeDependant() {
     return true;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
+++ b/chunky/src/java/se/llbit/chunky/block/legacy/blocks/LegacyVine.java
@@ -27,4 +27,9 @@ public class LegacyVine extends UnfinalizedLegacyBlock {
     // otherwise just unwrap the block
     state.replaceCurrentBlock(tag);
   }
+
+  @Override
+  public boolean useBiomeTint() {
+    return true;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/model/AABBModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AABBModel.java
@@ -9,6 +9,7 @@ import se.llbit.math.Vector3;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -180,5 +181,17 @@ public abstract class AABBModel implements BlockModel {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public boolean useBiomeTint() {
+    Tint[][] tints = getTints();
+    if(tints == null)
+      return false;
+
+    return Arrays.stream(tints)
+      .filter(Objects::nonNull)
+      .flatMap(Arrays::stream)
+      .anyMatch(Tint::isBiomeTint);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/model/AABBModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AABBModel.java
@@ -184,7 +184,7 @@ public abstract class AABBModel implements BlockModel {
   }
 
   @Override
-  public boolean useBiomeTint() {
+  public boolean isBiomeDependant() {
     Tint[][] tints = getTints();
     if(tints == null)
       return false;

--- a/chunky/src/java/se/llbit/chunky/model/BlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/BlockModel.java
@@ -18,4 +18,6 @@ public interface BlockModel {
   void sample(int face, Vector3 loc, Random rand);
 
   double faceSurfaceArea(int face);
+
+  boolean useBiomeTint();
 }

--- a/chunky/src/java/se/llbit/chunky/model/BlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/BlockModel.java
@@ -19,5 +19,5 @@ public interface BlockModel {
 
   double faceSurfaceArea(int face);
 
-  boolean useBiomeTint();
+  boolean isBiomeDependant();
 }

--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -152,7 +152,7 @@ public abstract class QuadModel implements BlockModel {
   }
 
   @Override
-  public boolean useBiomeTint() {
+  public boolean isBiomeDependant() {
     Tint[] tints = getTints();
     if(tints == null)
       return false;

--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -28,6 +28,8 @@ import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -147,5 +149,15 @@ public abstract class QuadModel implements BlockModel {
       ray.o.scaleAdd(ray.t, ray.d);
     }
     return hit;
+  }
+
+  @Override
+  public boolean useBiomeTint() {
+    Tint[] tints = getTints();
+    if(tints == null)
+      return false;
+
+    return Arrays.stream(tints)
+      .anyMatch(Tint::isBiomeTint);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/model/Tint.java
+++ b/chunky/src/java/se/llbit/chunky/model/Tint.java
@@ -98,4 +98,8 @@ public class Tint {
       color.z *= tintColor[2];
     }
   }
+
+  public boolean isBiomeTint() {
+    return type == TintType.BIOME_FOLIAGE || type == TintType.BIOME_GRASS || type == TintType.BIOME_WATER;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -930,9 +930,9 @@ public class Scene implements JsonSerializable, Refreshable {
         int wz0 = cp.z * 16;
         BiomeData biomeData = chunkData.getBiomeData();
         ChunkBiomeBlendingHelper chunkBiomeHelper = new ChunkBiomeBlendingHelper();
+        biomeBlendingHelper.put(cp, chunkBiomeHelper);
 
         if (use3dBiomes) {
-          biomeBlendingHelper.put(cp, chunkBiomeHelper);
           // We need to load biome data for the full height of the chunk
           // and not only limited to the sections where there are blocks
           // because it is possible that a neighboring chunks has blocks
@@ -999,7 +999,7 @@ public class Scene implements JsonSerializable, Refreshable {
                   int octNode = currentBlock;
                   Block block = palette.get(currentBlock);
 
-                  if(block.useBiomeTint())
+                  if(block.isBiomeDependant())
                     chunkBiomeHelper.makeBiomeRelevant(y);
 
                   if(block.isEntity()) {
@@ -1239,54 +1239,80 @@ public class Scene implements JsonSerializable, Refreshable {
 
 //        Finalize grass and foliage textures.
 //        3x3 box blur.
-        if (biomeBlendingRadius > 0) {
-          if (use3dBiomes) {
-            ChunkBiomeBlendingHelper chunkBiomeHelper = biomeBlendingHelper.get(cp);
-            ChunkBiomeBlendingHelper[] neighboringChunks = new ChunkBiomeBlendingHelper[] {
-              biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z - 1)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z + 1)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x, cp.z - 1)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x, cp.z + 1)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z - 1)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z)),
-              biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z + 1))
-            };
+        ChunkBiomeBlendingHelper chunkBiomeHelper = biomeBlendingHelper.get(cp);
+        if(chunkBiomeHelper.isBiomeUsed()) {
+          if(biomeBlendingRadius > 0) {
+            if(use3dBiomes) {
+              ChunkBiomeBlendingHelper[] neighboringChunks = new ChunkBiomeBlendingHelper[]{
+                biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z - 1)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x - 1, cp.z + 1)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x, cp.z - 1)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x, cp.z + 1)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z - 1)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z)),
+                biomeBlendingHelper.get(new ChunkPosition(cp.x + 1, cp.z + 1))
+              };
 
-            int[] combinedBiomeTransitions = chunkBiomeHelper.combineAndTrimTransitions(neighboringChunks, biomeBlendingRadius);
+              int[] combinedBiomeTransitions = chunkBiomeHelper.combineAndTrimTransitions(neighboringChunks, biomeBlendingRadius);
 
-            // When doing 3D blur we use the list of (vertical) biome transition
-            // in the chunk or in neighboring ones
-            // If there is no transition, a 2D blur is enough, otherwise we only
-            // need to compute the colors around the transitions
+              // When doing 3D blur we use the list of (vertical) biome transition
+              // in the chunk or in neighboring ones
+              // If there is no transition, a 2D blur is enough, otherwise we only
+              // need to compute the colors around the transitions
 
-            // For example, if loading from y=0 to y=200 with a biome transition at y=20
-            // and another one at y=50 and with a blur radius of 2 (5*5*5 box)
-            // We can compute a 2D blur at y=0 and use those color for up to y=17
-            // For y in [18, 21] we need to compute the real 3D blur (because of the biome transition
-            // at y=20 and the blur radius of 2)
-            // Then we can compute the 2D blur at y=22 and use those colors for up to y=47
-            // And so on, 3D blur for y in [48, 51] and 2D blur for y in [52,200]
+              // For example, if loading from y=0 to y=200 with a biome transition at y=20
+              // and another one at y=50 and with a blur radius of 2 (5*5*5 box)
+              // We can compute a 2D blur at y=0 and use those color for up to y=17
+              // For y in [18, 21] we need to compute the real 3D blur (because of the biome transition
+              // at y=20 and the blur radius of 2)
+              // Then we can compute the 2D blur at y=22 and use those colors for up to y=47
+              // And so on, 3D blur for y in [48, 51] and 2D blur for y in [52,200]
 
-            // As such, in spirit every transition make us compute an additional 16*16*(2*biomeBlendingRadius) 3D blur
-            // and a 16*16 2D blur (that can be combined in a 16*16*(2*biomeBlendingRadius+1) 3D blur)
-            // (ignoring cases where transition are close to one another which are handled by the code)
+              // As such, in spirit every transition make us compute an additional 16*16*(2*biomeBlendingRadius) 3D blur
+              // and a 16*16 2D blur (that can be combined in a 16*16*(2*biomeBlendingRadius+1) 3D blur)
+              // (ignoring cases where transition are close to one another which are handled by the code)
 
-            // Note that having a single (x, y) column that effectively has a biome transition
-            // in the chunk are a neighboring chunk causes us to compute the 3D blur for the whole 16*16
-            // vertical slice of the chunk. Because vertical biome transition are pretty rare,
-            // that's probably ok.
-            int nextY = chunkBiomeHelper.getyMinBiomeRelevant();
+              // Note that having a single (x, y) column that effectively has a biome transition
+              // in the chunk are a neighboring chunk causes us to compute the 3D blur for the whole 16*16
+              // vertical slice of the chunk. Because vertical biome transition are pretty rare,
+              // that's probably ok.
+              int nextY = chunkBiomeHelper.getyMinBiomeRelevant();
 
-            for(int i = 0; i < combinedBiomeTransitions.length; ++i) {
-              int transition = combinedBiomeTransitions[i];
-              if(nextY < transition - biomeBlendingRadius) {
-                // Do a 2d blur to fill up to the height affected by the transition
-                BiomeBlendingUtility.chunk2DBlur(
+              for(int i = 0; i < combinedBiomeTransitions.length; ++i) {
+                int transition = combinedBiomeTransitions[i];
+                if(nextY < transition - biomeBlendingRadius) {
+                  // Do a 2d blur to fill up to the height affected by the transition
+                  BiomeBlendingUtility.chunk2DBlur(
+                    cp,
+                    biomeBlendingRadius,
+                    nextY,
+                    transition - biomeBlendingRadius,
+                    origin,
+                    biomePaletteIdxStructure,
+                    biomePalette,
+                    nonEmptyChunks,
+                    grassTexture,
+                    foliageTexture,
+                    waterTexture);
+                  nextY = transition - biomeBlendingRadius;
+                }
+
+                // Do a 3D blur to fill the next 2*biomeBlendingRadius layers
+                // or more if the next transition is close by, in which case
+                // both transition (or even more) are handled by a bigger 3D blur
+                int maxYWorkedOn = transition + biomeBlendingRadius;
+                while(i < combinedBiomeTransitions.length - 1 && maxYWorkedOn >= combinedBiomeTransitions[i + 1] - biomeBlendingRadius) {
+                  // Extends the 3D blur to enclose the next transition as well
+                  maxYWorkedOn = combinedBiomeTransitions[i + 1] + biomeBlendingRadius;
+                  ++i;
+                }
+                int maxYWorkedOnClamped = Math.min(maxYWorkedOn, chunkBiomeHelper.getyMaxBiomeRelevant());
+                BiomeBlendingUtility.chunk3DBlur(
                   cp,
                   biomeBlendingRadius,
                   nextY,
-                  transition - biomeBlendingRadius,
+                  maxYWorkedOnClamped + 1,
                   origin,
                   biomePaletteIdxStructure,
                   biomePalette,
@@ -1294,96 +1320,71 @@ public class Scene implements JsonSerializable, Refreshable {
                   grassTexture,
                   foliageTexture,
                   waterTexture);
-                nextY = transition - biomeBlendingRadius;
+                nextY = maxYWorkedOnClamped + 1;
               }
 
-              // Do a 3D blur to fill the next 2*biomeBlendingRadius layers
-              // or more if the next transition is close by, in which case
-              // both transition (or even more) are handled by a bigger 3D blur
-              int maxYWorkedOn = transition + biomeBlendingRadius;
-              while(i < combinedBiomeTransitions.length - 1 && maxYWorkedOn >= combinedBiomeTransitions[i+1] - biomeBlendingRadius)
-              {
-                // Extends the 3D blur to enclose the next transition as well
-                maxYWorkedOn = combinedBiomeTransitions[i+1] + biomeBlendingRadius;
-                ++i;
+              // Last 2D blur that extent up to the top
+              if(nextY <= chunkBiomeHelper.getyMaxBiomeRelevant()) {
+                BiomeBlendingUtility.chunk2DBlur(
+                  cp,
+                  biomeBlendingRadius,
+                  nextY,
+                  chunkBiomeHelper.getyMaxBiomeRelevant() + 1,
+                  origin,
+                  biomePaletteIdxStructure,
+                  biomePalette,
+                  nonEmptyChunks,
+                  grassTexture,
+                  foliageTexture,
+                  waterTexture);
               }
-              int maxYWorkedOnClamped = Math.min(maxYWorkedOn, chunkBiomeHelper.getyMaxBiomeRelevant());
-              BiomeBlendingUtility.chunk3DBlur(
-                cp,
-                biomeBlendingRadius,
-                nextY,
-                maxYWorkedOnClamped + 1,
-                origin,
-                biomePaletteIdxStructure,
-                biomePalette,
-                nonEmptyChunks,
-                grassTexture,
-                foliageTexture,
-                waterTexture);
-              nextY = maxYWorkedOnClamped + 1;
-            }
-
-            // Last 2D blur that extent up to the top
-            if(nextY <= chunkBiomeHelper.getyMaxBiomeRelevant()) {
-              BiomeBlendingUtility.chunk2DBlur(
-                cp,
-                biomeBlendingRadius,
-                nextY,
-                chunkBiomeHelper.getyMaxBiomeRelevant() + 1,
-                origin,
-                biomePaletteIdxStructure,
-                biomePalette,
-                nonEmptyChunks,
-                grassTexture,
-                foliageTexture,
-                waterTexture);
+            } else {
+              BiomeBlendingUtility.chunk2DBlur(cp, biomeBlendingRadius, 0, 1, origin, biomePaletteIdxStructure, biomePalette, nonEmptyChunks, grassTexture, foliageTexture, waterTexture);
             }
           } else {
-            BiomeBlendingUtility.chunk2DBlur(cp, biomeBlendingRadius, 0, 1, origin, biomePaletteIdxStructure, biomePalette, nonEmptyChunks, grassTexture, foliageTexture, waterTexture);
-          }
-        } else {
-          if (use3dBiomes) {
-            for (int sectionY = yMin >> 4; sectionY < (yMax - 1 >> 4) + 1; sectionY++) {
-              for (int y = 0; y < 16; y++) {
-                int wy = sectionY * 16 + y;
-                for (int x = 0; x < 16; ++x) {
-                  int wx = cp.x * Chunk.X_MAX + x;
-                  for (int z = 0; z < 16; ++z) {
-                    int wz = cp.z * Chunk.Z_MAX + z;
+            if(use3dBiomes) {
+              for(int sectionY = yMin >> 4; sectionY < (yMax - 1 >> 4) + 1; sectionY++) {
+                for(int y = 0; y < 16; y++) {
+                  int wy = sectionY * 16 + y;
+                  for(int x = 0; x < 16; ++x) {
+                    int wx = cp.x * Chunk.X_MAX + x;
+                    for(int z = 0; z < 16; ++z) {
+                      int wz = cp.z * Chunk.Z_MAX + z;
 
-                    int id = biomePaletteIdxStructure.get(wx, wy, wz);
+                      int id = biomePaletteIdxStructure.get(wx, wy, wz);
 
-                    Biome biome = biomePalette.get(id);
-                    grassTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.grassColorLinear);
-                    foliageTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.foliageColorLinear);
-                    waterTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.waterColorLinear);
+                      Biome biome = biomePalette.get(id);
+                      grassTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.grassColorLinear);
+                      foliageTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.foliageColorLinear);
+                      waterTexture.set(cp.x * 16 + x - origin.x, sectionY * 16 + y - origin.y, cp.z * 16 + z - origin.z, biome.waterColorLinear);
+                    }
                   }
                 }
               }
-            }
-          } else {
-            for (int x = 0; x < 16; ++x) {
-              int wx = cp.x * 16 + x;
-              for (int z = 0; z < 16; ++z) {
-                int wz = cp.z * 16 + z;
+            } else {
+              for(int x = 0; x < 16; ++x) {
+                int wx = cp.x * 16 + x;
+                for(int z = 0; z < 16; ++z) {
+                  int wz = cp.z * 16 + z;
 
-                int id = biomePaletteIdxStructure.get(wx, 0, wz);
-                Biome biome = biomePalette.get(id);
+                  int id = biomePaletteIdxStructure.get(wx, 0, wz);
+                  Biome biome = biomePalette.get(id);
 
-                grassTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.grassColorLinear);
-                foliageTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.foliageColorLinear);
-                waterTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.waterColorLinear);
+                  grassTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.grassColorLinear);
+                  foliageTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.foliageColorLinear);
+                  waterTexture.set(cp.x * 16 + x - origin.x, 0, cp.z * 16 + z - origin.z, biome.waterColorLinear);
+                }
               }
             }
           }
         }
-        task.updateEta(target, done);
-        done += 1;
         OctreeFinalizer.finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
         if (legacyChunks.contains(cp)) {
           LegacyBlocksFinalizer
               .finalizeChunk(worldOctree, waterOctree, palette, origin, cp, yMin, yMax);
         }
+        task.updateEta(target, done);
+        done += 1;
       }
 
       worldOctree.endFinalization();

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -945,7 +945,7 @@ public class Scene implements JsonSerializable, Refreshable {
               for (int cx = 0; cx < 16; ++cx) {
                 int wx = cx + wx0;
                 int biomePaletteIdx = biomeData.getBiome(cx, y, cz);
-                if(y != chunkData.minY()) {
+                if(y != yMin) {
                   int biomeUnder = biomeData.getBiome(cx, y-1, cz);
                   if(biomeUnder != biomePaletteIdx)
                     chunkBiomeHelper.addTransition(y);
@@ -1001,9 +1001,8 @@ public class Scene implements JsonSerializable, Refreshable {
                   int octNode = currentBlock;
                   Block block = palette.get(currentBlock);
 
-                  // TODO Implement isUsingBiome() and uncomment if
-                  //if(block.isUsingBiome())
-                  chunkBiomeHelper.makeBiomeRelevant(y);
+                  if(block.useBiomeTint())
+                    chunkBiomeHelper.makeBiomeRelevant(y);
 
                   if(block.isEntity()) {
                     Vector3 position = new Vector3(cx + cp.x * 16, y, cz + cp.z * 16);
@@ -1260,7 +1259,7 @@ public class Scene implements JsonSerializable, Refreshable {
 
             int[] combinedBiomeTransitions = chunkBiomeHelper.combineAndTrimTransitions(neighboringChunks, blurRadius);
 
-            System.out.printf("Chunk %d, %d :", cp.x, cp.z);
+            System.out.printf("Chunk %d, %d (from %d to %d) :", cp.x, cp.z, chunkBiomeHelper.getyMinBiomeRelevant(), chunkBiomeHelper.getyMaxBiomeRelevant());
             for(int t : combinedBiomeTransitions)
               System.out.printf("%d, ", t);
             System.out.print("\n");

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -865,8 +865,6 @@ public class Scene implements JsonSerializable, Refreshable {
     final Mutable<ChunkData> loadingChunkData = new Mutable<>(null); // chunkData currently being used for loading from save
     final Mutable<ChunkData> activeChunkData = new Mutable<>(null); // chunkData for loading into the octree
 
-    long start = System.nanoTime();
-
     try (TaskTracker.Task task = taskTracker.task("(3/6) Loading chunks")) {
       int done = 1;
       int target = chunksToLoad.size();
@@ -1257,11 +1255,6 @@ public class Scene implements JsonSerializable, Refreshable {
 
             int[] combinedBiomeTransitions = chunkBiomeHelper.combineAndTrimTransitions(neighboringChunks, biomeBlendingRadius);
 
-            System.out.printf("Chunk %d, %d (from %d to %d) :", cp.x, cp.z, chunkBiomeHelper.getyMinBiomeRelevant(), chunkBiomeHelper.getyMaxBiomeRelevant());
-            for(int t : combinedBiomeTransitions)
-              System.out.printf("%d, ", t);
-            System.out.print("\n");
-
             // When doing 3D blur we use the list of (vertical) biome transition
             // in the chunk or in neighboring ones
             // If there is no transition, a 2D blur is enough, otherwise we only
@@ -1400,10 +1393,6 @@ public class Scene implements JsonSerializable, Refreshable {
       foliageTexture.compact();
       waterTexture.compact();
     }
-
-    long end = System.nanoTime();
-
-    System.out.printf("Loading time: %fms\n", (end - start) / 1000000.0);
 
     entities.loadDataFromOctree(worldOctree, palette, origin);
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -935,7 +935,11 @@ public class Scene implements JsonSerializable, Refreshable {
 
         if (use3dBiomes) {
           biomeBlendingHelper.put(cp, chunkBiomeHelper);
-          for (int y = chunkData.minY(); y < chunkData.maxY(); y++) {
+          // We need to load biome data for the full height of the chunk
+          // and not only limited to the sections where there are blocks
+          // because it is possible that a neighboring chunks has blocks
+          // that will observe the biome color (via biome blending)
+          for (int y = yMin; y < yMax; y++) {
             for (int cz = 0; cz < 16; ++cz) {
               int wz = cz + wz0;
               for (int cx = 0; cx < 16; ++cx) {
@@ -1233,7 +1237,7 @@ public class Scene implements JsonSerializable, Refreshable {
       int done = 0;
       int target = nonEmptyChunks.size();
 
-      final int blurRadius = 1;
+      final int blurRadius = 5;
 
       for (ChunkPosition cp : nonEmptyChunks) {
 //        TODO: make this less special cased in some way, having 2 ifs for biomeBlending and use3dBiomes is quite awful to read and maintain
@@ -1299,6 +1303,7 @@ public class Scene implements JsonSerializable, Refreshable {
                   grassTexture,
                   foliageTexture,
                   waterTexture);
+                nextY = transition - blurRadius;
               }
 
               // Do a 3D blur to fill the next 2*blurRadius layers

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -1312,6 +1312,8 @@ public class Scene implements JsonSerializable, Refreshable {
               // we will fill the layers y in [7, 12] while working on the first
               // transition and on [13, 14] when working on the second. But the
               // blur will use the correct biome even during the first transition
+              // (that being said, it would probably be more efficient to do only
+              // one call of 3D blur for multiple transition, TODO)
               int maxLayerWorkedOn = Math.min(transition + blurRadius, chunkBiomeHelper.getyMaxBiomeRelevant());
               BiomeBlendingUtility.chunk3DBlur(
                 cp,

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
@@ -1,0 +1,114 @@
+package se.llbit.chunky.renderer.scene.biome;
+
+import se.llbit.chunky.world.ChunkPosition;
+import se.llbit.chunky.world.biome.Biome;
+import se.llbit.chunky.world.biome.BiomePalette;
+import se.llbit.math.Vector3i;
+import se.llbit.math.structures.Position2IntStructure;
+
+import java.util.Set;
+
+public class BiomeBlendingUtility {
+  public static void addEqual(float[] result, float[] addend) {
+    result[0] += addend[0];
+    result[1] += addend[1];
+    result[2] += addend[2];
+  }
+
+  /**
+   * Compute the blended biome colors for a chunk by doing a 2D blur and store the result in the given biome structures
+   * Sample the biome at a given y level and writes the result for y levels going from samplingY (inclusive) to maxFillY (exclusive)
+   */
+  static public void chunk2DBlur(ChunkPosition cp, int blurRadius, int samplingY, int maxFillY, Vector3i origin, Position2IntStructure biomeIdx, BiomePalette biomePalette, Set<ChunkPosition> nonEmptyChunks, BiomeStructure grassTexture, BiomeStructure foliageTexture, BiomeStructure waterTexture) {
+    for (int x = 0; x < 16; ++x) {
+      for (int z = 0; z < 16; ++z) {
+        int nsum = 0;
+        float[] grassMix = {0, 0, 0};
+        float[] foliageMix = {0, 0, 0};
+        float[] waterMix = {0, 0, 0};
+        for (int sx = x - blurRadius; sx <= x + blurRadius; ++sx) {
+          int wx = cp.x * 16 + sx;
+          for (int sz = z - blurRadius; sz <= z + blurRadius; ++sz) {
+            int wz = cp.z * 16 + sz;
+
+            ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
+            if (nonEmptyChunks.contains(ccp)) {
+              nsum += 1;
+              Biome biome = biomePalette.get(biomeIdx.get(wx, samplingY, wz));
+              addEqual(grassMix, biome.grassColorLinear);
+              addEqual(foliageMix, biome.foliageColorLinear);
+              addEqual(waterMix, biome.waterColorLinear);
+            }
+          }
+        }
+        grassMix[0] /= nsum;
+        grassMix[1] /= nsum;
+        grassMix[2] /= nsum;
+
+        foliageMix[0] /= nsum;
+        foliageMix[1] /= nsum;
+        foliageMix[2] /= nsum;
+
+        waterMix[0] /= nsum;
+        waterMix[1] /= nsum;
+        waterMix[2] /= nsum;
+
+        for(int y = samplingY; y < maxFillY; ++y) {
+          // TODO Introduce additional API to BiomeStructure to make them aware of the vertical repetition so they can optimize if wanted
+          grassTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, grassMix);
+          foliageTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, foliageMix);
+          waterTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, waterMix);
+        }
+      }
+    }
+  }
+
+  /**
+   * Compute the blended biome colors for a portion of chunk by doing a 3D blur and store the result in the given biome structures
+   */
+  static public void chunk3DBlur(ChunkPosition cp, int blurRadius, int minY, int maxY, Vector3i origin, Position2IntStructure biomeIdx, BiomePalette biomePalette, Set<ChunkPosition> nonEmptyChunks, BiomeStructure grassTexture, BiomeStructure foliageTexture, BiomeStructure waterTexture) {
+    for (int x = 0; x < 16; ++x) {
+      for (int z = 0; z < 16; ++z) {
+        for(int y = minY; y < maxY; ++y) {
+          int nsum = 0;
+          float[] grassMix = {0, 0, 0};
+          float[] foliageMix = {0, 0, 0};
+          float[] waterMix = {0, 0, 0};
+          for(int sx = x - blurRadius; sx <= x + blurRadius; ++sx) {
+            int wx = cp.x * 16 + sx;
+            for(int sz = z - blurRadius; sz <= z + blurRadius; ++sz) {
+              int wz = cp.z * 16 + sz;
+
+              ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
+              if(nonEmptyChunks.contains(ccp)) {
+                // TODO if y is out of bounds, biomeIdx.get will return 0 and we will blur with the wrong biome
+                for(int sy = y - blurRadius; sy <= y + blurRadius; ++sy) {
+                  nsum += 1;
+                  Biome biome = biomePalette.get(biomeIdx.get(wx, sy, wz));
+                  addEqual(grassMix, biome.grassColorLinear);
+                  addEqual(foliageMix, biome.foliageColorLinear);
+                  addEqual(waterMix, biome.waterColorLinear);
+                }
+              }
+            }
+          }
+          grassMix[0] /= nsum;
+          grassMix[1] /= nsum;
+          grassMix[2] /= nsum;
+
+          foliageMix[0] /= nsum;
+          foliageMix[1] /= nsum;
+          foliageMix[2] /= nsum;
+
+          waterMix[0] /= nsum;
+          waterMix[1] /= nsum;
+          waterMix[2] /= nsum;
+
+          grassTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, grassMix);
+          foliageTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, foliageMix);
+          waterTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, waterMix);
+        }
+      }
+    }
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
@@ -121,7 +121,7 @@ public class BiomeBlendingUtility {
     SummedAreaTable table = new SummedAreaTable(blurRadius);
     for(int x = -blurRadius; x < 16 + blurRadius; ++x) {
       for(int z = -blurRadius; z < 16 + blurRadius; ++z) {
-        ChunkPosition ccp = new ChunkPosition((cp.x * 16 + x) / 16, (cp.z * 16 + z) / 16);
+        ChunkPosition ccp = new ChunkPosition(Math.floorDiv(cp.x * 16 + x, 16), Math.floorDiv(cp.z * 16 + z, 16));
         if (nonEmptyChunks.contains(ccp)) {
           int biomeId = biomeIdx.get(cp.x * 16 + x, samplingY, cp.z * 16 + z);
           if(biomeId != -1) {
@@ -298,7 +298,7 @@ public class BiomeBlendingUtility {
     for(int y = minY - blurRadius; y < maxY + blurRadius; ++y) {
       for(int x = -blurRadius; x < 16 + blurRadius; ++x) {
         for(int z = -blurRadius; z < 16 + blurRadius; ++z) {
-          ChunkPosition ccp = new ChunkPosition((cp.x * 16 + x) / 16, (cp.z * 16 + z) / 16);
+          ChunkPosition ccp = new ChunkPosition(Math.floorDiv(cp.x * 16 + x, 16), Math.floorDiv(cp.z * 16 + z, 16));
           if (nonEmptyChunks.contains(ccp)) {
             int biomeId = biomeIdx.get(cp.x * 16 + x, y, cp.z * 16 + z);
             if(biomeId != -1) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
@@ -17,19 +17,19 @@ public class BiomeBlendingUtility {
 
   /**
    * Helper class to compute average of subrectangle of a 2D table in O(n²) init time
-   * and O(1) use time. Based on summed-area table // TODO link to wikipedia here
+   * and O(1) use time. Based on summed-area table https://en.wikipedia.org/wiki/Summed-area_table
    */
   private static class SummedAreaTable {
     // (16+2*r)² Summed area table of 9 entries vector (3 components for 3 colors)
-    float[] samData;
+    float[] satData;
     // Other summed area table to count the number of summed color to get denominator for average
-    int[] samN;
+    int[] satN;
     final int blurRadius;
     final int xStride;
 
     public SummedAreaTable(int blurRadius) {
-      samData = new float[(16 + 2*blurRadius) * (16 + 2*blurRadius) * 9 + 9];
-      samN = new int[(16 + 2*blurRadius) * (16 + 2*blurRadius) + 1];
+      satData = new float[(16 + 2*blurRadius) * (16 + 2*blurRadius) * 9 + 9];
+      satN = new int[(16 + 2*blurRadius) * (16 + 2*blurRadius) + 1];
       // (a bit more space is allocated at the end and left with 0 to simplify implmeentation of getAverageFor
       this.blurRadius = blurRadius;
       xStride = 16 + 2*blurRadius;
@@ -40,40 +40,40 @@ public class BiomeBlendingUtility {
       int offsetedZ = z + blurRadius;
       if(offsetedX < 0 || offsetedZ < 0) {
         // if requesting before the table, redirect to the space allocated at the end
-        return samN.length - 1;
+        return satN.length - 1;
       }
       return offsetedX * xStride + offsetedZ;
     }
 
     void init(int x, int z, Biome biome) {
       int idx = indexFor(x, z);
-      samData[idx*9] = biome.grassColorLinear[0];
-      samData[idx*9+1] = biome.grassColorLinear[1];
-      samData[idx*9+2] = biome.grassColorLinear[2];
-      samData[idx*9+3] = biome.foliageColorLinear[0];
-      samData[idx*9+4] = biome.foliageColorLinear[1];
-      samData[idx*9+5] = biome.foliageColorLinear[2];
-      samData[idx*9+6] = biome.waterColorLinear[0];
-      samData[idx*9+7] = biome.waterColorLinear[1];
-      samData[idx*9+8] = biome.waterColorLinear[2];
-      samN[idx] = 1;
+      satData[idx*9] = biome.grassColorLinear[0];
+      satData[idx*9+1] = biome.grassColorLinear[1];
+      satData[idx*9+2] = biome.grassColorLinear[2];
+      satData[idx*9+3] = biome.foliageColorLinear[0];
+      satData[idx*9+4] = biome.foliageColorLinear[1];
+      satData[idx*9+5] = biome.foliageColorLinear[2];
+      satData[idx*9+6] = biome.waterColorLinear[0];
+      satData[idx*9+7] = biome.waterColorLinear[1];
+      satData[idx*9+8] = biome.waterColorLinear[2];
+      satN[idx] = 1;
     }
 
     void computeSum() {
       // Compute first line
       for(int offsetedX = 1; offsetedX < 16 + 2*blurRadius; ++offsetedX) {
         for(int i = 0; i < 9; ++i) {
-          samData[(offsetedX * xStride) * 9 + i] += samData[((offsetedX - 1) * xStride) * 9 + i];
+          satData[(offsetedX * xStride) * 9 + i] += satData[((offsetedX - 1) * xStride) * 9 + i];
         }
-        samN[offsetedX * xStride] += samN[(offsetedX - 1) * xStride];
+        satN[offsetedX * xStride] += satN[(offsetedX - 1) * xStride];
       }
 
       // Compute first column
       for(int offsetedZ = 1; offsetedZ < 16 + 2*blurRadius; ++offsetedZ) {
         for(int i = 0; i < 9; ++i) {
-          samData[offsetedZ * 9 + i] += samData[(offsetedZ - 1) * 9 + i];
+          satData[offsetedZ * 9 + i] += satData[(offsetedZ - 1) * 9 + i];
         }
-        samN[offsetedZ] += samN[offsetedZ - 1];
+        satN[offsetedZ] += satN[offsetedZ - 1];
       }
 
       // Compute rest
@@ -81,15 +81,15 @@ public class BiomeBlendingUtility {
         for(int offsetedZ = 1; offsetedZ < 16 + 2 * blurRadius; ++offsetedZ) {
           for(int i = 0; i < 9; ++i) {
             // current += top + left - topleft
-            samData[(offsetedX * xStride + offsetedZ) * 9 + i] +=
-                samData[((offsetedX - 1) * xStride + offsetedZ) * 9 + i]
-              + samData[(offsetedX * xStride + (offsetedZ - 1)) * 9 + i]
-              - samData[((offsetedX - 1) * xStride + (offsetedZ - 1)) * 9 + i];
+            satData[(offsetedX * xStride + offsetedZ) * 9 + i] +=
+                satData[((offsetedX - 1) * xStride + offsetedZ) * 9 + i]
+              + satData[(offsetedX * xStride + (offsetedZ - 1)) * 9 + i]
+              - satData[((offsetedX - 1) * xStride + (offsetedZ - 1)) * 9 + i];
           }
-          samN[offsetedX * xStride + offsetedZ] +=
-              samN[(offsetedX - 1) * xStride + offsetedZ]
-            + samN[offsetedX * xStride + (offsetedZ - 1)]
-            - samN[(offsetedX - 1) * xStride + (offsetedZ - 1)];
+          satN[offsetedX * xStride + offsetedZ] +=
+              satN[(offsetedX - 1) * xStride + offsetedZ]
+            + satN[offsetedX * xStride + (offsetedZ - 1)]
+            - satN[(offsetedX - 1) * xStride + (offsetedZ - 1)];
         }
       }
     }
@@ -100,11 +100,11 @@ public class BiomeBlendingUtility {
       int bottomLeft = indexFor(x + blurRadius, z - blurRadius - 1);
       int bottomRight = indexFor(x + blurRadius, z + blurRadius);
 
-      int n = samN[topLeft] + samN[bottomRight] - samN[topRight] - samN[bottomLeft];
+      int n = satN[topLeft] + satN[bottomRight] - satN[topRight] - satN[bottomLeft];
 
       float[] result = new float[9];
       for(int i = 0; i < 9; ++i) {
-        result[i] = samData[topLeft*9+i] + samData[bottomRight*9+i] - samData[topRight*9+i] - samData[bottomLeft*9+i];
+        result[i] = satData[topLeft*9+i] + satData[bottomRight*9+i] - satData[topRight*9+i] - satData[bottomLeft*9+i];
         result[i] /= n;
       }
 
@@ -162,45 +162,170 @@ public class BiomeBlendingUtility {
   }
 
   /**
+   * Same as SummedAreaTable but in 3D
+   * https://stackoverflow.com/questions/20445084/3d-variant-for-summed-area-table-sat
+   */
+  private static class SummedVolumeTable {
+    // (16+2*r)^3 Summed area table of 9 entries vector (3 components for 3 colors)
+    float[] satData;
+    // Other summed area table to count the number of summed color to get denominator for average
+    int[] satN;
+    final int blurRadius;
+    final int yMin;
+    final int yMax;
+    final int yStride;
+    final int xStride;
+
+    public SummedVolumeTable(int blurRadius, int yMin, int yMax) {
+      satData = new float[(16 + 2*blurRadius) * (16 + 2*blurRadius) * (yMax - yMin + 2*blurRadius) * 9 + 9];
+      satN = new int[(16 + 2*blurRadius) * (16 + 2*blurRadius) * (yMax - yMin + 2*blurRadius) + 1];
+      // (a bit more space is allocated at the end and left with 0 to simplify implmeentation of getAverageFor
+      this.blurRadius = blurRadius;
+      this.yMin = yMin;
+      this.yMax = yMax;
+      yStride = (16 + 2*blurRadius) * (16 + 2*blurRadius);
+      xStride = 16 + 2*blurRadius;
+    }
+
+    int indexFor(int x, int y, int z) {
+      int offsetedY = y - yMin + blurRadius;
+      int offsetedX = x + blurRadius;
+      int offsetedZ = z + blurRadius;
+      if(offsetedY < 0 || offsetedX < 0 || offsetedZ < 0) {
+        // if requesting before the table, redirect to the space allocated at the end
+        return satN.length - 1;
+      }
+      return offsetedY * yStride + offsetedX * xStride + offsetedZ;
+    }
+
+    void init(int x, int y, int z, Biome biome) {
+      int idx = indexFor(x, y, z);
+      satData[idx*9] = biome.grassColorLinear[0];
+      satData[idx*9+1] = biome.grassColorLinear[1];
+      satData[idx*9+2] = biome.grassColorLinear[2];
+      satData[idx*9+3] = biome.foliageColorLinear[0];
+      satData[idx*9+4] = biome.foliageColorLinear[1];
+      satData[idx*9+5] = biome.foliageColorLinear[2];
+      satData[idx*9+6] = biome.waterColorLinear[0];
+      satData[idx*9+7] = biome.waterColorLinear[1];
+      satData[idx*9+8] = biome.waterColorLinear[2];
+      satN[idx] = 1;
+    }
+
+    void computeSum() {
+      // Because of the trick of redirecting out of bounds index to the end
+      // (that we only read and never write, so full of zeros)
+      // there is no need to special case the start
+
+      for(int y = yMin - blurRadius; y < yMax + blurRadius; ++y) {
+        for(int x = -blurRadius; x < 16 + blurRadius; ++x) {
+          for(int z = -blurRadius; z < 16 + blurRadius; ++z) {
+            int xyz = indexFor(x, y, z);
+            int xyz1 = indexFor(x, y, z - 1);
+            int xy1z = indexFor(x, y - 1, z);
+            int xy1z1 = indexFor(x, y - 1, z - 1);
+            int x1yz = indexFor(x - 1, y, z);
+            int x1yz1 = indexFor(x - 1, y, z - 1);
+            int x1y1z = indexFor(x - 1, y - 1, z);
+            int x1y1z1 = indexFor(x - 1, y - 1, z - 1);
+
+            for(int i = 0; i < 9; ++i) {
+              satData[xyz*9 + i] +=
+                  satData[x1yz*9 + i]
+                + satData[xy1z*9 + i]
+                + satData[xyz1*9 + i]
+                - satData[x1y1z*9 + i]
+                - satData[x1yz1*9 + i]
+                - satData[xy1z1*9 + i]
+                + satData[x1y1z1*9 + i];
+            }
+            satN[xyz] +=
+                satN[x1yz]
+              + satN[xy1z]
+              + satN[xyz1]
+              - satN[x1y1z]
+              - satN[x1yz1]
+              - satN[xy1z1]
+              + satN[x1y1z1];
+          }
+        }
+      }
+    }
+
+    public float[] getAverageFor(int x, int y, int z) {
+      int x1y1z1 = indexFor(x - blurRadius - 1, y - blurRadius - 1, z - blurRadius - 1);
+      int x1y1z2 = indexFor(x - blurRadius - 1, y - blurRadius - 1, z + blurRadius);
+      int x1y2z1 = indexFor(x - blurRadius - 1, y + blurRadius, z - blurRadius - 1);
+      int x1y2z2 = indexFor(x - blurRadius - 1, y + blurRadius, z + blurRadius);
+      int x2y1z1 = indexFor(x + blurRadius, y - blurRadius - 1, z - blurRadius - 1);
+      int x2y1z2 = indexFor(x + blurRadius, y - blurRadius - 1, z + blurRadius);
+      int x2y2z1 = indexFor(x + blurRadius, y + blurRadius, z - blurRadius - 1);
+      int x2y2z2 = indexFor(x + blurRadius, y + blurRadius, z + blurRadius);
+
+      int n =
+          satN[x2y2z2]
+        - satN[x2y2z1]
+        - satN[x2y1z2]
+        - satN[x1y2z2]
+        + satN[x2y1z1]
+        + satN[x1y2z1]
+        + satN[x1y1z2]
+        - satN[x1y1z1];
+
+      float[] result = new float[9];
+      for(int i = 0; i < 9; ++i) {
+        result[i] =
+            satData[x2y2z2*9 + i]
+          - satData[x2y2z1*9 + i]
+          - satData[x2y1z2*9 + i]
+          - satData[x1y2z2*9 + i]
+          + satData[x2y1z1*9 + i]
+          + satData[x1y2z1*9 + i]
+          + satData[x1y1z2*9 + i]
+          - satData[x1y1z1*9 + i];
+        result[i] /= n;
+      }
+
+      return result;
+    }
+  }
+
+  /**
    * Compute the blended biome colors for a portion of chunk by doing a 3D blur and store the result in the given biome structures
    */
   static public void chunk3DBlur(ChunkPosition cp, int blurRadius, int minY, int maxY, Vector3i origin, Position2IntStructure biomeIdx, BiomePalette biomePalette, Set<ChunkPosition> nonEmptyChunks, BiomeStructure grassTexture, BiomeStructure foliageTexture, BiomeStructure waterTexture) {
-    for (int x = 0; x < 16; ++x) {
-      for (int z = 0; z < 16; ++z) {
-        for(int y = minY; y < maxY; ++y) {
-          int nsum = 0;
-          float[] grassMix = {0, 0, 0};
-          float[] foliageMix = {0, 0, 0};
-          float[] waterMix = {0, 0, 0};
-          for(int sx = x - blurRadius; sx <= x + blurRadius; ++sx) {
-            int wx = cp.x * 16 + sx;
-            for(int sz = z - blurRadius; sz <= z + blurRadius; ++sz) {
-              int wz = cp.z * 16 + sz;
-
-              ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
-              if(nonEmptyChunks.contains(ccp)) {
-                // TODO if y is out of bounds, biomeIdx.get will return 0 and we will blur with the wrong biome
-                for(int sy = y - blurRadius; sy <= y + blurRadius; ++sy) {
-                  nsum += 1;
-                  Biome biome = biomePalette.get(biomeIdx.get(wx, sy, wz));
-                  addEqual(grassMix, biome.grassColorLinear);
-                  addEqual(foliageMix, biome.foliageColorLinear);
-                  addEqual(waterMix, biome.waterColorLinear);
-                }
-              }
+    SummedVolumeTable table = new SummedVolumeTable(blurRadius, minY, maxY);
+    for(int y = minY - blurRadius; y < maxY + blurRadius; ++y) {
+      for(int x = -blurRadius; x < 16 + blurRadius; ++x) {
+        for(int z = -blurRadius; z < 16 + blurRadius; ++z) {
+          ChunkPosition ccp = new ChunkPosition((cp.x * 16 + x) / 16, (cp.z * 16 + z) / 16);
+          if (nonEmptyChunks.contains(ccp)) {
+            int biomeId = biomeIdx.get(cp.x * 16 + x, y, cp.z * 16 + z);
+            if(biomeId != -1) {
+              Biome biome = biomePalette.get(biomeId);
+              table.init(x, y, z, biome);
             }
+            // if biomeId is -1, either y is outside of the loaded interval
+            // or there is a bug in loading similar to chunk2DBlur
           }
-          grassMix[0] /= nsum;
-          grassMix[1] /= nsum;
-          grassMix[2] /= nsum;
+        }
+      }
+    }
+    table.computeSum();
 
-          foliageMix[0] /= nsum;
-          foliageMix[1] /= nsum;
-          foliageMix[2] /= nsum;
-
-          waterMix[0] /= nsum;
-          waterMix[1] /= nsum;
-          waterMix[2] /= nsum;
+    for(int y = minY; y < maxY; ++y) {
+      for (int x = 0; x < 16; ++x) {
+        for (int z = 0; z < 16; ++z) {
+          float[] data = table.getAverageFor(x, y, z);
+          float[] grassMix = {
+            data[0], data[1], data[2]
+          };
+          float[] foliageMix = {
+            data[3], data[4], data[5]
+          };
+          float[] waterMix = {
+            data[6], data[7], data[8]
+          };
 
           grassTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, grassMix);
           foliageTexture.set(cp.x * 16 + x - origin.x, y - origin.y, cp.z * 16 + z - origin.z, foliageMix);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/BiomeBlendingUtility.java
@@ -16,42 +16,140 @@ public class BiomeBlendingUtility {
   }
 
   /**
+   * Helper class to compute average of subrectangle of a 2D table in O(n²) init time
+   * and O(1) use time. Based on summed-area table // TODO link to wikipedia here
+   */
+  private static class SummedAreaTable {
+    // (16+2*r)² Summed area table of 9 entries vector (3 components for 3 colors)
+    float[] samData;
+    // Other summed area table to count the number of summed color to get denominator for average
+    int[] samN;
+    final int blurRadius;
+    final int xStride;
+
+    public SummedAreaTable(int blurRadius) {
+      samData = new float[(16 + 2*blurRadius) * (16 + 2*blurRadius) * 9 + 9];
+      samN = new int[(16 + 2*blurRadius) * (16 + 2*blurRadius) + 1];
+      // (a bit more space is allocated at the end and left with 0 to simplify implmeentation of getAverageFor
+      this.blurRadius = blurRadius;
+      xStride = 16 + 2*blurRadius;
+    }
+
+    int indexFor(int x, int z) {
+      int offsetedX = x + blurRadius;
+      int offsetedZ = z + blurRadius;
+      if(offsetedX < 0 || offsetedZ < 0) {
+        // if requesting before the table, redirect to the space allocated at the end
+        return samN.length - 1;
+      }
+      return offsetedX * xStride + offsetedZ;
+    }
+
+    void init(int x, int z, Biome biome) {
+      int idx = indexFor(x, z);
+      samData[idx*9] = biome.grassColorLinear[0];
+      samData[idx*9+1] = biome.grassColorLinear[1];
+      samData[idx*9+2] = biome.grassColorLinear[2];
+      samData[idx*9+3] = biome.foliageColorLinear[0];
+      samData[idx*9+4] = biome.foliageColorLinear[1];
+      samData[idx*9+5] = biome.foliageColorLinear[2];
+      samData[idx*9+6] = biome.waterColorLinear[0];
+      samData[idx*9+7] = biome.waterColorLinear[1];
+      samData[idx*9+8] = biome.waterColorLinear[2];
+      samN[idx] = 1;
+    }
+
+    void computeSum() {
+      // Compute first line
+      for(int offsetedX = 1; offsetedX < 16 + 2*blurRadius; ++offsetedX) {
+        for(int i = 0; i < 9; ++i) {
+          samData[(offsetedX * xStride) * 9 + i] += samData[((offsetedX - 1) * xStride) * 9 + i];
+        }
+        samN[offsetedX * xStride] += samN[(offsetedX - 1) * xStride];
+      }
+
+      // Compute first column
+      for(int offsetedZ = 1; offsetedZ < 16 + 2*blurRadius; ++offsetedZ) {
+        for(int i = 0; i < 9; ++i) {
+          samData[offsetedZ * 9 + i] += samData[(offsetedZ - 1) * 9 + i];
+        }
+        samN[offsetedZ] += samN[offsetedZ - 1];
+      }
+
+      // Compute rest
+      for(int offsetedX = 1; offsetedX < 16 + 2*blurRadius; ++offsetedX) {
+        for(int offsetedZ = 1; offsetedZ < 16 + 2 * blurRadius; ++offsetedZ) {
+          for(int i = 0; i < 9; ++i) {
+            // current += top + left - topleft
+            samData[(offsetedX * xStride + offsetedZ) * 9 + i] +=
+                samData[((offsetedX - 1) * xStride + offsetedZ) * 9 + i]
+              + samData[(offsetedX * xStride + (offsetedZ - 1)) * 9 + i]
+              - samData[((offsetedX - 1) * xStride + (offsetedZ - 1)) * 9 + i];
+          }
+          samN[offsetedX * xStride + offsetedZ] +=
+              samN[(offsetedX - 1) * xStride + offsetedZ]
+            + samN[offsetedX * xStride + (offsetedZ - 1)]
+            - samN[(offsetedX - 1) * xStride + (offsetedZ - 1)];
+        }
+      }
+    }
+
+    public float[] getAverageFor(int x, int z) {
+      int topLeft = indexFor(x - blurRadius - 1, z - blurRadius - 1);
+      int topRight = indexFor(x - blurRadius - 1, z + blurRadius);
+      int bottomLeft = indexFor(x + blurRadius, z - blurRadius - 1);
+      int bottomRight = indexFor(x + blurRadius, z + blurRadius);
+
+      int n = samN[topLeft] + samN[bottomRight] - samN[topRight] - samN[bottomLeft];
+
+      float[] result = new float[9];
+      for(int i = 0; i < 9; ++i) {
+        result[i] = samData[topLeft*9+i] + samData[bottomRight*9+i] - samData[topRight*9+i] - samData[bottomLeft*9+i];
+        result[i] /= n;
+      }
+
+      return result;
+    }
+  }
+
+  /**
    * Compute the blended biome colors for a chunk by doing a 2D blur and store the result in the given biome structures
    * Sample the biome at a given y level and writes the result for y levels going from samplingY (inclusive) to maxFillY (exclusive)
    */
   static public void chunk2DBlur(ChunkPosition cp, int blurRadius, int samplingY, int maxFillY, Vector3i origin, Position2IntStructure biomeIdx, BiomePalette biomePalette, Set<ChunkPosition> nonEmptyChunks, BiomeStructure grassTexture, BiomeStructure foliageTexture, BiomeStructure waterTexture) {
-    for (int x = 0; x < 16; ++x) {
-      for (int z = 0; z < 16; ++z) {
-        int nsum = 0;
-        float[] grassMix = {0, 0, 0};
-        float[] foliageMix = {0, 0, 0};
-        float[] waterMix = {0, 0, 0};
-        for (int sx = x - blurRadius; sx <= x + blurRadius; ++sx) {
-          int wx = cp.x * 16 + sx;
-          for (int sz = z - blurRadius; sz <= z + blurRadius; ++sz) {
-            int wz = cp.z * 16 + sz;
 
-            ChunkPosition ccp = new ChunkPosition(wx >> 4, wz >> 4);
-            if (nonEmptyChunks.contains(ccp)) {
-              nsum += 1;
-              Biome biome = biomePalette.get(biomeIdx.get(wx, samplingY, wz));
-              addEqual(grassMix, biome.grassColorLinear);
-              addEqual(foliageMix, biome.foliageColorLinear);
-              addEqual(waterMix, biome.waterColorLinear);
-            }
+    SummedAreaTable table = new SummedAreaTable(blurRadius);
+    for(int x = -blurRadius; x < 16 + blurRadius; ++x) {
+      for(int z = -blurRadius; z < 16 + blurRadius; ++z) {
+        ChunkPosition ccp = new ChunkPosition((cp.x * 16 + x) / 16, (cp.z * 16 + z) / 16);
+        if (nonEmptyChunks.contains(ccp)) {
+          int biomeId = biomeIdx.get(cp.x * 16 + x, samplingY, cp.z * 16 + z);
+          if(biomeId != -1) {
+            Biome biome = biomePalette.get(biomeId);
+            table.init(x, z, biome);
+          } else {
+            // Not having the biome data loaded at this point is
+            // a bug earlier in the loading process.
+            // In case it happens, ignore the block to get a somewhat sensible result
+            assert false;
           }
         }
-        grassMix[0] /= nsum;
-        grassMix[1] /= nsum;
-        grassMix[2] /= nsum;
+      }
+    }
+    table.computeSum();
 
-        foliageMix[0] /= nsum;
-        foliageMix[1] /= nsum;
-        foliageMix[2] /= nsum;
-
-        waterMix[0] /= nsum;
-        waterMix[1] /= nsum;
-        waterMix[2] /= nsum;
+    for (int x = 0; x < 16; ++x) {
+      for (int z = 0; z < 16; ++z) {
+        float[] data = table.getAverageFor(x, z);
+        float[] grassMix = {
+          data[0], data[1], data[2]
+        };
+        float[] foliageMix = {
+          data[3], data[4], data[5]
+        };
+        float[] waterMix = {
+          data[6], data[7], data[8]
+        };
 
         for(int y = samplingY; y < maxFillY; ++y) {
           // TODO Introduce additional API to BiomeStructure to make them aware of the vertical repetition so they can optimize if wanted

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
@@ -1,0 +1,68 @@
+package se.llbit.chunky.renderer.scene.biome;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+
+/**
+ * Holds information relative to biome in a a chunk to help with biome blending at load time
+ */
+public class ChunkBiomeBlendingHelper {
+  /// List of the y values at which a vertical biome transition occurs.
+  /// A value of y means that the biome between height y-1 and height y is different
+  /// (if null, no transition vertical biome transition exist for this chunk)
+  /// Should stay sorted, but not checked by this class itself
+  private IntArrayList transitions;
+  /// The interval of y values for which the biome is relevant
+  /// ie some block tint depend on the biome
+  /// (both inclusive)
+  private int yMinBiomeRelevant = Integer.MAX_VALUE;
+  private int yMaxBiomeRelevant = Integer.MIN_VALUE;
+
+  /**
+   * Add a transition. Transitions should be inserted in sorted order
+   * @param y The transition to add
+   */
+  public void addTransition(int y) {
+    if(transitions == null)
+      transitions = new IntArrayList();
+    if(transitions.size() > 0 && transitions.getInt(transitions.size() - 1) == y)
+      return;
+    transitions.add(y);
+  }
+
+  public void makeBiomeRelevant(int y) {
+    yMinBiomeRelevant = Math.min(yMinBiomeRelevant, y);
+    yMaxBiomeRelevant = Math.max(yMaxBiomeRelevant, y);
+  }
+
+  public int[] combineAndTrimTransitions(ChunkBiomeBlendingHelper[] neighboringChunks, int blurRadius) {
+    // merge sorted arrays and deduplication
+    // Simple implementation for, new probably enough even later
+    IntSortedSet set = new IntRBTreeSet();
+    if(transitions != null) {
+      for(int y : transitions) {
+        if(y > yMinBiomeRelevant - blurRadius && y <= yMaxBiomeRelevant + blurRadius)
+          set.add(y);
+      }
+    }
+    for(ChunkBiomeBlendingHelper other : neighboringChunks) {
+      if(other != null && other.transitions != null) {
+        for(int y : other.transitions){
+          if(y > yMinBiomeRelevant - blurRadius && y <= yMaxBiomeRelevant + blurRadius)
+            set.add(y);
+        }
+      }
+    }
+    return set.toIntArray(); // sorted merge and deduplication done by set
+  }
+
+  public int getyMinBiomeRelevant() {
+    return yMinBiomeRelevant;
+  }
+
+  public int getyMaxBiomeRelevant() {
+    return yMaxBiomeRelevant;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
@@ -39,7 +39,7 @@ public class ChunkBiomeBlendingHelper {
 
   public int[] combineAndTrimTransitions(ChunkBiomeBlendingHelper[] neighboringChunks, int blurRadius) {
     // merge sorted arrays and deduplication
-    // Simple implementation for, new probably enough even later
+    // Simple implementation for now, probably enough even later
     IntSortedSet set = new IntRBTreeSet();
     if(transitions != null) {
       for(int y : transitions) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/ChunkBiomeBlendingHelper.java
@@ -65,4 +65,9 @@ public class ChunkBiomeBlendingHelper {
   public int getyMaxBiomeRelevant() {
     return yMaxBiomeRelevant;
   }
+
+  public boolean isBiomeUsed() {
+    // Has makeBiomeRelevant been called at least once
+    return yMaxBiomeRelevant >= yMinBiomeRelevant;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
@@ -33,6 +33,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.RenderController;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.renderer.scene.SceneManager;
+import se.llbit.chunky.ui.IntegerAdjuster;
 import se.llbit.chunky.ui.controller.RenderControlsFxController;
 import se.llbit.chunky.ui.dialogs.ResourcePackChooser;
 import se.llbit.chunky.ui.render.RenderControlsTab;
@@ -51,7 +52,7 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML
   private CheckBox biomeColors;
   @FXML
-  private CheckBox biomeBlending;
+  private IntegerAdjuster biomeBlendingRadiusInput;
   @FXML
   private CheckBox singleColorBtn;
   @FXML
@@ -99,7 +100,7 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
       boolean enabled = scene.biomeColorsEnabled();
 
       scene.setBiomeColorsEnabled(newValue);
-      biomeBlending.setDisable(!newValue);
+      biomeBlendingRadiusInput.setDisable(!newValue);
 
       if(!scene.haveLoadedChunks()) {
         return;
@@ -109,14 +110,16 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
       }
     });
 
-    biomeBlending.setTooltip(new Tooltip("Blend edges of biomes (looks better but loads slower)."));
-    biomeBlending.selectedProperty().addListener((observable, oldValue, newValue) -> {
+    biomeBlendingRadiusInput.setTooltip("Set the radius used for the blending of biome colors. 0 to disable. (1 is what minecraft calls 3×3, 2 is 5×5 and so on)");
+    biomeBlendingRadiusInput.setRange(0, 16);
+    biomeBlendingRadiusInput.clampBoth();
+    biomeBlendingRadiusInput.onValueChange(value -> {
       Scene scene = sceneManager.getScene();
-      boolean enabled = scene.biomeBlendingEnabled();
+      int previous = scene.biomeBlendingRadius();
 
-      scene.setBiomeBlendingEnabled(newValue);
+      scene.setBiomeBlendingRadius(value);
 
-      if(enabled != newValue) {
+      if(previous != value) {
         alertIfReloadNeeded("biome blending");
       }
     });
@@ -147,8 +150,8 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
   @Override
   public void update(Scene scene) {
     biomeColors.setSelected(scene.biomeColorsEnabled());
-    biomeBlending.setDisable(!scene.biomeColorsEnabled());
-    biomeBlending.setSelected(scene.biomeBlendingEnabled());
+    biomeBlendingRadiusInput.setDisable(!scene.biomeColorsEnabled());
+    biomeBlendingRadiusInput.set(scene.biomeBlendingRadius());
   }
 
   @Override

--- a/chunky/src/java/se/llbit/math/structures/Position3d2IntPackedArray.java
+++ b/chunky/src/java/se/llbit/math/structures/Position3d2IntPackedArray.java
@@ -3,6 +3,7 @@ package se.llbit.math.structures;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceMap;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class Position3d2IntPackedArray implements Position2IntStructure {
@@ -28,7 +29,7 @@ public class Position3d2IntPackedArray implements Position2IntStructure {
     if(xSection == this.lastX && ySection == this.lastY && zSection == this.lastZ) {
       arr = this.lastData;
     } else {
-      arr = this.structure.computeIfAbsent(new XYZTriple(xSection, ySection, zSection), sectionPos -> new int[16 * 16 * 16]);
+      arr = this.structure.computeIfAbsent(new XYZTriple(xSection, ySection, zSection), sectionPos -> newSection());
       this.lastX = xSection;
       this.lastY = ySection;
       this.lastZ = zSection;
@@ -37,6 +38,12 @@ public class Position3d2IntPackedArray implements Position2IntStructure {
     if(arr != null) {
       arr[packedIndex(x, y, z)] = data;
     }
+  }
+
+  private static int[] newSection() {
+    int[] section = new int[16*16*16];
+    Arrays.fill(section, -1);
+    return section;
   }
 
   @Override
@@ -48,7 +55,7 @@ public class Position3d2IntPackedArray implements Position2IntStructure {
     if(xSection == this.lastX && ySection == this.lastY && zSection == this.lastZ) {
       arr = this.lastData;
     } else {
-      arr = this.structure.computeIfAbsent(new XYZTriple(xSection, ySection, zSection), sectionPos -> new int[16 * 16 * 16]);
+      arr = this.structure.computeIfAbsent(new XYZTriple(xSection, ySection, zSection), sectionPos -> newSection());
       this.lastX = xSection;
       this.lastY = ySection;
       this.lastZ = zSection;
@@ -57,7 +64,7 @@ public class Position3d2IntPackedArray implements Position2IntStructure {
     if(arr != null) {
       return arr[packedIndex(x, y, z)];
     }
-    return 0;
+    return -1;
   }
 
   protected static class XYZTriple {

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/TexturesTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/TexturesTab.fxml
@@ -10,7 +10,7 @@
   <VBox spacing="10.0">
     <CheckBox fx:id="biomeColors" mnemonicParsing="false" text="Enable biome colors" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
-      <IntegerAdjuster fx:id="biomeBlendingRadiusInput" name="Biome Blending Radius" />
+      <IntegerAdjuster fx:id="biomeBlendingRadiusInput" name="Biome blending radius" />
     </HBox>
     <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures"/>
     <Button fx:id="editResourcePacks" maxWidth="1.7976931348623157E308" mnemonicParsing="false"

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/TexturesTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/TexturesTab.fxml
@@ -3,11 +3,15 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.VBox?>
+<?import se.llbit.chunky.ui.IntegerAdjuster?>
+<?import javafx.scene.layout.HBox?>
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40"
          xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
     <CheckBox fx:id="biomeColors" mnemonicParsing="false" text="Enable biome colors" />
-    <CheckBox fx:id="biomeBlending" mnemonicParsing="false" text="Enable biome blending" />
+    <HBox alignment="CENTER_LEFT" spacing="10.0">
+      <IntegerAdjuster fx:id="biomeBlendingRadiusInput" name="Biome Blending Radius" />
+    </HBox>
     <CheckBox fx:id="singleColorBtn" mnemonicParsing="false" text="Single color textures"/>
     <Button fx:id="editResourcePacks" maxWidth="1.7976931348623157E308" mnemonicParsing="false"
             text="Edit resource packs"/>


### PR DESCRIPTION
This PR improves performance of doing biome blending during chunk loading. 
The combined time of step 3 and 4 (loading chunks and finalization ; biome blending occurs during step 4) has roughly been halved based on my rough timings. (Sorry, no precise timings provided, I've been winging it a bit). 
The improved performance and the improved asymptotic complexity of blur make it reasonable to do blur bigger than 3*3*3 so that's now possible and exposed in the UI. 
As an added bonus that wasn't really intentional, memory usage has decreased when using trivial 3D biome structure (by virtue of not storing biome color for every block, more on that later).

The improved performances are achieved for 3 reasons:
 - When possible a 2D blur is used instead of a 3D one. To know when using a 2D blur can be used (will give the same result as the 3D one), I keep track of vertical biome transition during chunk loading, ie when the biome at a block is different than the biome at the block just under. When a transition occurs, for every y level that is close to transition (closer than the blur radius), a 3D blur is needed as the biomes are not vertically uniform. Basically, for each y at which a (vertical) biome transition occurs, there is an interval of y value for which a 3D blur must be used. But for every y level outside of all of those intervals, a 2D blur is enough. Even better, there is usually a lot of consecutive y levels with (vertically) uniform biomes, this means the 2D blur can be computed for only one of those levels and copied for the other levels. In practice I don't track biome transition for each (x, z) column but for each chunk, this means that if there is a biome transition in a single column of the chunk, the 3D blur will be used for the entire chunk (for the y levels around the transition). And even more, because neighboring chunks affect biome blending, a single biome transition in a column will affect the whole chunk of the block and the neighboring chunks. To be effective this optimization relies on the fact that there isn't a lot of vertical biome transition in a minecraft world (which seems to be the case in my very limited testing). (this optimization does nothing to help performance when using 2D biome only)
 - The blur computations, both 2D and 3D, have been changed to use a summed-area table to reduce the complexity, especially with bigger blur radius. (while writing this message I realized that in asymptotic sense, it doesn't actually improve the complexity the way I've done it. It's better then naive blur but maybe an separated blur is even better but that would be a separated PR). This optimization benefits the 2D biome only case as well.
 - Only compute the biome colors when needed. That's a very rough way to do it (it could be done more finaly later I guess), during loading chunk I keep track of the min and max y value for which at least one block of the chunk needs biome color. When comes times to compute biome color, I don't compute any color outside of this interval. This simple test can lead to big wins on some chunks (like when there is no water underground, the biome colors will only be computed around surface level). (doesn't help in the 2D biome case). This is the change that cause the memory usage reduction, because in some cases a lot less biomes colors are stored.

The setting for enabling/disabling biome blending has been replace for a setting to choose the biome blending radius (and a radius of 0 means biome blending is disabled)

Sorry no screenshot of bigger radius, I'm too lazy and my test scene is stupid looking anyway