### PR TITLE
Fix banner pattern alpha channel being ignored.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
+++ b/chunky/src/java/se/llbit/chunky/entity/StandingBanner.java
@@ -452,7 +452,7 @@ public class StandingBanner extends Entity {
             int argb = bitmap.getPixel(x, y);
             ColorUtil.getRGBAComponents(argb, col);
             ColorUtil.getRGBAComponents(tinted.getPixel(x, y), com);
-            float f = col[0];
+            float f = col[3];
             tinted.setPixel(x, y, ColorUtil.getArgb(
                 color[0] * f + (1 - f) * com[0],
                 color[1] * f + (1 - f) * com[1],


### PR DESCRIPTION
Found a bug while working on #1707, which also affects stable Chunky.

Before:
![image](https://github.com/chunky-dev/chunky/assets/5544859/8105a209-f34a-4da5-a601-55e140665bbd)

After:
![image](https://github.com/chunky-dev/chunky/assets/5544859/8621a71a-c564-475a-93dd-ba0c1b6d3d19)
