### PR TITLE
TIFF alpha channel

### DIFF
--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -320,7 +320,7 @@ public class Chunky {
           System.err.println("Failed to load the dump file found for this scene");
           return 1;
         }
-        PictureExportFormat outputMode = scene.getOutputMode();
+        PictureExportFormat outputMode = scene.getPictureExportFormat();
         if (options.imageOutputFile.isEmpty()) {
           options.imageOutputFile = String
               .format("%s-%d%s", scene.name(), scene.spp, outputMode.getExtension());

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PfmExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PfmExportFormat.java
@@ -44,11 +44,6 @@ public class PfmExportFormat implements PictureExportFormat {
   }
 
   @Override
-  public boolean isTransparencySupported() {
-    return false;
-  }
-
-  @Override
   public void write(OutputStream out, Scene scene, TaskTracker taskTracker) throws IOException {
     try (TaskTracker.Task task = taskTracker.task("Writing PFM rows", scene.canvasHeight());
         PfmFileWriter writer = new PfmFileWriter(out)) {

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
@@ -53,7 +53,7 @@ public interface PictureExportFormat {
 
   /**
    * @return true, if this export format supports exporting the alpha channel
-   * @deprecated Replaced by {@link #transparencyType()} and usage of {@link AlphaBuffer}
+   * @deprecated Replaced by {@link #getTransparencyType()} and usage of {@link AlphaBuffer}
    */
   @Deprecated(forRemoval = true)
   default boolean isTransparencySupported() {
@@ -65,7 +65,7 @@ public interface PictureExportFormat {
    *
    * @return the required format for the alpha buffer or {@link AlphaBuffer.Type#UNSUPPORTED} if alpha is not supported.
    */
-  default AlphaBuffer.Type transparencyType() {
+  default AlphaBuffer.Type getTransparencyType() {
     return isTransparencySupported() ? AlphaBuffer.Type.UINT8 : AlphaBuffer.Type.UNSUPPORTED;
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
@@ -54,10 +54,10 @@ public interface PictureExportFormat {
   /**
    * Note: It depends on the scene settings if the alpha buffer will be available on export.
    *
-   * @return the required format for the alpha buffer or DISABLED if alpha is not supported.
+   * @return the required format for the alpha buffer or {@link AlphaBuffer.Type#UNSUPPORTED} if alpha is not supported.
    */
   default AlphaBuffer.Type transparencyType() {
-    return AlphaBuffer.Type.DISABLED;
+    return AlphaBuffer.Type.UNSUPPORTED;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
@@ -18,6 +18,8 @@ package se.llbit.chunky.renderer.export;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
+import se.llbit.chunky.renderer.scene.AlphaBuffer;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.TaskTracker;
 
@@ -50,12 +52,20 @@ public interface PictureExportFormat {
   String getExtension();
 
   /**
-   * Check if this format supports transparency (used for transparent sky).
+   * Note: It depends on the scene settings if the alpha buffer will be available on export.
    *
-   * @return True if this format supports transparency, false otherwise
+   * @return the required format for the alpha buffer or DISABLED if alpha is not supported.
    */
-  default boolean isTransparencySupported() {
-    return false;
+  default AlphaBuffer.Type transparencyType() {
+    return AlphaBuffer.Type.DISABLED;
+  }
+
+  /**
+   * @return true, if the export formats wants preprocessed buffer data<br>
+   *         false, if the export format uses the unprocessed sampling data
+   */
+  default boolean wantsPostprocessing() {
+    return true;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PictureExportFormat.java
@@ -52,12 +52,21 @@ public interface PictureExportFormat {
   String getExtension();
 
   /**
+   * @return true, if this export format supports exporting the alpha channel
+   * @deprecated Replaced by {@link #transparencyType()} and usage of {@link AlphaBuffer}
+   */
+  @Deprecated(forRemoval = true)
+  default boolean isTransparencySupported() {
+    return false;
+  }
+
+  /**
    * Note: It depends on the scene settings if the alpha buffer will be available on export.
    *
    * @return the required format for the alpha buffer or {@link AlphaBuffer.Type#UNSUPPORTED} if alpha is not supported.
    */
   default AlphaBuffer.Type transparencyType() {
-    return AlphaBuffer.Type.UNSUPPORTED;
+    return isTransparencySupported() ? AlphaBuffer.Type.UINT8 : AlphaBuffer.Type.UNSUPPORTED;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PngExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PngExportFormat.java
@@ -43,7 +43,7 @@ public class PngExportFormat implements PictureExportFormat {
   }
 
   @Override
-  public AlphaBuffer.Type transparencyType() {
+  public AlphaBuffer.Type getTransparencyType() {
     return AlphaBuffer.Type.UINT8;
   }
 
@@ -53,7 +53,7 @@ public class PngExportFormat implements PictureExportFormat {
         PngFileWriter writer = new PngFileWriter(out)) {
       BitmapImage backBuffer = scene.getBackBuffer();
       AlphaBuffer alpha = scene.getAlphaBuffer();
-      if (alpha.getType() == transparencyType()) {
+      if (alpha.getType() == getTransparencyType()) {
         writer.write(backBuffer.data, alpha.getBuffer(), scene.canvasWidth(), scene.canvasHeight(), task);
       } else {
         writer.write(backBuffer.data, scene.canvasWidth(), scene.canvasHeight(), task);

--- a/chunky/src/java/se/llbit/chunky/renderer/export/PngExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/PngExportFormat.java
@@ -20,6 +20,7 @@ package se.llbit.chunky.renderer.export;
 import java.io.IOException;
 import java.io.OutputStream;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
+import se.llbit.chunky.renderer.scene.AlphaBuffer;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.imageformats.png.ITXT;
@@ -42,8 +43,8 @@ public class PngExportFormat implements PictureExportFormat {
   }
 
   @Override
-  public boolean isTransparencySupported() {
-    return true;
+  public AlphaBuffer.Type transparencyType() {
+    return AlphaBuffer.Type.UINT8;
   }
 
   @Override
@@ -51,9 +52,9 @@ public class PngExportFormat implements PictureExportFormat {
     try (TaskTracker.Task task = taskTracker.task("Writing PNG");
         PngFileWriter writer = new PngFileWriter(out)) {
       BitmapImage backBuffer = scene.getBackBuffer();
-      if (scene.transparentSky()) {
-        writer.write(backBuffer.data, scene.getAlphaChannel(), scene.canvasWidth(),
-            scene.canvasHeight(), task);
+      AlphaBuffer alpha = scene.getAlphaBuffer();
+      if (alpha.getType() == transparencyType()) {
+        writer.write(backBuffer.data, alpha.getBuffer(), scene.canvasWidth(), scene.canvasHeight(), task);
       } else {
         writer.write(backBuffer.data, scene.canvasWidth(), scene.canvasHeight(), task);
       }

--- a/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import se.llbit.chunky.renderer.scene.AlphaBuffer;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.imageformats.tiff.CompressionType;
 import se.llbit.imageformats.tiff.TiffFileWriter;
@@ -53,7 +54,7 @@ public class Tiff32ExportFormat implements PictureExportFormat {
   }
 
   @Override
-  public boolean isTransparencySupported() {
+  public boolean wantsPostprocessing() {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
@@ -54,7 +54,7 @@ public class Tiff32ExportFormat implements PictureExportFormat {
   }
 
   @Override
-  public AlphaBuffer.Type transparencyType() {
+  public AlphaBuffer.Type getTransparencyType() {
     return AlphaBuffer.Type.FP32;
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/export/Tiff32ExportFormat.java
@@ -54,6 +54,11 @@ public class Tiff32ExportFormat implements PictureExportFormat {
   }
 
   @Override
+  public AlphaBuffer.Type transparencyType() {
+    return AlphaBuffer.Type.FP32;
+  }
+
+  @Override
   public boolean wantsPostprocessing() {
     return false;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AlphaBuffer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AlphaBuffer.java
@@ -1,0 +1,129 @@
+package se.llbit.chunky.renderer.scene;
+
+import se.llbit.chunky.main.Chunky;
+import se.llbit.chunky.renderer.WorkerState;
+import se.llbit.chunky.renderer.projection.ParallelProjector;
+import se.llbit.chunky.renderer.projection.ProjectionMode;
+import se.llbit.log.Log;
+import se.llbit.math.Ray;
+import se.llbit.util.TaskTracker;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+/**
+ * The AlphaBuffer acts as a cache for the alpha layer and will only be calculated on demand.
+ */
+public class AlphaBuffer {
+
+  public enum Type {
+    DISABLED(0,
+      (buffer, index, alphaValue) -> {
+      }
+    ),
+    UINT8(1,
+      (buffer, index, alphaValue) -> buffer.put(index, (byte) (255 * alphaValue + 0.5))
+    ),
+    FP32(4,
+      (buffer, index, alphaValue) -> buffer.putFloat(index<<2, (float) alphaValue)
+    );
+
+    final byte byteSize;
+    final AlphaWriter writer;
+
+    Type(int byteSize, AlphaWriter writer) {
+      this.byteSize = (byte) byteSize;
+      this.writer = writer;
+    }
+
+    @FunctionalInterface
+    interface AlphaWriter {
+      /**
+       * @param alphaValue 1 = occluded, 0 = transparent
+       */
+      void write(ByteBuffer buffer, int index, double alphaValue);
+    }
+  }
+
+  private Type type = Type.DISABLED;
+  private ByteBuffer buffer = null;
+
+  public Type getType() {
+    return type;
+  }
+
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+
+  public void reset() {
+    type = Type.DISABLED;
+    buffer = null;
+  }
+
+  /**
+   * Compute the alpha channel.
+   */
+  void computeAlpha(Scene scene, Type type, TaskTracker taskTracker) {
+    if(type == Type.DISABLED) return;
+    if(this.type == type && buffer != null) return;
+
+    try (TaskTracker.Task task = taskTracker.task("Computing alpha channel")) {
+      this.type = type;
+      buffer = ByteBuffer.allocate(scene.width * scene.height * type.byteSize);
+
+      AtomicInteger done = new AtomicInteger(0);
+      Chunky.getCommonThreads().submit(() -> {
+        IntStream.range(0, scene.width).parallel().forEach(x -> {
+          WorkerState state = new WorkerState();
+          state.ray = new Ray();
+
+          for (int y = 0; y < scene.height; y++) {
+            computeAlpha(scene, x, y, state);
+          }
+
+          task.update(scene.width, done.incrementAndGet());
+        });
+      }).get();
+    } catch (InterruptedException | ExecutionException e) {
+      Log.error("Failed to compute alpha channel", e);
+    }
+  }
+
+  /**
+   * Compute the alpha channel based on sky visibility.
+   */
+  public void computeAlpha(Scene scene, int x, int y, WorkerState state) {
+    Ray ray = state.ray;
+    double halfWidth = scene.width / (2.0 * scene.height);
+    double invHeight = 1.0 / scene.height;
+
+    // Rotated grid supersampling.
+    double[][] offsets = new double[][]{
+      {-3.0 / 8.0, 1.0 / 8.0},
+      {1.0 / 8.0, 3.0 / 8.0},
+      {-1.0 / 8.0, -3.0 / 8.0},
+      {3.0 / 8.0, -1.0 / 8.0},
+    };
+
+    double occlusion = 0.0;
+    for (double[] offset : offsets) {
+      scene.camera.calcViewRay(ray,
+        -halfWidth + (x + offset[0]) * invHeight,
+        -0.5 + (y + offset[1]) * invHeight);
+      ray.o.x -= scene.origin.x;
+      ray.o.y -= scene.origin.y;
+      ray.o.z -= scene.origin.z;
+
+      if (scene.camera.getProjectionMode() == ProjectionMode.PARALLEL) {
+        ParallelProjector.fixRay(state.ray, scene);
+      }
+      occlusion += PreviewRayTracer.skyOcclusion(scene, state);
+    }
+    occlusion /= 4.0;
+
+    type.writer.write(buffer, y * scene.width + x, occlusion);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AlphaBuffer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AlphaBuffer.java
@@ -19,7 +19,7 @@ import java.util.stream.IntStream;
 public class AlphaBuffer {
 
   public enum Type {
-    DISABLED(0,
+    UNSUPPORTED(0,
       (buffer, index, alphaValue) -> {
       }
     ),
@@ -47,7 +47,7 @@ public class AlphaBuffer {
     }
   }
 
-  private Type type = Type.DISABLED;
+  private Type type = Type.UNSUPPORTED;
   private ByteBuffer buffer = null;
 
   public Type getType() {
@@ -59,7 +59,7 @@ public class AlphaBuffer {
   }
 
   public void reset() {
-    type = Type.DISABLED;
+    type = Type.UNSUPPORTED;
     buffer = null;
   }
 
@@ -67,7 +67,7 @@ public class AlphaBuffer {
    * Compute the alpha channel.
    */
   void computeAlpha(Scene scene, Type type, TaskTracker taskTracker) {
-    if(type == Type.DISABLED) return;
+    if(type == Type.UNSUPPORTED) return;
     if(this.type == type && buffer != null) return;
 
     try (TaskTracker.Task task = taskTracker.task("Computing alpha channel")) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -62,7 +62,7 @@ public class PreviewRayTracer implements RayTracer {
 
   /**
    * Calculate sky occlusion.
-   * @return occlusion value
+   * @return occlusion value (1 = occluded, 0 = transparent)
    */
   public static double skyOcclusion(Scene scene, WorkerState state) {
     Ray ray = state.ray;
@@ -83,7 +83,7 @@ public class PreviewRayTracer implements RayTracer {
 
   /**
    * Find next ray intersection.
-   * @return Next intersection
+   * @return true if intersected, false if no intersection has been found
    */
   public static boolean nextIntersection(Scene scene, Ray ray) {
     ray.setPrevMaterial(ray.getCurrentMaterial(), ray.getCurrentData());

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2374,6 +2374,20 @@ public class Scene implements JsonSerializable, Refreshable {
     return backBuffer;
   }
 
+  /**
+   * @return returns a view of the alpha channel as uint8 array
+   * @deprecated Replaced by {@link #getAlphaBuffer()}
+   */
+  @Deprecated(forRemoval = true)
+  public byte[] getAlphaChannel() {
+    if(alphaBuffer.getType() != AlphaBuffer.Type.UINT8) {
+      throw new UnsupportedOperationException(
+        "Export Format uses out-of-date API, please update the plugin for \""+ pictureExportFormat.getName() +"\""
+      );
+    }
+    return alphaBuffer.getBuffer().array();
+  }
+
   public AlphaBuffer getAlphaBuffer() {
     return alphaBuffer;
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -2081,7 +2081,7 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public synchronized void writeFrame(OutputStream out, PictureExportFormat mode, TaskTracker taskTracker) throws IOException {
     if (transparentSky) {
-      if (mode.transparencyType() == AlphaBuffer.Type.DISABLED) {
+      if (mode.transparencyType() == AlphaBuffer.Type.UNSUPPORTED) {
         Log.warn("You selected \"transparent sky\", but the selected picture format \"" + mode.getName() + "\" does not support alpha layers.\nUse a different format like PNG instead.");
         }
       alphaBuffer.computeAlpha(this, mode.transparencyType(), taskTracker);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -487,6 +487,7 @@ public class Scene implements JsonSerializable, Refreshable {
       frontBuffer = other.frontBuffer;
       samples = other.samples;
     }
+    // TODO: could we copy it without resetting if the export format and camera perspective didn't change?
     alphaBuffer.reset();
 
     fullWidth = other.fullWidth;
@@ -2081,10 +2082,10 @@ public class Scene implements JsonSerializable, Refreshable {
    */
   public synchronized void writeFrame(OutputStream out, PictureExportFormat mode, TaskTracker taskTracker) throws IOException {
     if (transparentSky) {
-      if (mode.transparencyType() == AlphaBuffer.Type.UNSUPPORTED) {
+      if (mode.getTransparencyType() == AlphaBuffer.Type.UNSUPPORTED) {
         Log.warn("You selected \"transparent sky\", but the selected picture format \"" + mode.getName() + "\" does not support alpha layers.\nUse a different format like PNG instead.");
         }
-      alphaBuffer.computeAlpha(this, mode.transparencyType(), taskTracker);
+      alphaBuffer.computeAlpha(this, mode.getTransparencyType(), taskTracker);
       }
     if (mode.wantsPostprocessing() && !finalized) {
       postProcessFrame(taskTracker);

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -755,7 +755,7 @@ public class ChunkyFxController
       filters.put(filter, mode);
     }
     fileChooser.getExtensionFilters().stream()
-      .filter(e -> filters.get(e).equals(scene.outputMode))
+      .filter(e -> filters.get(e).equals(scene.getPictureExportFormat()))
       .findFirst().ifPresent(fileChooser::setSelectedExtensionFilter);
     fileChooser.setInitialFileName(String.format("%s-%d",
         scene.name(), renderManager.getRenderStatus().getSpp()));

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -149,7 +149,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
       }
     });
     outputMode.getSelectionModel().selectedItemProperty()
-            .addListener((observable, oldValue, newValue) -> scene.setOutputMode(newValue));
+            .addListener((observable, oldValue, newValue) -> scene.setPictureExportFormat(newValue));
     if(!ShutdownAlert.canShutdown()) {
       shutdown.setDisable(true);
     }
@@ -331,7 +331,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
 
   @Override
   public void update(Scene scene) {
-    outputMode.getSelectionModel().select(scene.getOutputMode());
+    outputMode.getSelectionModel().select(scene.getPictureExportFormat());
     fastFog.setSelected(scene.fog.fastFog());
     fancierTranslucency.setSelected(scene.getFancierTranslucency());
     transmissivityCap.set(scene.getTransmissivityCap());

--- a/chunky/src/java/se/llbit/imageformats/png/PngFileWriter.java
+++ b/chunky/src/java/se/llbit/imageformats/png/PngFileWriter.java
@@ -20,10 +20,13 @@ package se.llbit.imageformats.png;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+
+import se.llbit.chunky.renderer.scene.AlphaBuffer;
 import se.llbit.util.TaskTracker;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.zip.Deflater;
 
 /**
@@ -98,7 +101,7 @@ public class PngFileWriter implements AutoCloseable {
   /**
    * Write the image to a PNG file.
    */
-  public void write(int[] data, byte[] alpha, int width, int height,
+  public void write(int[] data, ByteBuffer alpha, int width, int height,
       TaskTracker.Task task) throws IOException {
     writeChunk(new IHDR(width, height, IHDR.COLOR_TYPE_RGBA));
     IDATWriter idat = new IDATWriter();
@@ -111,7 +114,7 @@ public class PngFileWriter implements AutoCloseable {
         idat.write((rgb >> 16) & 0xFF);
         idat.write((rgb >> 8) & 0xFF);
         idat.write(rgb & 0xFF);
-        idat.write(alpha[i]);
+        idat.write(alpha.get(i));
         i += 1;
       }
       task.update(height, y + 1);

--- a/chunky/src/java/se/llbit/imageformats/tiff/IFDTag.java
+++ b/chunky/src/java/se/llbit/imageformats/tiff/IFDTag.java
@@ -45,6 +45,7 @@ public abstract class IFDTag<SingleType, ArrayType> {
   static final ShortTag TAG_IMAGE_HEIGHT = new ShortTag(0x0101);
   static final ShortTag TAG_BITS_PER_SAMPLE = new ShortTag(0x0102);
   static final ShortTag TAG_SAMPLE_FORMAT = new ShortTag(0x0153);
+  static final ShortTag TAG_EXTRA_SAMPLES = new ShortTag(0x0152);
 
   /**
    * defines details of subfile using 32 flag bits


### PR DESCRIPTION
- refactored alpha channel computation and storage
- renamed some PictureExportFormat stuff and replaced `isTransparencySupported` with `transparencyType`
- added TIFF alpha channel export (#1651)
- PR based on top of PR 1659