### PR TITLE
Fix FirstTimeSetupDialog when chunky.home is set

### DIFF
--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -324,7 +324,7 @@ public class ChunkyLauncher {
       if (afterFirstTimeSetup.showLauncher()) {
         ChunkyLauncherFx.withLauncher(settings, Stage::show);
       }
-    } else if (SettingsDirectory.getChunkyHomeDirectory() != null) {
+    } else if (SettingsDirectory.getChunkyHomeDirectoryOverwrite().isPresent()) {
       headlessCreateSettingsDirectory();
       if (afterFirstTimeSetup.showLauncher()) {
         ChunkyLauncherFx.withLauncher(settings, Stage::show);

--- a/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
+++ b/launcher/src/se/llbit/chunky/launcher/ChunkyLauncher.java
@@ -319,8 +319,13 @@ public class ChunkyLauncher {
    * callback. Ensures that the JavaFX application (ChunkyLauncherFx) is initialized
    * before calling afterFirstTimeSetup.
    */
-  private static void firstTimeSetup(LauncherSettings settings, ShowLauncher afterFirstTimeSetup) {
+  private static void firstTimeSetup(LauncherSettings settings, ShowLauncher afterFirstTimeSetup) throws FileNotFoundException {
     if (SettingsDirectory.findSettingsDirectory()) {
+      if (afterFirstTimeSetup.showLauncher()) {
+        ChunkyLauncherFx.withLauncher(settings, Stage::show);
+      }
+    } else if (SettingsDirectory.getChunkyHomeDirectory() != null) {
+      headlessCreateSettingsDirectory();
       if (afterFirstTimeSetup.showLauncher()) {
         ChunkyLauncherFx.withLauncher(settings, Stage::show);
       }

--- a/lib/src/se/llbit/chunky/resources/SettingsDirectory.java
+++ b/lib/src/se/llbit/chunky/resources/SettingsDirectory.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.PersistentSettings;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Optional;
 
 /**
  * Utility class with helper function to locate the Chunky settings directory.
@@ -56,7 +57,7 @@ public final class SettingsDirectory {
    * if the settings directory could not be located.
    */
   public static File getSettingsDirectory() { // TODO: make this return Optional<File>.
-    File directory = getChunkyHomeDirectory();
+    File directory = getChunkyHomeDirectoryOverwrite().orElse(null);
     if (directory != null) {
       // We don't check if this is a valid settings directory because
       // we should always respect the system property in case the user
@@ -93,14 +94,14 @@ public final class SettingsDirectory {
   }
 
   /**
-   * @return the path specified by the "chunky.home" system property.
+   * @return the path specified by the "chunky.home" system property, if any
    */
-  public static File getChunkyHomeDirectory() {
+  public static Optional<File> getChunkyHomeDirectoryOverwrite() {
     String chunkyHomeProperty = System.getProperty("chunky.home");
     if (chunkyHomeProperty != null && !chunkyHomeProperty.isEmpty()) {
-      return new File(chunkyHomeProperty);
+      return Optional.of(new File(chunkyHomeProperty));
     }
-    return null;
+    return Optional.empty();
   }
 
   /**

--- a/lib/src/se/llbit/chunky/resources/SettingsDirectory.java
+++ b/lib/src/se/llbit/chunky/resources/SettingsDirectory.java
@@ -56,14 +56,14 @@ public final class SettingsDirectory {
    * if the settings directory could not be located.
    */
   public static File getSettingsDirectory() { // TODO: make this return Optional<File>.
-    String chunkyHomeProperty = System.getProperty("chunky.home");
-    if (chunkyHomeProperty != null && !chunkyHomeProperty.isEmpty()) {
+    File directory = getChunkyHomeDirectory();
+    if (directory != null) {
       // We don't check if this is a valid settings directory because
       // we should always respect the system property in case the user
       // has manually specified it.
-      return new File(chunkyHomeProperty);
+      return directory;
     }
-    File directory = getWorkingDirectory();
+    directory = getWorkingDirectory();
     if (isSettingsDirectory(directory)) {
       return directory;
     }
@@ -90,6 +90,17 @@ public final class SettingsDirectory {
       }
     }
     return false;
+  }
+
+  /**
+   * @return the path specified by the "chunky.home" system property.
+   */
+  public static File getChunkyHomeDirectory() {
+    String chunkyHomeProperty = System.getProperty("chunky.home");
+    if (chunkyHomeProperty != null && !chunkyHomeProperty.isEmpty()) {
+      return new File(chunkyHomeProperty);
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Solves: #1720

This prevents a FirstTimeSetupDialog GUI from being opened if a `chunky.home` system property is specified by the user.