### PR TITLE
22w42a (crafter) and 22w43a (copper & tuff additions)

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -1,6 +1,5 @@
 package se.llbit.chunky.block;
 
-import org.w3c.dom.Text;
 import se.llbit.chunky.block.minecraft.Comparator;
 import se.llbit.chunky.block.minecraft.Observer;
 import se.llbit.chunky.block.minecraft.Tripwire;
@@ -8,7 +7,6 @@ import se.llbit.chunky.block.minecraft.*;
 import se.llbit.chunky.entity.SkullEntity;
 import se.llbit.chunky.model.minecraft.FlowerPotModel;
 import se.llbit.chunky.model.minecraft.FlowerPotModel.Kind;
-import se.llbit.chunky.resources.EntityTexture;
 import se.llbit.chunky.resources.ShulkerTexture;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.world.BlockData;

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.block;
 
+import org.w3c.dom.Text;
 import se.llbit.chunky.block.minecraft.Comparator;
 import se.llbit.chunky.block.minecraft.Observer;
 import se.llbit.chunky.block.minecraft.Tripwire;
@@ -1005,7 +1006,6 @@ public class MinecraftBlockProvider implements BlockProvider {
     addBlock("bamboo_mosaic_slab", (name, tag) -> slab(tag, Texture.bambooMosaic));
     addBlock("bamboo_mosaic_stairs", (name, tag) -> stairs(tag, Texture.bambooMosaic));
     addBlock("bamboo_trapdoor", (name, tag) -> trapdoor(tag, Texture.bambooTrapdoor));
-
     addBlock("cherry_button", (name, tag) -> button(tag, Texture.cherryPlanks));
     addBlock("cherry_door", (name, tag) -> door(tag, Texture.cherryDoorTop, Texture.cherryDoorBottom));
     addBlock("cherry_fence", (name, tag) -> fence(tag, Texture.cherryPlanks));
@@ -1074,6 +1074,51 @@ public class MinecraftBlockProvider implements BlockProvider {
     addBlock("bamboo_wall_hanging_sign", (name, tag) -> wallHangingSign(tag, "bamboo"));
     addBlock("cherry_hanging_sign", (name, tag) -> hangingSign(tag, "cherry"));
     addBlock("cherry_wall_hanging_sign", (name, tag) -> wallHangingSign(tag, "cherry"));
+
+    //1.21
+    addBlock("tuff_slab", (name, tag) -> slab(tag, Texture.tuff));
+    addBlock("tuff_stairs", (name, tag) -> stairs(tag, Texture.tuff));
+    addBlock("tuff_wall", (name, tag) -> wall(tag, Texture.tuff));
+    addBlock("polished_tuff", Texture.polishedTuff);
+    addBlock("polished_tuff_slab", (name, tag) -> slab(tag, Texture.polishedTuff));
+    addBlock("polished_tuff_stairs", (name, tag) -> stairs(tag, Texture.polishedTuff));
+    addBlock("polished_tuff_wall", (name, tag) -> wall(tag, Texture.polishedTuff));
+    addBlock("tuff_bricks", Texture.tuffBricks);
+    addBlock("tuff_brick_slab", (name, tag) -> slab(tag, Texture.tuffBricks));
+    addBlock("tuff_brick_stairs", (name, tag) -> stairs(tag, Texture.tuffBricks));
+    addBlock("tuff_brick_wall", (name, tag) -> wall(tag, Texture.tuffBricks));
+    addBlock("chiseled_tuff", Texture.chiseledTuff);
+    addBlock("chiseled_tuff_bricks", Texture.chiseledTuffBricks);
+    for(String s : new String[]{"", "waxed_"}) {
+      addBlock(s + "chiseled_copper", Texture.chiseledCopper);
+      addBlock(s + "copper_grate", (name, tag) -> new SolidNonOpaqueBlock(name, Texture.copperGrate));
+      addBlock(s + "copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
+        Texture.copperBulbLitPowered, Texture.copperBulbLit, Texture.copperBulbPowered, Texture.copperBulb));
+      addBlock(s + "copper_door", (name, tag) -> door(tag, Texture.copperDoorTop, Texture.copperDoorBottom));
+      addBlock(s + "copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.copperTrapdoor));
+      addBlock(s + "exposed_chiseled_copper", Texture.exposedChiseledCopper);
+      addBlock(s + "exposed_copper_grate", Texture.exposedCopperGrate);
+      addBlock(s + "exposed_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
+        Texture.exposedCopperBulbLitPowered, Texture.exposedCopperBulbLit, Texture.exposedCopperBulbPowered, Texture.exposedCopperBulb));
+      addBlock(s + "exposed_copper_door", (name, tag) -> door(tag, Texture.exposedCopperDoorTop, Texture.exposedCopperDoorBottom));
+      addBlock(s + "exposed_copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.exposedCopperTrapdoor));
+      addBlock(s + "weathered_chiseled_copper", Texture.weatheredChiseledCopper);
+      addBlock(s + "weathered_copper_grate", Texture.weatheredCopperGrate);
+      addBlock(s + "weathered_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
+        Texture.weatheredCopperBulbLitPowered, Texture.weatheredCopperBulbLit, Texture.weatheredCopperBulbPowered, Texture.weatheredCopperBulb));
+      addBlock(s + "weathered_copper_door", (name, tag) -> door(tag, Texture.weatheredCopperDoorTop, Texture.weatheredCopperDoorBottom));
+      addBlock(s + "weathered_copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.weatheredCopperTrapdoor));
+      addBlock(s + "oxidized_chiseled_copper", Texture.oxidizedChiseledCopper);
+      addBlock(s + "oxidized_copper_grate", Texture.oxidizedCopperGrate);
+      addBlock(s + "oxidized_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
+        Texture.oxidizedCopperBulbLitPowered, Texture.oxidizedCopperBulbLit, Texture.oxidizedCopperBulbPowered, Texture.oxidizedCopperBulb));
+      addBlock(s + "oxidized_copper_door", (name, tag) -> door(tag, Texture.oxidizedCopperDoorTop, Texture.oxidizedCopperDoorBottom));
+      addBlock(s + "oxidized_copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.oxidizedCopperTrapdoor));
+    }
+    addBlock("crafter", (name, tag) -> new Crafter(name, tag.get("Properties").get("orientation").stringValue(), tag.get("Properties").get("crafting").stringValue().equals("true"), tag.get("Properties").get("triggered").stringValue().equals("true"),
+      Texture.crafterNorth, Texture.crafterNorthCrafting, Texture.crafterEast, Texture.crafterEastCrafting, Texture.crafterEastTriggered,
+      Texture.crafterSouth, Texture.crafterSouthTriggered, Texture.crafterWest, Texture.crafterWestCrafting, Texture.crafterWestTriggered,
+      Texture.crafterTop, Texture.crafterTopCrafting, Texture.crafterTopTriggered, Texture.crafterBottom));
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/SolidNonOpaqueBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/SolidNonOpaqueBlock.java
@@ -1,0 +1,12 @@
+package se.llbit.chunky.block;
+
+import se.llbit.chunky.resources.Texture;
+
+public class SolidNonOpaqueBlock extends Block {
+
+  public SolidNonOpaqueBlock(String name, Texture texture) {
+    super(name, texture);
+    solid = true;
+    opaque = false;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CopperBulb.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CopperBulb.java
@@ -22,16 +22,23 @@ import se.llbit.chunky.block.MinecraftBlock;
 import se.llbit.chunky.resources.Texture;
 
 public class CopperBulb extends MinecraftBlock {
-  public final boolean isLit;
-  public final boolean isPowered;
+  private final boolean lit;
+  private final boolean powered;
 
   public CopperBulb(String name, boolean lit, boolean powered, Texture lp, Texture lnp, Texture nlp, Texture nlnp) {
     super(name, lit ? (powered ? lp : lnp) : (powered ? nlp : nlnp));
-    this.isLit = lit;
-    this.isPowered = powered;
+    this.lit = lit;
+    this.powered = powered;
+  }
+  public boolean isLit() {
+    return lit;
+  }
+
+  public boolean isPowered() {
+    return powered;
   }
 
   @Override public String description() {
-    return "lit=" + isLit + ", powered=" + isPowered;
+    return "lit=" + lit + ", powered=" + powered;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/CopperBulb.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/CopperBulb.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.block.minecraft;
+
+import se.llbit.chunky.block.MinecraftBlock;
+import se.llbit.chunky.resources.Texture;
+
+public class CopperBulb extends MinecraftBlock {
+  public final boolean isLit;
+  public final boolean isPowered;
+
+  public CopperBulb(String name, boolean lit, boolean powered, Texture lp, Texture lnp, Texture nlp, Texture nlnp) {
+    super(name, lit ? (powered ? lp : lnp) : (powered ? nlp : nlnp));
+    this.isLit = lit;
+    this.isPowered = powered;
+  }
+
+  @Override public String description() {
+    return "lit=" + isLit + ", powered=" + isPowered;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Crafter.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Crafter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyeast (c) 2023 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.block.minecraft;
+
+import se.llbit.chunky.block.AbstractModelBlock;
+import se.llbit.chunky.model.RotatableBlockModel;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+public class Crafter extends AbstractModelBlock {
+
+  private final String description;
+
+  public Crafter(String name, String orientation, boolean crafting, boolean triggered, Texture north, Texture northCrafting, Texture east, Texture eastCrafting, Texture eastTriggered,
+                 Texture south, Texture southTriggered, Texture west, Texture westCrafting, Texture westTriggered, Texture top, Texture topCrafting, Texture topTriggered, Texture bottom) {
+    super(name, north);
+    this.description = "orientation=" + orientation + ", crafting=" + crafting + ", triggered=" + triggered;
+    RotatableBlockModel m = new RotatableBlockModel(crafting ? northCrafting : north,
+      crafting ? eastCrafting : (triggered ? eastTriggered : east),
+      triggered ? southTriggered : south,
+      crafting ? westCrafting : (triggered ? westTriggered : west),
+      crafting ? topCrafting : (triggered ? topTriggered : top),
+      bottom);
+    // Fix top quad
+    m.setFaceQuad(4, new Quad(
+      new Vector3(1, 1, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(1, 1, 1),
+      new Vector4(1, 0, 0, 1))); // texture is mirrored for some reason??
+    switch(orientation) {
+      case "north_up":
+        break;
+      case "east_up":
+        m.rotateY(1);
+        break;
+      case "south_up":
+        m.rotateY(2);
+        break;
+      case "west_up":
+        m.rotateY(-1);
+        break;
+      case "up_south":
+        m.rotateX(1);
+        break;
+      case "up_west":
+        m.rotateX(1);
+        m.rotateY(1);
+        break;
+      case "up_north":
+        m.rotateX(1);
+        m.rotateY(2);
+        break;
+      case "up_east":
+        m.rotateX(1);
+        m.rotateY(-1);
+        break;
+      case "down_north":
+        m.rotateX(-1);
+        break;
+      case "down_east":
+        m.rotateX(-1);
+        m.rotateY(1);
+        break;
+      case "down_south":
+        m.rotateX(-1);
+        m.rotateY(2);
+        break;
+      case "down_west":
+        m.rotateX(-1);
+        m.rotateY(-1);
+        break;
+    }
+    this.model = m;
+    opaque = true;
+    solid = true;
+  }
+
+  @Override
+  public String description() {
+    return description;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneLamp.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneLamp.java
@@ -22,14 +22,18 @@ import se.llbit.chunky.block.MinecraftBlock;
 import se.llbit.chunky.resources.Texture;
 
 public class RedstoneLamp extends MinecraftBlock {
-  public final boolean isLit;
+  private final boolean lit;
 
   public RedstoneLamp(boolean lit) {
     super("redstone_lamp", lit ? Texture.redstoneLampOn : Texture.redstoneLampOff);
-    this.isLit = lit;
+    this.lit = lit;
+  }
+
+  public boolean isLit() {
+    return lit;
   }
 
   @Override public String description() {
-    return "lit=" + isLit;
+    return "lit=" + lit;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -381,7 +381,7 @@ public class BlockPalette {
       block.ior = 1.52f;
     });
     materialProperties.put("minecraft:redstone_lamp", block -> {
-      if (block instanceof RedstoneLamp && ((RedstoneLamp) block).isLit) {
+      if (block instanceof RedstoneLamp && ((RedstoneLamp) block).isLit()) {
         block.emittance = 1.0f;
       }
     });
@@ -582,22 +582,22 @@ public class BlockPalette {
     });
     for(String s : new String[]{"minecraft:", "minecraft:waxed_"}) {
       materialProperties.put(s + "copper_bulb", block -> {
-        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit()) {
           block.emittance = 1.0f;
         }
       });
       materialProperties.put(s + "exposed_copper_bulb", block -> {
-        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit()) {
           block.emittance = 12 / 15f;
         }
       });
       materialProperties.put(s + "weathered_copper_bulb", block -> {
-        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit()) {
           block.emittance = 8 / 15f;
         }
       });
       materialProperties.put(s + "oxidized_copper_bulb", block -> {
-        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit()) {
           block.emittance = 4 / 15f;
         }
       });

--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.chunk;
 import se.llbit.chunky.block.*;
 import se.llbit.chunky.block.minecraft.*;
 import se.llbit.chunky.plugin.PluginApi;
+import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Octree;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.IntTag;
@@ -480,42 +481,46 @@ public class BlockPalette {
       block.metalness = 1.0f;
       block.setPerceptualSmoothness(0.75);
     };
-    Consumer<Block> lightlyWeatheredCopperConfig = block -> {
+    Consumer<Block> exposedCopperConfig = block -> {
       block.metalness = 0.66f;
       block.setPerceptualSmoothness(0.75);
     };
-    Consumer<Block> semiWeatheredCopperConfig = block -> {
+    Consumer<Block> weatheredCopperConfig = block -> {
       block.metalness = 0.66f;
       block.setPerceptualSmoothness(0.75);
     };
-    materialProperties.put("minecraft:copper_block", copperConfig);
     materialProperties.put("minecraft:raw_copper_block", block -> {
       block.metalness = 0.66f;
       block.setPerceptualSmoothness(0.5);
     });
-    materialProperties.put("minecraft:exposed_copper", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:weathered_copper", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:cut_copper", copperConfig);
-    materialProperties.put("minecraft:exposed_cut_copper", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:weathered_cut_copper", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:cut_copper_stairs", copperConfig);
-    materialProperties.put("minecraft:exposed_cut_copper_stairs", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:weathered_cut_copper_stairs", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:cut_copper_slab", copperConfig);
-    materialProperties.put("minecraft:exposed_cut_copper_slab", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:weathered_cut_copper_slab", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_copper_block", copperConfig);
-    materialProperties.put("minecraft:waxed_exposed_copper", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_weathered_copper", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_cut_copper", copperConfig);
-    materialProperties.put("minecraft:waxed_exposed_cut_copper", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_weathered_cut_copper", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_cut_copper_stairs", copperConfig);
-    materialProperties.put("minecraft:waxed_exposed_cut_copper_stairs", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_weathered_cut_copper_stairs", semiWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_cut_copper_slab", copperConfig);
-    materialProperties.put("minecraft:waxed_exposed_cut_copper_slab", lightlyWeatheredCopperConfig);
-    materialProperties.put("minecraft:waxed_weathered_cut_copper_slab", semiWeatheredCopperConfig);
+    for(String s : new String[]{"minecraft:", "minecraft:waxed_"}) {
+      materialProperties.put(s + "copper_block", copperConfig);
+      materialProperties.put(s + "cut_copper", copperConfig);
+      materialProperties.put(s + "cut_copper_stairs", copperConfig);
+      materialProperties.put(s + "cut_copper_slab", copperConfig);
+      materialProperties.put(s + "chiseled_copper", copperConfig);
+      materialProperties.put(s + "copper_grate", copperConfig);
+      materialProperties.put(s + "copper_door", copperConfig);
+      materialProperties.put(s + "copper_trapdoor", copperConfig);
+      
+      materialProperties.put(s + "exposed_copper", exposedCopperConfig);
+      materialProperties.put(s + "exposed_cut_copper", exposedCopperConfig);
+      materialProperties.put(s + "exposed_cut_copper_stairs", exposedCopperConfig);
+      materialProperties.put(s + "exposed_cut_copper_slab", exposedCopperConfig);
+      materialProperties.put(s + "exposed_chiseled_copper", exposedCopperConfig);
+      materialProperties.put(s + "exposed_copper_grate", exposedCopperConfig);
+      materialProperties.put(s + "exposed_copper_door", exposedCopperConfig);
+      materialProperties.put(s + "exposed_copper_trapdoor", exposedCopperConfig);
+
+      materialProperties.put(s + "weathered_copper", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_cut_copper", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_cut_copper_stairs", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_cut_copper_slab", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_chiseled_copper", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_copper_grate", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_copper_door", weatheredCopperConfig);
+      materialProperties.put(s + "weathered_copper_trapdoor", weatheredCopperConfig);
+    }
     materialProperties.put("minecraft:lightning_rod", block -> {
       // apply copper attributes only to non-powered lightning rods
       if (block instanceof LightningRod && !((LightningRod) block).isPowered()) {
@@ -575,6 +580,28 @@ public class BlockPalette {
     materialProperties.put("minecraft:sculk_catalyst", block -> {
       block.emittance = 1.0f / 15f * 6;
     });
+    for(String s : new String[]{"minecraft:", "minecraft:waxed_"}) {
+      materialProperties.put(s + "copper_bulb", block -> {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+          block.emittance = 1.0f;
+        }
+      });
+      materialProperties.put(s + "exposed_copper_bulb", block -> {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+          block.emittance = 12 / 15f;
+        }
+      });
+      materialProperties.put(s + "weathered_copper_bulb", block -> {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+          block.emittance = 8 / 15f;
+        }
+      });
+      materialProperties.put(s + "oxidized_copper_bulb", block -> {
+        if(block instanceof CopperBulb && ((CopperBulb) block).isLit) {
+          block.emittance = 4 / 15f;
+        }
+      });
+    }
     return materialProperties;
   }
 

--- a/chunky/src/java/se/llbit/chunky/model/Model.java
+++ b/chunky/src/java/se/llbit/chunky/model/Model.java
@@ -169,6 +169,18 @@ public class Model {
 
   /**
    * @param src source quads
+   * @return Quads rotated about the negative Z axis
+   */
+  public static Quad[] rotateNegZ(Quad[] src) {
+    Quad[] rot = new Quad[src.length];
+    for (int i = 0; i < src.length; ++i) {
+      rot[i] = src[i].transform(Transform.NONE.rotateNegZ());
+    }
+    return rot;
+  }
+
+  /**
+   * @param src source quads
    * @return Quads rotated about the Z axis by some angle
    */
   public static Quad[] rotateZ(Quad[] src, double angle) {

--- a/chunky/src/java/se/llbit/chunky/model/RotatableBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/RotatableBlockModel.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2016 Jesper Öqvist <jesper@llbit.se>
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.model;
+
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+/**
+ * This block model is used to render blocks which can face east, west, north, south, up and down.
+ * For example, command blocks and observer blocks.
+ */
+public class RotatableBlockModel extends QuadModel {
+  // Facing up:
+  private Quad[] quads = new Quad[] {
+    FULL_BLOCK_NORTH_SIDE,
+    FULL_BLOCK_EAST_SIDE,
+    FULL_BLOCK_SOUTH_SIDE,
+    FULL_BLOCK_WEST_SIDE,
+    FULL_BLOCK_TOP_SIDE,
+    FULL_BLOCK_BOTTOM_SIDE
+  };
+  private final Texture[] textures;
+
+  public RotatableBlockModel(Texture north, Texture east, Texture south, Texture west, Texture top, Texture bottom) {
+    textures = new Texture[] {north, east, south, west, top, bottom};
+  }
+
+  public void setFaceQuad(int face, Quad quad) {
+    quads[face] = quad;
+  }
+
+  public void rotateX(int r) {
+    r %= 4;
+    if(r < 0) {
+      r += 4;
+    }
+    switch(r) {
+      case 1:
+        quads = Model.rotateX(quads);
+        break;
+      case 2:
+        quads = Model.rotateX(Model.rotateX(quads));
+        break;
+      case 3:
+        quads = Model.rotateNegX(quads);
+        break;
+    }
+  }
+
+  public void rotateY(int r) {
+    r %= 4;
+    if(r < 0) {
+      r += 4;
+    }
+    switch(r) {
+      case 1:
+        System.out.println("ry1");
+        quads = Model.rotateY(quads);
+        break;
+      case 2:
+        quads = Model.rotateY(Model.rotateY(quads));
+        break;
+      case 3:
+        quads = Model.rotateNegY(quads);
+        break;
+    }
+  }
+
+  public void rotateZ(int r) {
+    r %= 4;
+    if(r < 0) {
+      r += 4;
+    }
+    switch(r) {
+      case 1:
+        quads = Model.rotateZ(quads);
+        break;
+      case 2:
+        quads = Model.rotateZ(Model.rotateZ(quads));
+        break;
+      case 3:
+        quads = Model.rotateNegZ(quads);
+        break;
+    }
+  }
+
+  @Override
+  public Quad[] getQuads() {
+    return quads;
+  }
+
+  @Override
+  public Texture[] getTextures() {
+    return textures;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/RotatableBlockModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/RotatableBlockModel.java
@@ -27,7 +27,6 @@ import se.llbit.math.Vector4;
  * For example, command blocks and observer blocks.
  */
 public class RotatableBlockModel extends QuadModel {
-  // Facing up:
   private Quad[] quads = new Quad[] {
     FULL_BLOCK_NORTH_SIDE,
     FULL_BLOCK_EAST_SIDE,
@@ -71,7 +70,6 @@ public class RotatableBlockModel extends QuadModel {
     }
     switch(r) {
       case 1:
-        System.out.println("ry1");
         quads = Model.rotateY(quads);
         break;
       case 2:

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1341,6 +1341,117 @@ public class Texture {
   public static final Texture cherryHangingSign = new Texture();
   @TexturePath("assets/minecraft/textures/entity/piglin/piglin")
   public static final Texture piglin = new Texture();
+  @TexturePath("assets/minecraft/textures/block/polished_tuff")
+  public static final Texture polishedTuff = new Texture();
+  @TexturePath("assets/minecraft/textures/block/tuff_bricks")
+  public static final Texture tuffBricks = new Texture();
+  @TexturePath("assets/minecraft/textures/block/chiseled_tuff")
+  public static final Texture chiseledTuff = new Texture();
+  @TexturePath("assets/minecraft/textures/block/chiseled_tuff_bricks")
+  public static final Texture chiseledTuffBricks = new Texture();
+  @TexturePath("assets/minecraft/textures/block/chiseled_copper")
+  public static final Texture chiseledCopper = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_grate")
+  public static final Texture copperGrate = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_bulb")
+  public static final Texture copperBulb = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_bulb_lit")
+  public static final Texture copperBulbLit = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_bulb_powered")
+  public static final Texture copperBulbPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_bulb_lit_powered")
+  public static final Texture copperBulbLitPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_door_top")
+  public static final Texture copperDoorTop = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_door_bottom")
+  public static final Texture copperDoorBottom = new Texture();
+  @TexturePath("assets/minecraft/textures/block/copper_trapdoor")
+  public static final Texture copperTrapdoor = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_chiseled_copper")
+  public static final Texture exposedChiseledCopper = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_grate")
+  public static final Texture exposedCopperGrate = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_bulb")
+  public static final Texture exposedCopperBulb = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_bulb_lit")
+  public static final Texture exposedCopperBulbLit = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_bulb_powered")
+  public static final Texture exposedCopperBulbPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_bulb_lit_powered")
+  public static final Texture exposedCopperBulbLitPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_door_top")
+  public static final Texture exposedCopperDoorTop = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_door_bottom")
+  public static final Texture exposedCopperDoorBottom = new Texture();
+  @TexturePath("assets/minecraft/textures/block/exposed_copper_trapdoor")
+  public static final Texture exposedCopperTrapdoor = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_chiseled_copper")
+  public static final Texture weatheredChiseledCopper = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_grate")
+  public static final Texture weatheredCopperGrate = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_bulb")
+  public static final Texture weatheredCopperBulb = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_bulb_lit")
+  public static final Texture weatheredCopperBulbLit = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_bulb_powered")
+  public static final Texture weatheredCopperBulbPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_bulb_lit_powered")
+  public static final Texture weatheredCopperBulbLitPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_door_top")
+  public static final Texture weatheredCopperDoorTop = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_door_bottom")
+  public static final Texture weatheredCopperDoorBottom = new Texture();
+  @TexturePath("assets/minecraft/textures/block/weathered_copper_trapdoor")
+  public static final Texture weatheredCopperTrapdoor = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_chiseled_copper")
+  public static final Texture oxidizedChiseledCopper = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_grate")
+  public static final Texture oxidizedCopperGrate = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_bulb")
+  public static final Texture oxidizedCopperBulb = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_bulb_lit")
+  public static final Texture oxidizedCopperBulbLit = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_bulb_powered")
+  public static final Texture oxidizedCopperBulbPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_bulb_lit_powered")
+  public static final Texture oxidizedCopperBulbLitPowered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_door_top")
+  public static final Texture oxidizedCopperDoorTop = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_door_bottom")
+  public static final Texture oxidizedCopperDoorBottom = new Texture();
+  @TexturePath("assets/minecraft/textures/block/oxidized_copper_trapdoor")
+  public static final Texture oxidizedCopperTrapdoor = new Texture();
+  //      Texture.crafterNorth, Texture.crafterNorthCrafting, Texture.crafterEast, Texture.crafterEastCrafting, Texture.crafterEastTriggered,
+  //      Texture.crafterSouth, Texture.crafterSouthTriggered, Texture.crafterWest, Texture.crafterWestCrafting, Texture.crafterWestTriggered,
+  //      Texture.crafterTop, Texture.crafterTopCrafting, Texture.crafterTopTriggered, Texture.crafterBottom));
+  @TexturePath("assets/minecraft/textures/block/crafter_north")
+  public static final Texture crafterNorth = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_north_crafting")
+  public static final Texture crafterNorthCrafting = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_east")
+  public static final Texture crafterEast = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_east_crafting")
+  public static final Texture crafterEastCrafting = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_east_triggered")
+  public static final Texture crafterEastTriggered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_south")
+  public static final Texture crafterSouth = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_south_triggered")
+  public static final Texture crafterSouthTriggered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_west")
+  public static final Texture crafterWest = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_west_crafting")
+  public static final Texture crafterWestCrafting = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_west_triggered")
+  public static final Texture crafterWestTriggered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_top")
+  public static final Texture crafterTop = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_top_crafting")
+  public static final Texture crafterTopCrafting = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_top_triggered")
+  public static final Texture crafterTopTriggered = new Texture();
+  @TexturePath("assets/minecraft/textures/block/crafter_bottom")
+  public static final Texture crafterBottom = new Texture();
 
   /** Banner base texture. */
   public static final Texture bannerBase = new Texture();

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1421,9 +1421,6 @@ public class Texture {
   public static final Texture oxidizedCopperDoorBottom = new Texture();
   @TexturePath("assets/minecraft/textures/block/oxidized_copper_trapdoor")
   public static final Texture oxidizedCopperTrapdoor = new Texture();
-  //      Texture.crafterNorth, Texture.crafterNorthCrafting, Texture.crafterEast, Texture.crafterEastCrafting, Texture.crafterEastTriggered,
-  //      Texture.crafterSouth, Texture.crafterSouthTriggered, Texture.crafterWest, Texture.crafterWestCrafting, Texture.crafterWestTriggered,
-  //      Texture.crafterTop, Texture.crafterTopCrafting, Texture.crafterTopTriggered, Texture.crafterBottom));
   @TexturePath("assets/minecraft/textures/block/crafter_north")
   public static final Texture crafterNorth = new Texture();
   @TexturePath("assets/minecraft/textures/block/crafter_north_crafting")


### PR DESCRIPTION
This PR adds support for the additions in Minecraft snapshots 22w42a and 22w43a. These include:

**22w42a**
- the Crafter, with its `crafting` and `triggered` block states as well as 12 different orientations

**22w43a**
- Copper doors and trapdoors
- Chiseled copper and copper grate blocks
- Copper bulbs, a light source which acts as a flip-flop and has `lit` and `powered` block states
- All waxed and oxidized variants of the new copper blocks
- Tuff stairs, slabs, and walls
- Tuff bricks, with stair, slab, and wall variants
- Polished tuff, with stair, slab, and wall variants
- Chiseled tuff and tuff bricks

The built-in material defaults have been updated to give copper-like properties to the new copper blocks and the proper emittance values for the copper bulbs, which decreases from 15 to 12 to 8 to 4 as the bulb oxidizes.

![23w43a-2500 denoised](https://github.com/chunky-dev/chunky/assets/46458276/ded4d643-4bc3-470a-9eb9-afea99854b4f)
![2023-10-26_01 34 53](https://github.com/chunky-dev/chunky/assets/46458276/aa3ab40b-6d02-4450-b3ce-c77f909ee73b)

