### PR TITLE
Rename grass to short_grass.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlockProvider.java
@@ -349,7 +349,8 @@ public class MinecraftBlockProvider implements BlockProvider {
     "minecraft:granite_stairs",
     "minecraft:granite_wall",
     "minecraft:grass_block",
-    "minecraft:grass",
+    "minecraft:grass", // pre 1.20.3-pre2
+    "minecraft:short_grass", // since 1.20.3-pre2
     "minecraft:grass_path", // pre 20w45a
     "minecraft:gravel",
     "minecraft:gray_banner",
@@ -1306,6 +1307,7 @@ public class MinecraftBlockProvider implements BlockProvider {
       case "cobweb":
         return new SpriteBlock(name, Texture.cobweb);
       case "grass":
+      case "short_grass": // since 1.20.3-pre2
         return new Grass();
       case "fern":
         return new Fern();

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Grass.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Grass.java
@@ -25,7 +25,7 @@ import se.llbit.chunky.resources.Texture;
 public class Grass extends AbstractModelBlock {
 
   public Grass() {
-    super("grass", Texture.tallGrass);
+    super("short_grass", Texture.tallGrass);
     solid = false;
     model = new GrassTintedSpriteModel(texture);
   }

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -325,6 +325,7 @@ public class TexturePackLoader {
         new SimpleTexture("textures/blocks/grass_side_overlay", Texture.grassSide),
         new IndexedTexture(0x26, Texture.grassSide)));
     ALL_TEXTURES.put("tallgrass", new AlternateTextures(
+        new SimpleTexture("assets/minecraft/textures/block/short_grass", Texture.tallGrass), // since 1.20.3-pre2
         new SimpleTexture("assets/minecraft/textures/block/grass", Texture.tallGrass),
         new SimpleTexture("assets/minecraft/textures/blocks/grass", Texture.tallGrass),
         new SimpleTexture("assets/minecraft/textures/blocks/tallgrass", Texture.tallGrass),


### PR DESCRIPTION
As of 1.20.3-pre2, grass now has completed its journey from tallgrass over grass to short_grass – without changing its size. :rofl: 