### PR TITLE
Fix HTTP Redirects in the launcher when fetching JFX versions

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -22,16 +22,13 @@ import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.json.JsonValue;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class JavaFxDownloads {
   public static class SyntaxException extends Exception {

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -128,7 +128,8 @@ public class JavaFxDownloads {
     if (responseCode == HttpURLConnection.HTTP_MOVED_PERM ||
       responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||
       responseCode == HttpURLConnection.HTTP_SEE_OTHER ||
-      responseCode == 307) { // HTTP 307: Temporary Redirect. Does not have const in HttpURLConnection
+      responseCode == 307 || // HTTP 307: Temporary Redirect. Does not have const in HttpURLConnection
+      responseCode == 308) { // HTTP 308: Permanent Redirect. Does not have a const in HttpURLConnection
       return fetch(new URL(conn.getHeaderField("Location")));
     }
 

--- a/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
+++ b/launcher/src/se/llbit/chunky/launcher/JavaFxDownloads.java
@@ -22,13 +22,16 @@ import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.json.JsonValue;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class JavaFxDownloads {
   public static class SyntaxException extends Exception {
@@ -127,7 +130,8 @@ public class JavaFxDownloads {
     int responseCode = conn.getResponseCode();
     if (responseCode == HttpURLConnection.HTTP_MOVED_PERM ||
       responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||
-      responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
+      responseCode == HttpURLConnection.HTTP_SEE_OTHER ||
+      responseCode == 307) { // HTTP 307: Temporary Redirect. Does not have const in HttpURLConnection
       return fetch(new URL(conn.getHeaderField("Location")));
     }
 


### PR DESCRIPTION
HttpURLConnection does not handle redirects from HTTP to HTTPS. This PR fixes being unable to fetch JavaFX versions from the update site when a redirect across protocols occurs. Handles the HTTP 307 and 308 responses by following the redirect.

This leaves only HTTP 300 and 304 unhandled. 300 could be handled by choosing the Location field if it exists on the response. 304 should never be seen here and would require caching a previous response.