### PR TITLE
Update Minecraft wiki links to new domain

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/PlayerEntity.java
@@ -677,7 +677,7 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
     JsonObject json = parseJson(helmJson);
     switch (id) {
       case "minecraft:skull":
-        // Reference: https://minecraft.gamepedia.com/Mob_head#Data_values
+        // Reference: https://minecraft.wiki/w/Mob_head#Data_values
         int type = item.get("type").asInt(3);
         switch (type) {
           case 0:
@@ -757,7 +757,7 @@ public class PlayerEntity extends Entity implements Poseable, Geared {
       TextureLoader loader = null;
       switch (id.substring("minecraft:".length())) {
         case "skull": {
-          // Reference: https://minecraft.gamepedia.com/Mob_head#Data_values
+          // Reference: https://minecraft.wiki/w/Mob_head#Data_values
           int type = item.get("type").asInt(3);
           switch (type) {
             case 0:


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.