### PR TITLE
Search for updates instead of telling the user if no versions are installed when trying to launch Chunky.

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
+++ b/launcher/src/se/llbit/chunky/launcher/ui/ChunkyLauncherController.java
@@ -448,6 +448,12 @@ public final class ChunkyLauncherController implements Initializable, UpdateList
 
     // Resolve specific version.
     VersionInfo version = ChunkyDeployer.resolveVersion(settings.version);
+    if (version == VersionInfo.NONE) {
+      setBusy(true);
+      UpdateChecker updateThread = new UpdateChecker(settings, settings.selectedChannel, this);
+      updateThread.start();
+      return;
+    }
     if (!ChunkyDeployer.canLaunch(version, this, true)) {
       return;
     }


### PR DESCRIPTION
To reproduce this condition, remove your Chunky config and all versions (eg. rename your chunky directory) and start the launcher.

* If the launcher is outdated, only the launcher update dialog is shown (and no Chunky update dialog)
* If the launcher is up to date, the Chunky update dialog is shown, cancel it
* If you now try to launch, it will yell at you (with this PR applied, it will search for updates instead)

Fixes #1304

Cc @Peregrine05