### PR TITLE
Homogenize Depth

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -125,6 +125,7 @@ public class PathTracer implements RayTracer {
       if(ray.depth + 1 >= scene.rayDepth) {
         break;
       }
+      ray.depth += 1;
       Vector4 cumulativeColor = new Vector4(0, 0, 0, 0);
       Ray next = new Ray();
       float pMetal = currentMat.metalness;

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -153,7 +153,7 @@ public class Ray {
   public void set(Ray other) {
     prevMaterial = other.prevMaterial;
     currentMaterial = other.currentMaterial;
-    depth = other.depth + 1;
+    depth = other.depth;
     distance = 0;
     o.set(other.o);
     d.set(other.d);


### PR DESCRIPTION
Chunky would rely `Ray.set(Ray)` to increase the depth, however different routines calls this a different amount of times leading to different ray depths in a scene. Here I have removed that change and made ray depth increase explicitly to successive frames in `PathTracer.pathTrace`.  Currently this does  not explicitly change the output, but it could be a easy mistake in the future or if the ray depth is needed in other parts of the code. 