### PR TITLE
Fix loading multiple textures with the same file name with addSimpleTexture.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3658,8 +3658,7 @@ public class TexturePackLoader {
   }
 
   private static void addSimpleTexture(String file, Texture texture) {
-    String[] path = file.split("/");
-    addSimpleTexture(path[path.length - 1], file, texture);
+    addSimpleTexture(file, file, texture);
   }
 
   private static void addSimpleTexture(String name, String file, Texture texture) {


### PR DESCRIPTION
When using `addSimpleTexture` or the `@TexturePath` annotation, textures are deduped by their filename (not their path). This causes eg. mangrove sign textures not to load if the `hanging/mangrove.png` texture was already loaded.

Fixes bamboo, cherry and mangrove signs. Regression probably introduced by #1600