### PR TITLE
Clarify render status UI

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
@@ -54,7 +54,7 @@ public class PreviewRenderer extends TileBasedRenderer {
   @Override
   public void render(DefaultRenderManager manager) throws InterruptedException {
     TaskTracker.Task task = manager.getRenderTask();
-    task.update("Preview", 2, 0, "");
+    task.update("Displaying preview", 2, 0, "");
 
     Scene scene = manager.bufferedScene;
 

--- a/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
@@ -54,7 +54,7 @@ public class PreviewRenderer extends TileBasedRenderer {
   @Override
   public void render(DefaultRenderManager manager) throws InterruptedException {
     TaskTracker.Task task = manager.getRenderTask();
-    task.update("Displaying preview", 2, 0, "");
+    task.update("Preparing preview", 2, 0, "");
 
     Scene scene = manager.bufferedScene;
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -162,8 +162,11 @@ public class ChunkyFxController
     @Override public void setProgress(String task, int done, int start, int target) {
       Platform.runLater(() -> {
         progressBar.setProgress((double) done / (target - start));
-        progressLbl.setText(String.format("%s: %s of %s", task, decimalFormat.format(done),
-            decimalFormat.format(target)));
+        if (target - start > 0) {
+          progressLbl.setText(String.format("%s - %s%%", task, Math.round(100 * (double) done / (target - start))));
+        } else {
+          progressLbl.setText(String.format("%s", task));
+        }
         etaLbl.setText("ETA: N/A");
       });
     }
@@ -171,8 +174,11 @@ public class ChunkyFxController
     @Override public void setProgress(String task, int done, int start, int target, String eta) {
       Platform.runLater(() -> {
         progressBar.setProgress((double) done / (target - start));
-        progressLbl.setText(String.format("%s: %s of %s", task, decimalFormat.format(done),
-            decimalFormat.format(target)));
+        if (target - start > 0) {
+          progressLbl.setText(String.format("%s - %s%%", task, Math.round(100 * (double) done / (target - start))));
+        } else {
+          progressLbl.setText(String.format("%s", task));
+        }
         etaLbl.setText("ETA: " + eta);
       });
     }
@@ -205,8 +211,7 @@ public class ChunkyFxController
         int seconds = (int) ((time / 1000) % 60);
         int minutes = (int) ((time / 60000) % 60);
         int hours = (int) (time / 3600000);
-        gui.renderTimeLbl.setText(String
-            .format("Render time: %d hours, %d minutes, %d seconds", hours, minutes, seconds));
+        gui.renderTimeLbl.setText(String.format("Time: %d:%02d:%02d", hours, minutes, seconds));
       });
     }
 
@@ -222,7 +227,7 @@ public class ChunkyFxController
 
     private void updateSppStats() {
       Platform.runLater(() -> gui.sppLbl.setText(String
-          .format("%s SPP, %s SPS", gui.decimalFormat.format(spp),
+          .format("%s SPP | %s SPS", gui.decimalFormat.format(spp),
               gui.decimalFormat.format(sps))));
     }
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -163,9 +163,11 @@ public class ChunkyFxController
       Platform.runLater(() -> {
         progressBar.setProgress((double) done / (target - start));
         if (target - start > 0) {
-          progressLbl.setText(String.format("%s - %s%%", task, Math.round(100 * (double) done / (target - start))));
+          progressLbl.setText(String.format("%s – %.1f%%", task, 100 * (double) done / (target - start)));
+          progressLbl.setTooltip(new Tooltip(String.format("%d of %d completed", done, target)));
         } else {
           progressLbl.setText(String.format("%s", task));
+          progressLbl.setTooltip(null);
         }
         etaLbl.setText("ETA: N/A");
       });
@@ -175,9 +177,11 @@ public class ChunkyFxController
       Platform.runLater(() -> {
         progressBar.setProgress((double) done / (target - start));
         if (target - start > 0) {
-          progressLbl.setText(String.format("%s - %s%%", task, Math.round(100 * (double) done / (target - start))));
+          progressLbl.setText(String.format("%s – %.1f%%", task, 100 * (double) done / (target - start)));
+          progressLbl.setTooltip(new Tooltip(String.format("%d of %d completed", done, target)));
         } else {
           progressLbl.setText(String.format("%s", task));
+          progressLbl.setTooltip(null);
         }
         etaLbl.setText("ETA: " + eta);
       });

--- a/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/Chunky.fxml
@@ -156,15 +156,15 @@
     </padding>
     <BorderPane>
       <left>
-        <Label fx:id="renderTimeLbl" text="Render time: 0"/>
+        <Label fx:id="progressLbl" text="Initialized"/>
       </left>
       <right>
-        <Label fx:id="sppLbl" text="0 SPP, 0 SPS"/>
+        <Label fx:id="sppLbl" text="0 SPP | 0 SPS"/>
       </right>
     </BorderPane>
     <BorderPane>
       <left>
-        <Label fx:id="progressLbl" text="Progress"/>
+        <Label fx:id="renderTimeLbl" text="Time: 0:00:00"/>
       </left>
       <right>
         <Label fx:id="etaLbl" text="ETA: N/A"/>


### PR DESCRIPTION
The current render status pane is somewhat messy with odd and inconsistent formatting, leading to issues like #1213, where `Rendering: 5 of 7` can be misinterpreted as _currently_ rendering 5 of 7. I tried to make it overall more readable and intuitively organized.

This (mostly) fixes #1213. It can still be misinterpreted, but it should be somewhat clearer without having to add additional visual clutter like "5 of 7 done".

I've attached before/after images below for comparison.

![chunkyuibefore](https://github.com/chunky-dev/chunky/assets/85633285/33b31e7a-6177-4fd3-9213-e9c851cc15e8)

![chunkyuiafter](https://github.com/chunky-dev/chunky/assets/85633285/19dc4bac-4f11-4008-a704-abec80bbe91f)

