### PR TITLE
Do not upload javadoc as artifact in gh actions.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,11 +26,6 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
-    - name: Upload documentation
-      uses: actions/upload-artifact@v2.2.2
-      with:
-        name: Chunky Docs
-        path: build/docs/
     - name: Build release jar
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x docs -x distTar -x distZip
     - name: Build release jar
       env:
         PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This will speed up the Actions by ~2 minutes. If someone needs the javadoc, they can always build it by themselves.