### PR TITLE
Improve launcher command line interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ Chunky uses the following 3rd party libraries:
 - **Apache Maven Artifact by the Apache Software Foundation**  
   The library is covered by the Apache License, version 2.0.
   See the file `licenses/Apache-2.0.txt` for the full license text.
+- **Apache Commons CLI by the Apache Software Foundation**  
+  The library is covered by the Apache License, version 2.0.
+  See the file `licenses/Apache-2.0.txt` for the full license text.
 - **FastUtil by Sebastiano Vigna**  
   FastUtil is covered by Apache License, version 2.0.
   See the file `licenses/Apache-2.0.txt` for the full license text.

--- a/chunky/src/java/se/llbit/chunky/ui/controller/CreditsController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/CreditsController.java
@@ -40,6 +40,7 @@ import javafx.scene.layout.Border;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
+import se.llbit.chunky.HelpCopyright;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.ui.ChunkyFx;
@@ -49,9 +50,10 @@ import se.llbit.log.Log;
 import se.llbit.util.Pair;
 
 public class CreditsController implements Initializable {
-
   @FXML
   private Label version;
+  @FXML
+  public Label copyrightLine;
   @FXML
   private Hyperlink gplv3;
   @FXML
@@ -82,6 +84,10 @@ public class CreditsController implements Initializable {
   private Hyperlink lz4Java;
   @FXML
   private Hyperlink lz4JavaLicense;
+  @FXML
+  private Hyperlink apacheCli;
+  @FXML
+  private Hyperlink apacheCliLicense;
   @FXML
   private VBox pluginBox;
   @FXML
@@ -140,6 +146,8 @@ public class CreditsController implements Initializable {
 
     version.setText(Chunky.getMainWindowTitle());
 
+    copyrightLine.setText(HelpCopyright.COPYRIGHT_LINE);
+
     gplv3.setOnAction(
         e -> launchAndReset(gplv3, "https://github.com/chunky-dev/chunky/blob/master/LICENSE")
     );
@@ -188,6 +196,11 @@ public class CreditsController implements Initializable {
     lz4Java.setOnAction(e -> launchAndReset(lz4Java, "https://github.com/lz4/lz4-java"));
     lz4JavaLicense.setBorder(Border.EMPTY);
     lz4JavaLicense.setOnAction(e -> launchAndReset(lz4JavaLicense, "https://github.com/lz4/lz4-java/blob/master/LICENSE.txt"));
+
+    apacheCli.setBorder(Border.EMPTY);
+    apacheCli.setOnAction(e -> launchAndReset(apacheCli, "https://commons.apache.org/proper/commons-cli/"));
+    apacheCliLicense.setBorder(Border.EMPTY);
+    apacheCliLicense.setOnAction(e -> launchAndReset(apacheCliLicense, "http://www.apache.org/licenses/LICENSE-2.0"));
 
     if (!plugins.isEmpty()) {
       plugins.forEach((key, item) -> pluginBox.getChildren().addAll(buildBox(item)));

--- a/chunky/src/res/se/llbit/chunky/ui/dialogs/Credits.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/dialogs/Credits.fxml
@@ -31,7 +31,7 @@
                     <Font name="System Bold" size="14.0"/>
                   </font>
                 </Label>
-                <Label text="Copyright (c) 2010-2024, Jesper Öqvist and Chunky contributors." wrapText="true">
+                <Label fx:id="copyrightLine" text="Copyright (c) 2010-2024, Jesper Öqvist and Chunky contributors" wrapText="true">
                   <padding>
                     <Insets top="10.0"/>
                   </padding>
@@ -247,6 +247,20 @@
                       </font>
                       <padding>
                         <Insets left="20.0" />
+                      </padding>
+                    </Hyperlink>
+
+                    <Hyperlink fx:id="apacheCli" text="Apache Commons CLI">
+                      <padding>
+                        <Insets/>
+                      </padding>
+                    </Hyperlink>
+                    <Hyperlink fx:id="apacheCliLicense" text="Apache License 2.0">
+                      <font>
+                        <Font size="10.0"/>
+                      </font>
+                      <padding>
+                        <Insets left="20.0"/>
                       </padding>
                     </Hyperlink>
                   </children>

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -9,9 +9,13 @@ configurations {
 }
 
 dependencies {
-    bundled 'org.apache.maven:maven-artifact:3.9.9'
+  bundled 'org.apache.maven:maven-artifact:3.9.9'
+  bundled 'commons-cli:commons-cli:1.6.0'
 
-    implementation project(':lib')
+  implementation project(':lib')
+
+  testImplementation 'com.google.truth:truth:1.1.3'
+  testImplementation 'junit:junit:4.13.2'
 }
 
 java {
@@ -21,13 +25,22 @@ java {
   }
 }
 
-sourceSets.main {
-    java.srcDir 'src'
-    resources {
-        srcDir 'src'
-        include '**/*.png'
-        include '**/*.fxml'
+sourceSets {
+  main {
+    java {
+      srcDir 'src'
     }
+    resources {
+      srcDir 'src'
+      include '**/*.png'
+      include '**/*.fxml'
+    }
+  }
+  test {
+    java {
+      srcDir 'test'
+    }
+  }
 }
 
 jar {

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -427,7 +427,15 @@ public class ChunkyLauncher {
       }
     }
 
-    System.out.print("Reload release channels [Y/n]: ");
+    System.out.printf("Update site [%s]: ", settings.updateSite);
+    {
+      String updateSite = in.nextLine().trim();
+      if (!updateSite.isEmpty()) {
+        settings.updateSite = updateSite;
+      }
+    }
+
+    System.out.print("Reload launcher metadata [Y/n]: ");
     {
       String updateReleaseChannels = in.nextLine().trim();
       if (!updateReleaseChannels.contains("n")) {
@@ -437,6 +445,7 @@ public class ChunkyLauncher {
   }
 
   private static void reloadReleaseChannels(LauncherSettings settings) {
+    System.out.print("...");
     LauncherInfoChecker checker = new LauncherInfoChecker(
       settings,
       error -> {
@@ -446,17 +455,21 @@ public class ChunkyLauncher {
       info -> {
         if (info != null) {
           if (info.version.compareTo(ChunkyLauncher.LAUNCHER_VERSION) > 0) {
-            System.out.printf("Launcher update found! Version %s released on %s: %s\n",
-              info.version, info.date, settings.getResourceUrl(info.path));
+            System.out.println("Launcher update found!");
+            System.out.printf("Version %s released on %s\n", info.version, info.date);
+            System.out.println(settings.getResourceUrl(info.path));
             if (info.notes.isEmpty()) {
               System.out.println("No release notes available.");
             } else {
               System.out.println(info.notes);
             }
             System.out.println();
+          } else {
+            System.out.println("Launcher is up to date!");
           }
 
           settings.setReleaseChannels(info.channels);
+          System.out.printf("%d release channels found.\n", info.channels.size());
         }
       }
     );

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -119,8 +119,8 @@ public class ChunkyLauncher {
 
     options.addOption(Option.builder()
       .longOpt("javaOptions")
+      .hasArg(true)
       .argName("options")
-      .optionalArg(false)
       .desc("Add a Java option when launching Chunky")
       .build()
     );

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -63,11 +63,6 @@ public class ChunkyLauncher {
     );
 
     options.addOption(Option.builder()
-      .longOpt("nolauncher")
-      .build()
-    );
-
-    options.addOption(Option.builder()
       .longOpt("launcher")
       .desc("Forces the launcher GUI to be shown")
       .build()
@@ -91,19 +86,12 @@ public class ChunkyLauncher {
       .build()
     );
 
-    options.addOptionGroup(new OptionGroup()
-      .addOption(Option.builder()
-        .longOpt("update")
-        .argName("release channel")
-        .optionalArg(true)
-        .desc("Update Chunky to the latest release")
-        .build()
-      )
-      .addOption(Option.builder()
-        .longOpt("updateAlpha")
-        .desc("Update Chunky to the latest snapshot release. Equivalent to `--update snapshot`. (legacy)")
-        .build()
-      )
+    options.addOption(Option.builder()
+      .longOpt("update")
+      .argName("release channel")
+      .optionalArg(true)
+      .desc("Update Chunky to the latest release")
+      .build()
     );
 
     options.addOption(Option.builder()
@@ -113,15 +101,15 @@ public class ChunkyLauncher {
     );
 
     options.addOption(Option.builder()
-      .longOpt("noRetryJavafx")
-      .build()
-    );
-
-    options.addOption(Option.builder()
       .longOpt("javaOptions")
       .hasArg(true)
       .argName("options")
       .desc("Add a Java option when launching Chunky")
+      .build()
+    );
+
+    options.addOption(Option.builder()
+      .longOpt("noRetryJavafx")
       .build()
     );
 
@@ -143,7 +131,7 @@ public class ChunkyLauncher {
   public static CommandLine parseCli(String[] args) throws ParseException {
     Options options = cliOptions();
     return new DefaultParser()
-      .parse(options, args, true);
+      .parse(options, args);
   }
 
   public static void main(String[] args) throws FileNotFoundException {
@@ -179,10 +167,6 @@ public class ChunkyLauncher {
           return;
         }
 
-        if (cmd.hasOption("nolauncher")) {
-          mode = LaunchMode.GUI;
-        }
-
         if (cmd.hasOption("launcher")) {
           forceLauncher = true;
         }
@@ -200,17 +184,12 @@ public class ChunkyLauncher {
           settings.forceGuiConsole = true;
         }
 
-        if (cmd.hasOption("update") || cmd.hasOption("updateAlpha")) {
-          ReleaseChannel channel;
-          if (cmd.hasOption("updateAlpha")) {
-            channel = LauncherSettings.SNAPSHOT_RELEASE_CHANNEL;
-          } else {
-            channel = settings.selectedChannel;
+        if (cmd.hasOption("update")) {
+          ReleaseChannel channel = settings.selectedChannel;
 
-            String selected = cmd.getOptionValue("update");
-            if (selected != null) {
-              channel = settings.releaseChannels.getOrDefault(selected, channel);
-            }
+          String selected = cmd.getOptionValue("update");
+          if (selected != null) {
+            channel = settings.releaseChannels.getOrDefault(selected, channel);
           }
 
           headlessUpdateChunky(settings, channel);

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -431,44 +431,40 @@ public class ChunkyLauncher {
     {
       String updateReleaseChannels = in.nextLine().trim();
       if (!updateReleaseChannels.contains("n")) {
-        LauncherInfoChecker checker = new LauncherInfoChecker(
-          settings,
-          error -> {
-            System.err.println("Failed to fetch launcher info!");
-            System.err.println(error);
-          },
-          info -> {
-            if (info != null) {
-              if (info.version.compareTo(ChunkyLauncher.LAUNCHER_VERSION) > 0) {
-                System.out.printf("Launcher update found! Version %s released on %s: %s\n",
-                  info.version, info.date, settings.getResourceUrl(info.path));
-                if (info.notes.isEmpty()) {
-                  System.out.println("No release notes available.");
-                } else {
-                  System.out.println(info.notes);
-                }
-                System.out.println();
-              }
-
-              settings.setReleaseChannels(info.channels);
-            }
-          }
-        );
-        checker.start();
-        try {
-          checker.join();
-        } catch (InterruptedException e) {
-          System.err.println("Interrupted!");
-        }
+        reloadReleaseChannels(settings);
       }
     }
+  }
 
-    System.out.println("Available channels:");
-    System.out.println(String.join(", ", settings.releaseChannels.keySet()));
-    System.out.printf("Release channel [%s]: ", settings.selectedChannel.id);
-    {
-      String releaseChannel = in.nextLine().trim();
-      settings.selectedChannel = settings.releaseChannels.getOrDefault(releaseChannel, settings.selectedChannel);
+  private static void reloadReleaseChannels(LauncherSettings settings) {
+    LauncherInfoChecker checker = new LauncherInfoChecker(
+      settings,
+      error -> {
+        System.err.println("Failed to fetch launcher info!");
+        System.err.println(error);
+      },
+      info -> {
+        if (info != null) {
+          if (info.version.compareTo(ChunkyLauncher.LAUNCHER_VERSION) > 0) {
+            System.out.printf("Launcher update found! Version %s released on %s: %s\n",
+              info.version, info.date, settings.getResourceUrl(info.path));
+            if (info.notes.isEmpty()) {
+              System.out.println("No release notes available.");
+            } else {
+              System.out.println(info.notes);
+            }
+            System.out.println();
+          }
+
+          settings.setReleaseChannels(info.channels);
+        }
+      }
+    );
+    checker.start();
+    try {
+      checker.join();
+    } catch (InterruptedException e) {
+      System.err.println("Interrupted!");
     }
   }
 

--- a/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
+++ b/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
@@ -79,16 +79,6 @@ public class ChunkyLauncherCliParseTest {
     assertThat(cmd.getOptions().length).isEqualTo(1);
     assertThat(cmd.hasOption("update")).isTrue();
 
-    // Check --noRetryJavafx
-    cmd = ChunkyLauncher.parseCli(new String[] { "--noRetryJavafx" });
-    assertThat(cmd.getOptions().length).isEqualTo(1);
-    assertThat(cmd.hasOption("noRetryJavafx")).isTrue();
-
-    // Check --checkJvm
-    cmd = ChunkyLauncher.parseCli(new String[] { "--checkJvm" });
-    assertThat(cmd.getOptions().length).isEqualTo(1);
-    assertThat(cmd.hasOption("checkJvm")).isTrue();
-
     // Check --dangerouslyDisableLibraryValidation
     cmd = ChunkyLauncher.parseCli(new String[] { "--dangerouslyDisableLibraryValidation" });
     assertThat(cmd.getOptions().length).isEqualTo(1);
@@ -99,5 +89,15 @@ public class ChunkyLauncherCliParseTest {
     assertThat(cmd.getOptions().length).isEqualTo(1);
     assertThat(cmd.hasOption("javaOptions")).isTrue();
     assertThat(cmd.getOptionValue("javaOptions")).isEqualTo("test");
+
+    // Check --noRetryJavafx
+    cmd = ChunkyLauncher.parseCli(new String[] { "--noRetryJavafx" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("noRetryJavafx")).isTrue();
+
+    // Check --checkJvm
+    cmd = ChunkyLauncher.parseCli(new String[] { "--checkJvm" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("checkJvm")).isTrue();
   }
 }

--- a/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
+++ b/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
@@ -49,11 +49,6 @@ public class ChunkyLauncherCliParseTest {
     assertThat(cmd.getOptions().length).isEqualTo(1);
     assertThat(cmd.hasOption("help")).isTrue();
 
-    // Check --nolauncher
-    cmd = ChunkyLauncher.parseCli(new String[] { "--nolauncher" });
-    assertThat(cmd.getOptions().length).isEqualTo(1);
-    assertThat(cmd.hasOption("nolauncher")).isTrue();
-
     // Check --launcher
     cmd = ChunkyLauncher.parseCli(new String[] { "--launcher" });
     assertThat(cmd.getOptions().length).isEqualTo(1);
@@ -79,6 +74,11 @@ public class ChunkyLauncherCliParseTest {
     assertThat(cmd.getOptions().length).isEqualTo(1);
     assertThat(cmd.hasOption("setup")).isTrue();
 
+    // Check --update
+    cmd = ChunkyLauncher.parseCli(new String[] { "--update" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("update")).isTrue();
+
     // Check --noRetryJavafx
     cmd = ChunkyLauncher.parseCli(new String[] { "--noRetryJavafx" });
     assertThat(cmd.getOptions().length).isEqualTo(1);
@@ -93,24 +93,11 @@ public class ChunkyLauncherCliParseTest {
     cmd = ChunkyLauncher.parseCli(new String[] { "--dangerouslyDisableLibraryValidation" });
     assertThat(cmd.getOptions().length).isEqualTo(1);
     assertThat(cmd.hasOption("dangerouslyDisableLibraryValidation")).isTrue();
-  }
 
-  @Test
-  public void testUpdateGroup() throws ParseException {
-    CommandLine cmd;
-
-    // Check --update
-    cmd = ChunkyLauncher.parseCli(new String[] { "--update" });
+    // Check --javaOptions
+    cmd = ChunkyLauncher.parseCli(new String[] { "--javaOptions", "test" });
     assertThat(cmd.getOptions().length).isEqualTo(1);
-    assertThat(cmd.hasOption("update")).isTrue();
-
-    // Check --updateAlpha
-    cmd = ChunkyLauncher.parseCli(new String[] { "--updateAlpha" });
-    assertThat(cmd.getOptions().length).isEqualTo(1);
-    assertThat(cmd.hasOption("updateAlpha")).isTrue();
-
-    // Check both --update and --updateAlpha is invalid
-    assertThrows(ParseException.class, () ->
-      ChunkyLauncher.parseCli(new String[] { "--update", "--updateAlpha" }));
+    assertThat(cmd.hasOption("javaOptions")).isTrue();
+    assertThat(cmd.getOptionValue("javaOptions")).isEqualTo("test");
   }
 }

--- a/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
+++ b/launcher/test/se/llbit/chunky/launcher/ChunkyLauncherCliParseTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.launcher;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.ParseException;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class ChunkyLauncherCliParseTest {
+  @Test
+  public void testAdditionalOptions() throws ParseException {
+    CommandLine cmd = ChunkyLauncher.parseCli(new String[] { "--", "--help", "--help1" });
+    assertThat(cmd.getOptions().length).isEqualTo(0);
+    assertThat(cmd.getArgs().length).isEqualTo(2);
+    assertThat(cmd.getArgs()[0]).isEqualTo("--help");
+    assertThat(cmd.getArgs()[1]).isEqualTo("--help1");
+  }
+
+  @Test
+  public void testOptions() throws ParseException {
+    CommandLine cmd;
+
+    // Check --help
+    cmd = ChunkyLauncher.parseCli(new String[] { "--help" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("help")).isTrue();
+
+    // Check -h
+    cmd = ChunkyLauncher.parseCli(new String[] { "-h" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("help")).isTrue();
+
+    // Check --nolauncher
+    cmd = ChunkyLauncher.parseCli(new String[] { "--nolauncher" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("nolauncher")).isTrue();
+
+    // Check --launcher
+    cmd = ChunkyLauncher.parseCli(new String[] { "--launcher" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("launcher")).isTrue();
+
+    // Check --version
+    cmd = ChunkyLauncher.parseCli(new String[] { "--version" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("version")).isTrue();
+
+    // Check --verbose
+    cmd = ChunkyLauncher.parseCli(new String[] { "--verbose" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("verbose")).isTrue();
+
+    // Check --console
+    cmd = ChunkyLauncher.parseCli(new String[] { "--console" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("console")).isTrue();
+
+    // Check --setup
+    cmd = ChunkyLauncher.parseCli(new String[] { "--setup" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("setup")).isTrue();
+
+    // Check --noRetryJavafx
+    cmd = ChunkyLauncher.parseCli(new String[] { "--noRetryJavafx" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("noRetryJavafx")).isTrue();
+
+    // Check --checkJvm
+    cmd = ChunkyLauncher.parseCli(new String[] { "--checkJvm" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("checkJvm")).isTrue();
+
+    // Check --dangerouslyDisableLibraryValidation
+    cmd = ChunkyLauncher.parseCli(new String[] { "--dangerouslyDisableLibraryValidation" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("dangerouslyDisableLibraryValidation")).isTrue();
+  }
+
+  @Test
+  public void testUpdateGroup() throws ParseException {
+    CommandLine cmd;
+
+    // Check --update
+    cmd = ChunkyLauncher.parseCli(new String[] { "--update" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("update")).isTrue();
+
+    // Check --updateAlpha
+    cmd = ChunkyLauncher.parseCli(new String[] { "--updateAlpha" });
+    assertThat(cmd.getOptions().length).isEqualTo(1);
+    assertThat(cmd.hasOption("updateAlpha")).isTrue();
+
+    // Check both --update and --updateAlpha is invalid
+    assertThrows(ParseException.class, () ->
+      ChunkyLauncher.parseCli(new String[] { "--update", "--updateAlpha" }));
+  }
+}

--- a/lib/src/se/llbit/chunky/HelpCopyright.java
+++ b/lib/src/se/llbit/chunky/HelpCopyright.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky;
+
+/**
+ * This contains the proper copyright information for various messages
+ */
+public class HelpCopyright {
+  public static final String COPYRIGHT_LINE = "Copyright (c) 2010-2024 Jesper Öqvist and Chunky Contributors";
+
+  public static final String COPYRIGHT_DISCLAIMER =
+    "Chunky comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute it " +
+    "under certain conditions. See the GNU General Public License v3 for more details.";
+}

--- a/lib/src/se/llbit/chunky/cli/CliUtil.java
+++ b/lib/src/se/llbit/chunky/cli/CliUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package se.llbit.chunky.cli;
+
+import se.llbit.chunky.HelpCopyright;
+
+public class CliUtil {
+  /**
+   * Width of the CLI help
+   */
+  public static final int CLI_WIDTH = 102;
+
+  /**
+   * Make the header for help messages
+   * @param name        Name of the program
+   * @param version     Version of the program
+   * @param description Description after the copyright statement
+   */
+  public static String makeHelpHeader(String name, String version, String description) {
+    return String.format("%s %s, ", name, version) +
+      HelpCopyright.COPYRIGHT_LINE + "\n\n" +
+      HelpCopyright.COPYRIGHT_DISCLAIMER + "\n\n" +
+      description;
+  }
+}


### PR DESCRIPTION
* Rewrite the launcher CLI using Apache Commons CLI.
* Improve launcher interactive setup.
* Setup unit tests for the launcher.

This does slightly change the usage of the CLI. The new parser parses all command line arguments until `--` for the launcher. Any arguments after `--` will be passed to Chunky. Any unknown commands will return with `Unrecognized option: -<command>`.

## Running `java -jar ChunkyLauncher.jar --help`:
```
usage: java -jar ChunkyLauncher.jar
Chunky Launcher 1.14.1, Copyright (c) 2010-2024 Jesper �qvist and Chunky Contributors

Chunky comes with ABSOLUTELY NO WARRANTY. This is free software, and you are welcome to redistribute
it under certain conditions. See the GNU General Public License v3 for more details.

    --console                               Forces debug console to be opened
    --dangerouslyDisableLibraryValidation   Disable library validation. This can be dangerous!
 -h,--help                                  Show this help message
    --javaOptions <options>                 Add a Java option when launching Chunky
    --launcher                              Forces the launcher GUI to be shown
    --setup                                 Runs the interactive command-line launcher setup
    --update <release channel>              Update Chunky to the latest release
    --verbose                               Enables verbose logging
    --version                               Show the launcher version and exit

Command line options after -- are passed to Chunky.
For Chunky's command line help, run:
  java -jar ChunkyLauncher.jar -- --help
```

## Running `java -jar ChunkyLauncher.jar --setup`
```
Memory limit (MiB) [8192]: 
Java options [--module-path "C:\Users\user\.chunky\javafx-sdk-17.0.2\lib" --add-modules javafx.controls,javafx.fxml]: 
Update site [https://chunky-pr.lemaik.de/]: 
Reload launcher metadata [Y/n]: 
...Launcher is up to date!
33 release channels found.
```