### PR TITLE
[Launcher] Fix jumbled download status column after updating libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,7 @@ task release {
 }
 
 task buildReleaseJar(type: Jar) {
+    dependsOn ':launcher:assembleDist'
     dependsOn 'versionInfo'
 
     archiveFileName = "chunky-${project.version}.jar"

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,3 +1,7 @@
+apply plugin: 'application'
+
+mainClassName = 'se.llbit.chunky.launcher.ChunkyLauncher'
+
 configurations {
     bundled
     implementation.extendsFrom configurations.bundled
@@ -20,7 +24,7 @@ sourceSets.main {
 }
 
 jar {
-    manifest.attributes 'Main-Class': 'se.llbit.chunky.launcher.ChunkyLauncher'
+    manifest.attributes 'Main-Class': mainClassName
 
     // Include classes from the common library.
     from project(':lib').configurations.archives.allArtifacts.files.collect {


### PR DESCRIPTION
![chunky-launcher-version-update](https://github.com/chunky-dev/chunky/assets/16897056/1d9f595b-f2e6-4a77-9900-7df161c99f8f)

Fixes jumbled status cell entries after downloading missing dependencies / updates.
Bug was caused by incorrect use of JavaFX (common mistake, I did the same multiple times).

Also made the launcher launchable as a Gradle task (application plugin) and cached the status icons, instead of loading them on every status change.