### PR TITLE
Rransmission roughness

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -265,8 +265,8 @@ public class PathTracer implements RayTracer {
       double directLightB = 0;
 
       boolean frontLight = next.d.dot(ray.getNormal()) > 0;
-
-      if (frontLight || (currentMat.subSurfaceScattering
+      //check if normal faces the sun direction, if so do sampling
+      if (frontLight || (false
         && random.nextFloat() < Scene.fSubSurface)) {
 
         if (!frontLight) {
@@ -359,31 +359,7 @@ public class PathTracer implements RayTracer {
         }
       } else {
         if (doRefraction) {
-
-          double t2 = FastMath.sqrt(radicand);
-          Vector3 n = ray.getNormal();
-          if (cosTheta > 0) {
-            next.d.x = n1n2 * ray.d.x + (n1n2 * cosTheta - t2) * n.x;
-            next.d.y = n1n2 * ray.d.y + (n1n2 * cosTheta - t2) * n.y;
-            next.d.z = n1n2 * ray.d.z + (n1n2 * cosTheta - t2) * n.z;
-          } else {
-            next.d.x = n1n2 * ray.d.x - (-n1n2 * cosTheta - t2) * n.x;
-            next.d.y = n1n2 * ray.d.y - (-n1n2 * cosTheta - t2) * n.y;
-            next.d.z = n1n2 * ray.d.z - (-n1n2 * cosTheta - t2) * n.z;
-          }
-
-          next.d.normalize();
-
-          // See Ray.specularReflection for information on why this is needed
-          // This is the same thing but for refraction instead of reflection
-          // so this time we want the signs of the dot product to be the same
-          if (QuickMath.signum(next.getGeometryNormal().dot(next.d)) != QuickMath.signum(next.getGeometryNormal().dot(ray.d))) {
-            double factor = QuickMath.signum(next.getGeometryNormal().dot(ray.d)) * -Ray.EPSILON - next.d.dot(next.getGeometryNormal());
-            next.d.scaleAdd(factor, next.getGeometryNormal());
-            next.d.normalize();
-          }
-
-          next.o.scaleAdd(Ray.OFFSET, next.d);
+          next.specularRefraction(ray, random, radicand, n1n2, cosTheta);
         }
 
         if (pathTrace(scene, next, state, false)) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -3257,6 +3257,16 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * Modifies the transmission roughness property for the given material.
+   */
+  public void setPerceptualTransmissionSmoothness(String materialName, float value) {
+    JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
+    material.set("transmissionRoughness", Json.of(Math.pow(1 - value, 2)));
+    materials.put(materialName, material);
+    refresh(ResetReason.MATERIALS_CHANGED);
+  }
+
+  /**
    * Modifies the metalness property for the given material.
    */
   public void setMetalness(String materialName, float value) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -53,6 +53,8 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
   private final DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
+
+  private final DoubleAdjuster perceptualTransmissionSmoothness = new DoubleAdjuster();
   private final DoubleAdjuster metalness = new DoubleAdjuster();
   private final ListView<String> listView;
 
@@ -69,6 +71,9 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     perceptualSmoothness.setName("Smoothness");
     perceptualSmoothness.setRange(0, 1);
     perceptualSmoothness.setTooltip("Smoothness of the selected material.");
+    perceptualTransmissionSmoothness.setName("Transmission Smoothness");
+    perceptualTransmissionSmoothness.setRange(0, 1);
+    perceptualTransmissionSmoothness.setTooltip("Smoothness of refraction though material");
     metalness.setName("Metalness");
     metalness.setRange(0, 1);
     metalness.setTooltip("Metalness (texture-tinted reflectivity) of the selected material.");
@@ -87,7 +92,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, specular, perceptualSmoothness, ior, metalness,
+        emittance, specular, perceptualSmoothness, ior,perceptualTransmissionSmoothness, metalness,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);
@@ -116,6 +121,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       double specAcc = 0;
       double iorAcc = 0;
       double perceptualSmoothnessAcc = 0;
+      double perceptualTransmissionSmoothnessAcc = 0;
       double metalnessAcc = 0;
       Collection<Block> blocks = MaterialStore.collections.get(materialName);
       for (Block block : blocks) {
@@ -123,12 +129,14 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
         specAcc += block.specular;
         iorAcc += block.ior;
         perceptualSmoothnessAcc += block.getPerceptualSmoothness();
+        perceptualTransmissionSmoothnessAcc += block.getPerceptualTransmissionSmoothness();
         metalnessAcc += block.metalness;
       }
       emittance.set(emAcc / blocks.size());
       specular.set(specAcc / blocks.size());
       ior.set(iorAcc / blocks.size());
       perceptualSmoothness.set(perceptualSmoothnessAcc / blocks.size());
+      perceptualTransmissionSmoothness.set(perceptualTransmissionSmoothnessAcc / blocks.size());
       metalness.set(metalnessAcc / blocks.size());
       materialExists = true;
     } else if (ExtraMaterials.idMap.containsKey(materialName)) {
@@ -138,6 +146,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
         specular.set(material.specular);
         ior.set(material.ior);
         perceptualSmoothness.set(material.getPerceptualSmoothness());
+        perceptualTransmissionSmoothness.set(material.getPerceptualTransmissionSmoothness());
         metalness.set(material.metalness);
         materialExists = true;
       }
@@ -148,6 +157,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       specular.set(block.specular);
       ior.set(block.ior);
       perceptualSmoothness.set(block.getPerceptualSmoothness());
+      perceptualTransmissionSmoothness.set(block.getPerceptualTransmissionSmoothness());
       metalness.set(block.metalness);
       materialExists = true;
     }
@@ -156,12 +166,15 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       specular.onValueChange(value -> scene.setSpecular(materialName, value.floatValue()));
       ior.onValueChange(value -> scene.setIor(materialName, value.floatValue()));
       perceptualSmoothness.onValueChange(value -> scene.setPerceptualSmoothness(materialName, value.floatValue()));
+      perceptualTransmissionSmoothness.onValueChange(value -> scene.setPerceptualTransmissionSmoothness(materialName,
+        value.floatValue()));
       metalness.onValueChange(value -> scene.setMetalness(materialName, value.floatValue()));
     } else {
       emittance.onValueChange(value -> {});
       specular.onValueChange(value -> {});
       ior.onValueChange(value -> {});
       perceptualSmoothness.onValueChange(value -> {});
+      perceptualTransmissionSmoothness.onValueChange(value -> {});
       metalness.onValueChange(value -> {});
     }
   }

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -67,6 +67,12 @@ public abstract class Material {
   public float roughness = 0f;
 
   /**
+   * The (linear) roughness controlling how blurry a refraction/transmission though a block is. A value of 0 makes the
+   * effect perfectly specular, a value of 1 makes it diffuse.
+   */
+  public float transmissionRoughness = 0f;
+
+  /**
    * The metalness value controls how metal-y a block appears. In reality this is a boolean value
    * but in practice usually a float is used in PBR to allow adding dirt or scratches on metals
    * without increasing the texture resolution.
@@ -76,9 +82,11 @@ public abstract class Material {
   public float metalness = 0;
 
   /**
-   * Subsurface scattering property.
+   * Additional amount of transmission to do for a given mat, for opaque materials this provides a first order
+   * approximation to subsurface scattering
+   * #TODO: figure out if to take a chunk of outgoing energy or use up left over energy
    */
-  public boolean subSurfaceScattering = false;
+  public float additionalTransmission = 0f;
 
   /**
    * Base texture.
@@ -104,7 +112,8 @@ public abstract class Material {
     specular = 0;
     emittance = 0;
     roughness = 0;
-    subSurfaceScattering = false;
+    transmissionRoughness = 0;
+    additionalTransmission = 0f;
   }
 
   public void getColor(Ray ray) {
@@ -125,6 +134,7 @@ public abstract class Material {
     emittance = json.get("emittance").floatValue(emittance);
     roughness = json.get("roughness").floatValue(roughness);
     metalness = json.get("metalness").floatValue(metalness);
+    transmissionRoughness = json.get("transmissionRoughness").floatValue(metalness);
   }
 
   public boolean isWater() {
@@ -145,5 +155,13 @@ public abstract class Material {
 
   public void setPerceptualSmoothness(double perceptualSmoothness) {
     roughness = (float) Math.pow(1 - perceptualSmoothness, 2);
+  }
+
+  public double getPerceptualTransmissionSmoothness() {
+    return 1 - Math.sqrt(transmissionRoughness);
+  }
+
+  public void setPerceptualTransmissionSmoothness(double perceptualSmoothness) {
+    transmissionRoughness = (float) Math.pow(1 - perceptualSmoothness, 2);
   }
 }


### PR DESCRIPTION
This pr is the first of a series to implement a better BTDF in chunky. This pr adds a linear lerping like in specular reflections in other to enable glossy reflections, a new material parameter called `trasmissionRoughness` which is set independently from `roughness` the UI parameter is Transmission smoothness. Fixes Issue #1591

|Before (1 smoothness,1 transmission smoothness)|After (1 smoothness,0.8 transmission smoothness)| 
|---|---|
|![image](https://github.com/chunky-dev/chunky/assets/55562739/d110b54e-3c96-4b84-a2cb-899426365dd4)|![image](https://github.com/chunky-dev/chunky/assets/55562739/2fbb2dfb-7ddc-4b0e-97e8-094be5fb449d)|

A scene example 80k SSP, the white glass has a transmission smoothness of 1, red glass of 0.75, blue glass of 0.5, notice the increase spread of the caustics (sun sampling is OFF)
![image](https://github.com/chunky-dev/chunky/assets/55562739/c643dce3-7020-47e9-bf67-bbde91fa93b4)


This pr is a draft, there are 2 pending issues:

- [ ] fix the bias caused from lerping b/w diffuse and specular (also present in reflections)
- [ ] fix intersections with air, currently refracted rays don't intersect air and "exit" materials, this causes 1. incorrect refractions with air gap, 2. eliminated internal refection events. This problem was okay with pure specular reflections but is a serious concern when introducing roughness. 

