### PR TITLE
Fix TIFF format export

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
@@ -24,7 +24,7 @@ import se.llbit.imageformats.tiff.TiffFileWriter;
 import se.llbit.util.TaskTracker;
 
 /**
- * TIFF with 32-bit color channels.
+ * TIFF with 32-bit floating point RGB channels.
  */
 public class Tiff32ExportFormat implements PictureExportFormat {
 
@@ -52,7 +52,7 @@ public class Tiff32ExportFormat implements PictureExportFormat {
   public void write(OutputStream out, Scene scene, TaskTracker taskTracker) throws IOException {
     try (TaskTracker.Task task = taskTracker.task("Writing TIFF");
         TiffFileWriter writer = new TiffFileWriter(out)) {
-      writer.write32(scene, task);
+      writer.export(scene, task);
     }
   }
 }


### PR DESCRIPTION
- fixes #1491
- make it easier to extend TIFF format in the future
- add lots of documentation
- add the Chunky version to software metadata
- add date/timestamp to metadata