### PR TITLE
Add block display support.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/Block.java
+++ b/chunky/src/java/se/llbit/chunky/block/Block.java
@@ -9,10 +9,14 @@ import se.llbit.json.JsonString;
 import se.llbit.json.JsonValue;
 import se.llbit.math.AABB;
 import se.llbit.math.Ray;
+import se.llbit.math.Transform;
 import se.llbit.math.Vector3;
+import se.llbit.math.primitive.Primitive;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -152,5 +156,10 @@ public abstract class Block extends Material {
    */
   public boolean isBiomeDependant() {
     return isWaterFilled();
+  }
+
+  public Collection<Primitive> getPrimitives(Transform transform) {
+    // TODO implement this for all block types
+    return Collections.emptyList();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/MinecraftBlock.java
+++ b/chunky/src/java/se/llbit/chunky/block/MinecraftBlock.java
@@ -2,6 +2,14 @@ package se.llbit.chunky.block;
 
 import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.world.Material;
+import se.llbit.math.Transform;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+import se.llbit.math.primitive.Box;
+import se.llbit.math.primitive.Primitive;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * A simple opaque block with a single texture.
@@ -13,5 +21,22 @@ public class MinecraftBlock extends Block {
     super("minecraft:" + name, texture);
     opaque = true;
     solid = true;
+  }
+
+  @Override
+  public Collection<Primitive> getPrimitives(Transform transform) {
+    // TODO check uv mapping and flip/rotate textures if needed
+    // TODO apply this block's material properties to the primitives
+
+    Collection<Primitive> primitives = new LinkedList<>();
+    Box box = new Box(0, 1, 0, 1, 0, 1);
+    box.transform(transform);
+    box.addFrontFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    box.addBackFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    box.addLeftFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    box.addRightFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    box.addTopFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    box.addBottomFaces(primitives, texture, new Vector4(0, 1, 0, 1));
+    return primitives;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/entity/BlockDisplayEntity.java
+++ b/chunky/src/java/se/llbit/chunky/entity/BlockDisplayEntity.java
@@ -1,0 +1,71 @@
+package se.llbit.chunky.entity;
+
+import se.llbit.chunky.block.Block;
+import se.llbit.json.JsonObject;
+import se.llbit.json.JsonValue;
+import se.llbit.math.Transform;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+import se.llbit.math.primitive.Primitive;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.Tag;
+
+import java.util.Collection;
+
+public class BlockDisplayEntity extends Entity {
+  private final Block block;
+  private final CompoundTag tag;
+
+  public BlockDisplayEntity(Vector3 position, Block block, CompoundTag tag) {
+    super(position);
+    this.block = block;
+    this.tag = tag;
+  }
+
+  @Override
+  public Collection<Primitive> primitives(Vector3 offset) {
+    // TODO add support for matrix form (ie. 16 values in row-major order)
+
+    Transform transform = getTransform(tag.get("transformation"))
+      .translate(position)
+      .translate(offset);
+
+    return block.getPrimitives(transform);
+  }
+
+  private Transform getTransform(Tag transformation) {
+    return Transform.NONE
+      .rotateQuaternion( // TODO support axis-angle form (ie. angle of rotation and axis vector)
+        new Vector4(
+          transformation.get("right_rotation").get(1).floatValue(),
+          transformation.get("right_rotation").get(2).floatValue(),
+          -transformation.get("right_rotation").get(3).floatValue(), // fix rotation direction
+          -transformation.get("right_rotation").get(0).floatValue() // fix rotation direction
+        )
+      )
+      .scale(
+        transformation.get("scale").get(0).floatValue(1),
+        transformation.get("scale").get(1).floatValue(1),
+        transformation.get("scale").get(2).floatValue(1)
+      )
+      .rotateQuaternion( // TODO support axis-angle form (ie. angle of rotation and axis vector)
+        new Vector4(
+          transformation.get("left_rotation").get(1).floatValue(),
+          transformation.get("left_rotation").get(2).floatValue(),
+          -transformation.get("left_rotation").get(3).floatValue(), // fix rotation direction
+          -transformation.get("left_rotation").get(0).floatValue() // fix rotation direction
+        )
+      )
+      .translate(
+        transformation.get("translation").get(0).floatValue(0),
+        transformation.get("translation").get(1).floatValue(0),
+        transformation.get("translation").get(2).floatValue(0)
+      );
+  }
+
+  @Override
+  public JsonValue toJson() {
+    // TODO can we even serialize this or do we put the tag into a block palette?
+    return new JsonObject();
+  }
+}

--- a/chunky/src/java/se/llbit/math/Transform.java
+++ b/chunky/src/java/se/llbit/math/Transform.java
@@ -126,6 +126,27 @@ public class Transform {
   }
 
   /**
+   * Scales all coordinates.
+   */
+  public final Transform scale(final double scaleX, final double scaleY, final double scaleZ) {
+    return chain(new Transform() {
+      @Override
+      public void apply(Vector3 v) {
+        v.x *= scaleX;
+        v.y *= scaleY;
+        v.z *= scaleZ;
+      }
+
+      @Override
+      public void applyRotScale(Vector3 v) {
+        v.x *= scaleX;
+        v.y *= scaleY;
+        v.z *= scaleZ;
+      }
+    });
+  }
+
+  /**
    * Rotation by 90 degrees around the Y axis
    */
   public final Transform rotateY() {
@@ -235,6 +256,34 @@ public class Transform {
         double tmp = o.x;
         o.x = o.y;
         o.y = -tmp;
+      }
+    });
+  }
+
+  public Transform rotateQuaternion(Vector4 quaternion) {
+    return chain(new Transform() {
+      @Override
+      public void apply(Vector3 o) {
+        Vector4 oAsVec4 = new Vector4(0, o);
+        Vector4 quaternionConj = new Vector4(quaternion.x, quaternion.y * -1, quaternion.z * -1, quaternion.w * -1);
+        Vector4 result = multiplyQuaternion(multiplyQuaternion(quaternion, oAsVec4), quaternionConj);
+        o.x = result.y;
+        o.y = result.z;
+        o.z = result.w;
+      }
+
+      @Override
+      public void applyRotScale(Vector3 o) {
+        apply(o);
+      }
+
+      private Vector4 multiplyQuaternion(Vector4 q, Vector4 r) {
+        return new Vector4(
+          r.x * q.x - r.y * q.y - r.z * q.z - r.w * q.w,
+          r.x * q.y + r.y * q.x - r.z * q.w + r.w * q.z,
+          r.x * q.z + r.y * q.w + r.z * q.x - r.w * q.y,
+          r.x * q.w - r.y * q.z + r.z * q.y + r.w * q.x
+        );
       }
     });
   }

--- a/chunky/src/java/se/llbit/math/Vector4.java
+++ b/chunky/src/java/se/llbit/math/Vector4.java
@@ -41,6 +41,8 @@ public class Vector4 {
 
   public Vector4(Vector3 v, double w) { this(v.x, v.y, v.z, w); }
 
+  public Vector4(double x, Vector3 v) { this(x, v.x, v.y, v.z); }
+
   public Vector4(double i, double j, double k, double l) {
     x = i;
     y = j;


### PR DESCRIPTION
This adds support for block display entities.
![image](https://github.com/chunky-dev/chunky/assets/5544859/615654ce-6ae9-449f-941d-ed9315c76d25)

- [ ] Matrix transformation
- [ ] Decomposed transformation
  - [x] Quaternion rotation
  - [ ] Axis-angle rotation
- [ ] Apply material properties of the block
- [ ] Tinting (eg. for grass block)
- [ ] `MinecraftBlock` support, ie. solid cube models with a single texture
- [ ] AABB model blocks
- [ ] Quad model blocks

Closes #1691 