### PR TITLE
Fix refraction and material transitions.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Air.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Air.java
@@ -29,5 +29,6 @@ public class Air extends MinecraftBlock {
     solid = false;
     opaque = false;
     invisible = true;
+    refractive = true;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/AnimatedQuadModel.java
@@ -3,6 +3,7 @@ package se.llbit.chunky.model;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.AnimatedTexture;
+import se.llbit.chunky.world.Material;
 import se.llbit.math.Quad;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
@@ -42,7 +43,7 @@ public abstract class AnimatedQuadModel extends QuadModel {
     Quad[] quads = getQuads();
     AnimatedTexture[] textures = getTextures();
     Tint[] tintedQuads = getTints();
-
+    Material mat = ray.getCurrentMaterial();
     // The animation frame to use
     int j = (int) (scene.getAnimationTime() * animationMode.framerate);
     if (animationMode.positional) {
@@ -58,11 +59,11 @@ public abstract class AnimatedQuadModel extends QuadModel {
       Quad quad = quads[i];
       if (quad.intersect(ray)) {
         float[] c = textures[i].getColor(ray.u, ray.v, j);
-        if (c[3] > Ray.EPSILON) {
+        if (c[3] > Ray.EPSILON || mat.refractive) {
           tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
           color = c;
           ray.t = ray.tNext;
-          if (quad.doubleSided)
+          if (quad.doubleSided || mat.refractive)
             ray.orientNormal(quad.n);
           else
             ray.setNormal(quad.n);

--- a/chunky/src/java/se/llbit/chunky/model/QuadModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/QuadModel.java
@@ -23,6 +23,7 @@ import se.llbit.chunky.model.Tint;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
+import se.llbit.chunky.world.Material;
 import se.llbit.math.Quad;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
@@ -112,6 +113,7 @@ public abstract class QuadModel implements BlockModel {
     Quad[] quads = getQuads();
     Texture[] textures = getTextures();
     Tint[] tintedQuads = getTints();
+    Material mat = ray.getCurrentMaterial();
 
     float[] color = null;
     Tint tint = Tint.NONE;
@@ -119,11 +121,11 @@ public abstract class QuadModel implements BlockModel {
       Quad quad = quads[i];
       if (quad.intersect(ray)) {
         float[] c = textures[i].getColor(ray.u, ray.v);
-        if (c[3] > Ray.EPSILON) {
+        if (c[3] > Ray.EPSILON || mat.refractive) {
           tint = tintedQuads == null ? Tint.NONE : tintedQuads[i];
           color = c;
           ray.t = ray.tNext;
-          if (quad.doubleSided)
+          if (quad.doubleSided || mat.refractive)
             ray.orientNormal(quad.n);
           else
             ray.setNormal(quad.n);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -360,8 +360,8 @@ public class Scene implements JsonSerializable, Refreshable {
     branchCount = PersistentSettings.getBranchCountDefault();
 
     palette = new BlockPalette();
-    worldOctree = new Octree(octreeImplementation, 1);
-    waterOctree = new Octree(octreeImplementation, 1);
+    worldOctree = new Octree(octreeImplementation, 1, Octree.OctreeType.WORLD);
+    waterOctree = new Octree(octreeImplementation, 1, Octree.OctreeType.WATER);
     emitterGrid = null;
   }
 
@@ -744,7 +744,7 @@ public class Scene implements JsonSerializable, Refreshable {
     } else {
       r = new Ray(start);
       r.setCurrentMaterial(start.getPrevMaterial(), start.getPrevData());
-      if (waterOctree.enterBlock(this, r, palette) && r.distance < ray.t) {
+      if (waterOctree.enterBlock(this, r, palette) && r.distance < ray.t + Ray.EPSILON) {
         ray.t = r.distance;
         ray.setNormal(r.getNormal());
         ray.color.set(r.color);
@@ -824,8 +824,8 @@ public class Scene implements JsonSerializable, Refreshable {
 
       // Create new octree to fit all chunks.
       palette = new BlockPalette();
-      worldOctree = new Octree(octreeImplementation, requiredDepth);
-      waterOctree = new Octree(octreeImplementation, requiredDepth);
+      worldOctree = new Octree(octreeImplementation, requiredDepth, Octree.OctreeType.WORLD);
+      waterOctree = new Octree(octreeImplementation, requiredDepth, Octree.OctreeType.WATER);
 
       grassTexture = biomeStructureFactory.create();
       foliageTexture = biomeStructureFactory.create();
@@ -2226,6 +2226,12 @@ public class Scene implements JsonSerializable, Refreshable {
         if (waterTexture == null) {
           // this dump is so old that it doesn't contain a water texture (Chunky 2.3.0, #691)
           waterTexture = BiomeStructure.get(this.biomeStructureImplementation).create();
+        }
+        if (worldOctree.type == null) {
+          worldOctree.type = Octree.OctreeType.WORLD;
+        }
+        if (waterOctree.type == null) {
+          waterOctree.type = Octree.OctreeType.WATER;
         }
         palette = data.palette;
         palette.applyMaterials();

--- a/chunky/src/java/se/llbit/math/Quad.java
+++ b/chunky/src/java/se/llbit/math/Quad.java
@@ -158,14 +158,14 @@ public class Quad {
    */
   public boolean intersect(Ray ray) {
     double u, v;
-
+    Material mat = ray.getCurrentMaterial();
     double ix = ray.o.x - QuickMath.floor(ray.o.x + ray.d.x * Ray.OFFSET);
     double iy = ray.o.y - QuickMath.floor(ray.o.y + ray.d.y * Ray.OFFSET);
     double iz = ray.o.z - QuickMath.floor(ray.o.z + ray.d.z * Ray.OFFSET);
 
     // Test that the ray is heading toward the plane of this quad.
     double denom = ray.d.dot(n);
-    if (denom < -Ray.EPSILON || (doubleSided && denom > Ray.EPSILON)) {
+    if (denom < -Ray.EPSILON || ((doubleSided || mat.refractive) && denom > Ray.EPSILON)) {
 
       // Test for intersection with the plane at origin.
       double t = -(ix * n.x + iy * n.y + iz * n.z + d) / denom;


### PR DESCRIPTION
This PR fixes #1515, in a way that is less hacky than #1601 by defining octree type and modifying the intersection logic based on which octree we are in. Also recovers total internal reflections. This is because Air has different contexts depending on location. Current changes fix solid block refractions, and partially addresses sub block refractions like glass panes. Currently I cant figure out a good methodology for fixing glass panes that does not break intersection logic. Additionally there are quite a few edge cases to consider like partially water logged glass panes. 

|Before|After| 
|---|---|
|![image](https://github.com/chunky-dev/chunky/assets/55562739/2436c4c9-773d-44ce-91bd-6395c2d5b638)|![image](https://github.com/chunky-dev/chunky/assets/55562739/6095b814-e2ee-46fd-a419-061c3bc683bb)|
|![image](https://github.com/chunky-dev/chunky/assets/55562739/4bdfd595-26dd-4046-a974-a02d9d1e3581)|![image](https://github.com/chunky-dev/chunky/assets/55562739/e9cccc04-ca73-4b0f-ba85-0d5d06103b1d)|
|![image](https://github.com/chunky-dev/chunky/assets/55562739/bfca5b56-e298-4884-bb5d-d0aead553a4c)|![image](https://github.com/chunky-dev/chunky/assets/55562739/386a3036-12b3-4dcd-9b70-03192822f41d)|

Now this makes for some *weird* views, dont know if these are correct but the above tests makes it seems so, in any case that is a function of refraction and Fresnel code than intersection code
![image](https://github.com/chunky-dev/chunky/assets/55562739/18f905d2-70f5-4601-b584-d8036bbe27a7)


Glass panes are still wrong example:
![image](https://github.com/chunky-dev/chunky/assets/55562739/113b9cc1-6434-4ea7-a3f7-e45612946681)
