### PR TITLE
Add sha256 support for library verification to the launcher and a flag to disable it.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
+++ b/chunky/src/java/se/llbit/chunky/main/CommandLineOptions.java
@@ -121,7 +121,9 @@ public class CommandLineOptions {
           "  --launcher            forces the launcher window to be displayed",
           "  --version             print the launcher version and exit",
           "  --verbose             verbose logging in the launcher",
-          "  --console             show the GUI console in headless mode");
+          "  --console             show the GUI console in headless mode",
+          "  --dangerouslyDisableLibraryValidation",
+          "                        disable library checksum validation (not recommended)");
 
   /**
    * True if any command line option provided was invalid.

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyDeployer.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyDeployer.java
@@ -98,7 +98,7 @@ public final class ChunkyDeployer {
           case INCOMPLETE_INFO:
             System.err.println("Missing library name or checksum");
             return false;
-          case MD5_MISMATCH:
+          case CHECKSUM_MISMATCH:
             System.err.println("Library MD5 checksum mismatch");
             return false;
           case MISSING:
@@ -473,7 +473,7 @@ public final class ChunkyDeployer {
       // Version not available!
       System.err.println("Found no installed Chunky version.");
       if (reportErrors) {
-        launcher.launcherError("No Chunky Available",
+        launcher.launcherError("No Chunky version available",
             "There is no local Chunky version installed. Please try updating.");
       }
       return false;
@@ -482,9 +482,9 @@ public final class ChunkyDeployer {
       // TODO: add a way to fix this (delete corrupt version and then update)!
       System.err.println("Version integrity check failed for version " + version.name);
       if (reportErrors) {
-        launcher.launcherError("Chunky Version is Corrupt",
+        launcher.launcherError("Chunky version is corrupt",
             "Version integrity check failed for version "
-            + version.name + ". Please select another version.");
+            + version.name + ". Please select another version or check for updates to repair it.");
       }
       return false;
     }

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -163,6 +163,10 @@ public class ChunkyLauncher {
                 System.err.println("This does not appear to be a 64-bit JVM.");
               }
               System.exit(is64Bit ? 0 : -1);
+            case "--dangerouslyDisableLibraryValidation":
+              System.out.println("Library validation is disabled.");
+              LauncherSettings.disableLibraryValidation = true;
+              break;
             default:
               if (!headlessOptions.isEmpty()) {
                 headlessOptions += " ";

--- a/launcher/src/se/llbit/chunky/launcher/VersionInfo.java
+++ b/launcher/src/se/llbit/chunky/launcher/VersionInfo.java
@@ -62,7 +62,6 @@ public class VersionInfo implements Comparable<VersionInfo> {
   }
 
   public static class Library {
-    private static final boolean DISABLE_CHECKSUM_CHECK = Boolean.parseBoolean(System.getProperty("chunky.dangerouslyDisableLibraryVerification", "false"));
     public final String name;
     public final String md5;
     public final String sha256;
@@ -90,14 +89,14 @@ public class VersionInfo implements Comparable<VersionInfo> {
     }
 
     public LibraryStatus testIntegrity(File libDir) {
-      if (name.isEmpty() || (!DISABLE_CHECKSUM_CHECK && md5.isEmpty() && sha256.isEmpty())) {
+      if (name.isEmpty() || (!LauncherSettings.disableLibraryValidation && md5.isEmpty() && sha256.isEmpty())) {
         return LibraryStatus.INCOMPLETE_INFO;
       }
       File library = new File(libDir, name);
       if (!library.isFile()) {
         return LibraryStatus.MISSING;
       }
-      if (!DISABLE_CHECKSUM_CHECK) {
+      if (!LauncherSettings.disableLibraryValidation) {
         if (!sha256.isEmpty()) {
           String libSha256 = Util.sha256sum(library);
           if (!libSha256.equalsIgnoreCase(sha256)) {

--- a/launcher/src/se/llbit/chunky/launcher/ui/UpdateDialogController.java
+++ b/launcher/src/se/llbit/chunky/launcher/ui/UpdateDialogController.java
@@ -123,7 +123,7 @@ public final class UpdateDialogController implements Initializable {
             case DOWNLOADED_OK:
               imageStream = getClass().getResourceAsStream("cached.png");
               break;
-            case MD5_MISMATCH:
+            case CHECKSUM_MISMATCH:
             case MISSING:
               imageStream = getClass().getResourceAsStream("refresh.png");
               break;

--- a/lib/src/se/llbit/chunky/launcher/LauncherSettings.java
+++ b/lib/src/se/llbit/chunky/launcher/LauncherSettings.java
@@ -40,6 +40,8 @@ public class LauncherSettings {
   static final ReleaseChannel SNAPSHOT_RELEASE_CHANNEL = new ReleaseChannel(
       "snapshot", "Snapshot", "snapshot.json", "Latest nightly snapshot of Chunky.");
 
+  public static boolean disableLibraryValidation = false;
+
   public int settingsRevision = 0;
 
   public String javaDir = "";

--- a/lib/src/se/llbit/util/Util.java
+++ b/lib/src/se/llbit/util/Util.java
@@ -60,7 +60,7 @@ public class Util {
   }
 
   /**
-   * @return the MD5 hash sum of the given file, in hexadecimal format.
+   * @return the SHA256 hash sum of the given file, in hexadecimal format.
    * Returns an error message if there was an error computing the checksum.
    */
   public static String sha256sum(File library) {

--- a/lib/src/se/llbit/util/Util.java
+++ b/lib/src/se/llbit/util/Util.java
@@ -44,7 +44,7 @@ public class Util {
     try {
       MessageDigest digest = MessageDigest.getInstance("MD5");
       try (FileInputStream in = new FileInputStream(library);
-          DigestInputStream dis = new DigestInputStream(in, digest)) {
+           DigestInputStream dis = new DigestInputStream(in, digest)) {
         byte[] buf = new byte[2048];
         int n;
         do {
@@ -56,6 +56,29 @@ public class Util {
       }
     } catch (NoSuchAlgorithmException e) {
       return "md5 compute error: " + e.getMessage();
+    }
+  }
+
+  /**
+   * @return the MD5 hash sum of the given file, in hexadecimal format.
+   * Returns an error message if there was an error computing the checksum.
+   */
+  public static String sha256sum(File library) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (FileInputStream in = new FileInputStream(library);
+           DigestInputStream dis = new DigestInputStream(in, digest)) {
+        byte[] buf = new byte[2048];
+        int n;
+        do {
+          n = dis.read(buf);
+        } while (n != -1);
+        return byteArrayToHexString(digest.digest());
+      } catch (IOException e) {
+        return "sha256 compute error: " + e.getMessage();
+      }
+    } catch (NoSuchAlgorithmException e) {
+      return "sha256 compute error: " + e.getMessage();
     }
   }
 

--- a/releasetools/src/releasetools/ReleaseBuilder.java
+++ b/releasetools/src/releasetools/ReleaseBuilder.java
@@ -161,6 +161,7 @@ public class ReleaseBuilder {
     JsonObject library = new JsonObject();
     library.add("name", lib.getName());
     library.add("md5", Util.md5sum(lib));
+    library.add("sha256", Util.sha256sum(lib));
     library.add("size", (int) Math.min(Integer.MAX_VALUE, lib.length()));
     return library;
   }


### PR DESCRIPTION
It's 2023 and md5 is basically broken. This PR adds sha256 verification support. The `latest.json` for Chunky 2.4.5 on my server already contains the sha256 hashes.

Using `--dangerouslyDisableLibraryValidation`, checksum validation of libraries can now be disabled. This is a potential security issue and thus not recommended. It does help with local debugging and sharing custom Chunky versions though. Closes #1509