### PR TITLE
fix exposed, weathered, and oxidized copper grates

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -1095,19 +1095,19 @@ public class MinecraftBlockProvider implements BlockProvider {
       addBlock(s + "copper_door", (name, tag) -> door(tag, Texture.copperDoorTop, Texture.copperDoorBottom));
       addBlock(s + "copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.copperTrapdoor));
       addBlock(s + "exposed_chiseled_copper", Texture.exposedChiseledCopper);
-      addBlock(s + "exposed_copper_grate", Texture.exposedCopperGrate);
+      addBlock(s + "exposed_copper_grate", (name, tag) -> new SolidNonOpaqueBlock(name, Texture.exposedCopperGrate));
       addBlock(s + "exposed_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
         Texture.exposedCopperBulbLitPowered, Texture.exposedCopperBulbLit, Texture.exposedCopperBulbPowered, Texture.exposedCopperBulb));
       addBlock(s + "exposed_copper_door", (name, tag) -> door(tag, Texture.exposedCopperDoorTop, Texture.exposedCopperDoorBottom));
       addBlock(s + "exposed_copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.exposedCopperTrapdoor));
       addBlock(s + "weathered_chiseled_copper", Texture.weatheredChiseledCopper);
-      addBlock(s + "weathered_copper_grate", Texture.weatheredCopperGrate);
+      addBlock(s + "weathered_copper_grate", (name, tag) -> new SolidNonOpaqueBlock(name, Texture.weatheredCopperGrate));
       addBlock(s + "weathered_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
         Texture.weatheredCopperBulbLitPowered, Texture.weatheredCopperBulbLit, Texture.weatheredCopperBulbPowered, Texture.weatheredCopperBulb));
       addBlock(s + "weathered_copper_door", (name, tag) -> door(tag, Texture.weatheredCopperDoorTop, Texture.weatheredCopperDoorBottom));
       addBlock(s + "weathered_copper_trapdoor", (name, tag) -> trapdoor(tag, Texture.weatheredCopperTrapdoor));
       addBlock(s + "oxidized_chiseled_copper", Texture.oxidizedChiseledCopper);
-      addBlock(s + "oxidized_copper_grate", Texture.oxidizedCopperGrate);
+      addBlock(s + "oxidized_copper_grate", (name, tag) -> new SolidNonOpaqueBlock(name, Texture.oxidizedCopperGrate));
       addBlock(s + "oxidized_copper_bulb", (name, tag) -> new CopperBulb(name, tag.get("Properties").get("lit").stringValue().equals("true"), tag.get("Properties").get("powered").stringValue().equals("true"),
         Texture.oxidizedCopperBulbLitPowered, Texture.oxidizedCopperBulbLit, Texture.oxidizedCopperBulbPowered, Texture.oxidizedCopperBulb));
       addBlock(s + "oxidized_copper_door", (name, tag) -> door(tag, Texture.oxidizedCopperDoorTop, Texture.oxidizedCopperDoorBottom));


### PR DESCRIPTION
Due to an oversight, I only made regular copper grates support transparency, not any of the oxidized variants:
![image](https://github.com/chunky-dev/chunky/assets/46458276/2fcd8c96-5a99-48da-9301-91c06b115b71)
![image](https://github.com/chunky-dev/chunky/assets/46458276/c3b610e6-53ae-4024-bafc-0f1d2e5a56f4)
(second image is on the emitter mapping branch just because that's what I had easily available)