### PR TITLE
Fix for possible crash in SceneChooserController.java

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
@@ -99,10 +99,13 @@ public class SceneChooserController implements Initializable {
         alert.setTitle("Delete Scene");
         alert.setContentText(String.format("Are you sure you want to delete the scene %s? "
             + "All files for the scene, except snapshot images, will be deleted.", scene.sceneName));
-        if (alert.showAndWait().get() == ButtonType.OK) {
-          Scene.delete(scene.sceneName, scene.sceneDirectory);
-          sceneTbl.getItems().remove(sceneTbl.getSelectionModel().getSelectedItem());
-        }
+        alert.showAndWait()
+          .ifPresent(result ->
+              if (result == ButtonType.OK) {
+                Scene.delete(scene.sceneName, scene.sceneDirectory);
+                sceneTbl.getItems().remove(sceneTbl.getSelectionModel().getSelectedItem());
+              }
+          );
       }
     });
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
@@ -100,12 +100,12 @@ public class SceneChooserController implements Initializable {
         alert.setContentText(String.format("Are you sure you want to delete the scene %s? "
             + "All files for the scene, except snapshot images, will be deleted.", scene.sceneName));
         alert.showAndWait()
-          .ifPresent(result ->
+          .ifPresent(result -> {
               if (result == ButtonType.OK) {
                 Scene.delete(scene.sceneName, scene.sceneDirectory);
                 sceneTbl.getItems().remove(sceneTbl.getSelectionModel().getSelectedItem());
               }
-          );
+          });
       }
     });
 


### PR DESCRIPTION
An unchecked call on the Optional result of `Alert#showAndWait()` may throw an exception at run time.

This commit refactors it to one of the recommended approaches to safely get its value [here](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/control/Alert.html).