### PR TITLE
Add a ground plane.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -95,6 +95,7 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.isWaterPlaneEnabled()) {
       hit = waterPlaneIntersection(scene, ray) || hit;
     }
+    hit |= groundPlaneIntersection(scene, ray);
     if (scene.intersect(ray)) {
       // Octree tracer handles updating distance.
       return true;
@@ -135,6 +136,30 @@ public class PreviewRayTracer implements RayTracer {
         ray.setCurrentMaterial(Air.INSTANCE);
         return true;
       }
+    }
+    return false;
+  }
+
+  private static boolean groundPlaneIntersection(Scene scene, Ray ray) {
+    double t = (scene.getYClipMin() - ray.o.y - scene.origin.y) / ray.d.y;
+    if (scene.getWaterPlaneChunkClip()) {
+      Vector3 pos = new Vector3(ray.o);
+      pos.scaleAdd(t, ray.d);
+      if (scene.isChunkLoaded((int)Math.floor(pos.x), (int)Math.floor(pos.y), (int)Math.floor(pos.z)))
+        return false;
+    }
+    if (ray.d.y < 0 && t > 0 && t < ray.t) {
+      double px = ray.o.x + t * ray.d.x;
+      double pz = ray.o.z + t * ray.d.z;
+
+      ray.u = px - Math.floor(px);
+      ray.v = pz - Math.floor(pz);
+
+      ray.t = t;
+      scene.getPalette().stone.getColor(ray);
+      ray.setNormal(0, 1, 0);
+      ray.setCurrentMaterial(scene.getPalette().stone);
+      return true;
     }
     return false;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -95,7 +95,9 @@ public class PreviewRayTracer implements RayTracer {
     if (scene.isWaterPlaneEnabled()) {
       hit = waterPlaneIntersection(scene, ray) || hit;
     }
-    hit |= groundPlaneIntersection(scene, ray);
+    if (scene.isGroundPlaneEnabled()) {
+      hit |= groundPlaneIntersection(scene, ray);
+    }
     if (scene.intersect(ray)) {
       // Octree tracer handles updating distance.
       return true;
@@ -141,8 +143,8 @@ public class PreviewRayTracer implements RayTracer {
   }
 
   private static boolean groundPlaneIntersection(Scene scene, Ray ray) {
-    double t = (scene.getYClipMin() - ray.o.y - scene.origin.y) / ray.d.y;
-    if (scene.getWaterPlaneChunkClip()) {
+    double t = (scene.getGroundPlaneHeight() - ray.o.y - scene.origin.y) / ray.d.y;
+    if (scene.getGroundPlaneChunkClip()) {
       Vector3 pos = new Vector3(ray.o);
       pos.scaleAdd(t, ray.d);
       if (scene.isChunkLoaded((int)Math.floor(pos.x), (int)Math.floor(pos.y), (int)Math.floor(pos.z)))

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -228,6 +228,11 @@ public class Scene implements JsonSerializable, Refreshable {
   protected double waterPlaneHeight = World.SEA_LEVEL;
   protected boolean waterPlaneOffsetEnabled = true;
   protected boolean waterPlaneChunkClip = true;
+
+  protected boolean groundPlaneEnabled = false;
+  protected double groundPlaneHeight = 0;
+  protected boolean groundPlaneChunkClip = true;
+
   protected WaterShader waterShading = new SimplexWaterShader();
 
   public final Fog fog = new Fog(this);
@@ -466,6 +471,11 @@ public class Scene implements JsonSerializable, Refreshable {
     waterPlaneHeight = other.waterPlaneHeight;
     waterPlaneOffsetEnabled = other.waterPlaneOffsetEnabled;
     waterPlaneChunkClip = other.waterPlaneChunkClip;
+
+    groundPlaneEnabled = other.groundPlaneEnabled;
+    groundPlaneHeight = other.groundPlaneHeight;
+    groundPlaneChunkClip = other.groundPlaneChunkClip;
+
     waterShading = other.waterShading.clone();
 
     hideUnknownBlocks = other.hideUnknownBlocks;
@@ -1859,6 +1869,39 @@ public class Scene implements JsonSerializable, Refreshable {
     return waterPlaneChunkClip;
   }
 
+  public void setGroundPlaneEnabled(boolean enabled) {
+    if (enabled != groundPlaneEnabled) {
+      groundPlaneEnabled = enabled;
+      refresh();
+    }
+  }
+
+  public boolean isGroundPlaneEnabled() {
+    return groundPlaneEnabled;
+  }
+
+  public void setGroundPlaneHeight(double height) {
+    if (height != groundPlaneHeight) {
+      groundPlaneHeight = height;
+      refresh();
+    }
+  }
+
+  public double getGroundPlaneHeight() {
+    return groundPlaneHeight;
+  }
+
+  public void setGroundPlaneChunkClip(boolean enabled) {
+    if (enabled != groundPlaneChunkClip) {
+      groundPlaneChunkClip = enabled;
+      refresh();
+    }
+  }
+
+  public boolean getGroundPlaneChunkClip() {
+    return groundPlaneChunkClip;
+  }
+
   /**
    * @return the dumpFrequency
    */
@@ -2663,10 +2706,16 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("fog", fog.toJson());
     json.add("biomeColorsEnabled", biomeColors);
     json.add("transparentSky", transparentSky);
+
     json.add("waterWorldEnabled", waterPlaneEnabled);
     json.add("waterWorldHeight", waterPlaneHeight);
     json.add("waterWorldHeightOffsetEnabled", waterPlaneOffsetEnabled);
     json.add("waterWorldClipEnabled", waterPlaneChunkClip);
+
+    json.add("groundPlaneEnabled", groundPlaneEnabled);
+    json.add("groundPlaneHeight", groundPlaneHeight);
+    json.add("groundPlaneClipEnabled", groundPlaneChunkClip);
+
     json.add("hideUnknownBlocks", hideUnknownBlocks);
 
     if (!worldPath.isEmpty()) {
@@ -2971,6 +3020,10 @@ public class Scene implements JsonSerializable, Refreshable {
         .boolValue(waterPlaneOffsetEnabled);
       waterPlaneChunkClip = json.get("waterWorldClipEnabled").boolValue(waterPlaneChunkClip);
     }
+
+    groundPlaneEnabled = json.get("groundPlaneEnabled").boolValue(groundPlaneEnabled);
+    groundPlaneHeight = json.get("groundPlaneHeight").doubleValue(groundPlaneHeight);
+    groundPlaneChunkClip = json.get("groundPlaneClipEnabled").boolValue(groundPlaneChunkClip);
 
     hideUnknownBlocks = json.get("hideUnknownBlocks").boolValue(hideUnknownBlocks);
     materials = json.get("materials").object().copy().toMap();

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/WaterTab.java
@@ -52,11 +52,18 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
   @FXML private CheckBox useCustomWaterColor;
   @FXML private LuxColorPicker waterColor;
   @FXML private Button saveDefaults;
+
   @FXML private CheckBox waterPlaneEnabled;
   @FXML private DoubleAdjuster waterPlaneHeight;
   @FXML private CheckBox waterPlaneOffsetEnabled;
   @FXML private CheckBox waterPlaneClip;
   @FXML private TitledPane waterWorldModeDetailsPane;
+
+  @FXML private CheckBox groundPlaneEnabled;
+  @FXML private DoubleAdjuster groundPlaneHeight;
+  @FXML private CheckBox groundPlaneClip;
+  @FXML private TitledPane groundPlaneDetailsPane;
+
   @FXML private CheckBox useProceduralWater;
   @FXML private IntegerAdjuster proceduralWaterIterations;
   @FXML private DoubleAdjuster proceduralWaterFrequency;
@@ -103,6 +110,11 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
     waterPlaneHeight.set(scene.getWaterPlaneHeight());
     waterPlaneOffsetEnabled.setSelected(scene.isWaterPlaneOffsetEnabled());
     waterPlaneClip.setSelected(scene.getWaterPlaneChunkClip());
+
+    groundPlaneEnabled.setSelected(scene.isGroundPlaneEnabled());
+    groundPlaneHeight.setRange(scene.yClipMin, scene.yClipMax);
+    groundPlaneHeight.set(scene.getGroundPlaneHeight());
+    groundPlaneClip.setSelected(scene.getGroundPlaneChunkClip());
 
     if(scene.getWaterShading() instanceof SimplexWaterShader) {
       useProceduralWater.setSelected(true);
@@ -193,6 +205,26 @@ public class WaterTab extends ScrollPane implements RenderControlsTab, Initializ
 
     waterPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
       scene.setWaterPlaneChunkClip(newValue)
+    );
+
+    groundPlaneDetailsPane.setVisible(groundPlaneEnabled.isSelected());
+    groundPlaneDetailsPane.setExpanded(groundPlaneEnabled.isSelected());
+    groundPlaneDetailsPane.setManaged(groundPlaneEnabled.isSelected());
+
+    groundPlaneEnabled.setTooltip(new Tooltip("If enabled, an infinite ground fills the scene."));
+    groundPlaneEnabled.selectedProperty().addListener((observable, oldValue, newValue) -> {
+      scene.setGroundPlaneEnabled(newValue);
+      groundPlaneDetailsPane.setVisible(newValue);
+      groundPlaneDetailsPane.setExpanded(newValue);
+      groundPlaneDetailsPane.setManaged(newValue);
+    });
+
+    groundPlaneHeight.setName("Ground height");
+    groundPlaneHeight.setTooltip("The default ground height is at y=0.");
+    groundPlaneHeight.onValueChange(value -> scene.setGroundPlaneHeight(value));
+
+    groundPlaneClip.selectedProperty().addListener((observable, oldValue, newValue) ->
+      scene.setGroundPlaneChunkClip(newValue)
     );
 
     proceduralWaterDetailsPane.setVisible(useProceduralWater.isSelected());

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/WaterTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/WaterTab.fxml
@@ -23,6 +23,7 @@
     </HBox>
     <Button fx:id="saveDefaults" mnemonicParsing="false" text="Save as defaults" />
     <Separator prefWidth="200.0" />
+
     <CheckBox fx:id="waterPlaneEnabled" mnemonicParsing="false" text="Water world mode" />
     <TitledPane fx:id="waterWorldModeDetailsPane" animated="false" text="Water world mode settings">
       <VBox spacing="10.0">
@@ -34,6 +35,19 @@
         <CheckBox fx:id="waterPlaneClip" mnemonicParsing="false" text="Hide the water plane in loaded chunks" />
       </VBox>
     </TitledPane>
+
+    <CheckBox fx:id="groundPlaneEnabled" mnemonicParsing="false" text="Ground plane" />
+    <TitledPane fx:id="groundPlaneDetailsPane" animated="false" text="Ground plane settings">
+      <VBox spacing="10.0">
+        <padding>
+          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+        </padding>
+
+        <DoubleAdjuster fx:id="groundPlaneHeight" />
+        <CheckBox fx:id="groundPlaneClip" mnemonicParsing="false" text="Hide the ground plane in loaded chunks" />
+      </VBox>
+    </TitledPane>
+
     <CheckBox fx:id="useProceduralWater" mnemonicParsing="false" text="Procedural water" />
     <TitledPane fx:id="proceduralWaterDetailsPane" animated="false" text="Procedural water settings">
       <VBox spacing="10.0">


### PR DESCRIPTION
This adds an infinite ground plane similar to the water plane.
![image](https://github.com/chunky-dev/chunky/assets/42661490/0c0c8487-8575-46c4-9c8c-008c10bd55b1)

Currently the texture is set to stone and isn't configurable. Currently the controls are in the `Water` tab so suggestions for a better place are welcome.