### PR TITLE
Add deprecation status to `Registerable`.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/Trivial2dBiomeStructure.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/Trivial2dBiomeStructure.java
@@ -76,6 +76,11 @@ public class Trivial2dBiomeStructure implements BiomeStructure.Factory {
     return ID;
   }
 
+  @Override
+  public DeprecationStatus getDeprecationStatus() {
+    return DeprecationStatus.HIDDEN;
+  }
+
   static class Impl extends Position2d2ReferencePackedArrayStructure<float[]> implements BiomeStructure {
 
     public void setCube(long packedPosition, float[][] data) {

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/biome/Trivial3dBiomeStructure.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/biome/Trivial3dBiomeStructure.java
@@ -79,6 +79,11 @@ public class Trivial3dBiomeStructure implements BiomeStructure.Factory {
     return ID;
   }
 
+  @Override
+  public DeprecationStatus getDeprecationStatus() {
+    return DeprecationStatus.HIDDEN;
+  }
+
   static class Impl extends Position3d2ReferencePackedArrayStructure<float[]> implements BiomeStructure {
 
     public void setCube(int x, int y, int z, float[][] data) {

--- a/chunky/src/java/se/llbit/util/Registerable.java
+++ b/chunky/src/java/se/llbit/util/Registerable.java
@@ -5,6 +5,21 @@ package se.llbit.util;
  * This would be, for example, different Octree implementations.
  */
 public interface Registerable {
+  enum DeprecationStatus {
+    /**
+     * Not deprecated.
+     */
+    ACTIVE,
+    /**
+     * Deprecated. Use is discouraged but not hidden.
+     */
+    DEPRECATED,
+    /**
+     * Deprecated. This option should be hidden.
+     */
+    HIDDEN,
+  }
+
   /**
    * Get the pretty name of this object.
    * For example, "Chunky Path Tracer".
@@ -22,4 +37,11 @@ public interface Registerable {
    * For example, "PathTracingRenderer".
    */
   String getId();
+
+  /**
+   * Get the deprecation status of this object.
+   */
+  default DeprecationStatus getDeprecationStatus() {
+    return DeprecationStatus.ACTIVE;
+  }
 }


### PR DESCRIPTION
Possible values are:
* `Active` - not deprecated
* `Deprecated` - use is discouraged but still an option
* `Hidden` - hidden and exists only for backwards compatibility

The intention is that in the future `Hidden` items will be hidden in the UI and `Deprecated` items will have some sort of indicator / note.