### PR TITLE
Include Semver4j in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Chunky uses the following 3rd party libraries:
   See the file `licenses/Apache-2.0.txt` for the full license text.
   See the file `licenses/fast-util.txt` for the copyright notice.
 - **Gson by Google**  
-  The library is convered by the Apache License, version 2.0.
+  The library is covered by the Apache License, version 2.0.
   See the file `licenses/Apache-2.0.txt` for the full license text.
   See the file `licenses/gson.txt` for the copyright notice.
 - **Simplex noise implementation by Stefan Gustavson and Keijiro Takahashi**  
@@ -215,6 +215,9 @@ Chunky uses the following 3rd party libraries:
   See the file `licenses/Apache-2.0.txt` for the full license text.
   See the file `licenses/lz4-java.txt` for the copyright notice.
   lz4-java uses LZ4, by Yann Collet, which is covered by the BSD 2-Clause license. See the file `licenses/lz4.txt` for the copyright notice and full license.
+- **Semver4j by Vincent Durmont**
+  The library is covered by the MIT License.
+  See the file `licenses/semver4j.txt` for the copyright notice.
 
 ## Special Thanks
 

--- a/licenses/semver4j.txt
+++ b/licenses/semver4j.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present Vincent DURMONT <vdurmont@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Solves #1700

Lists Semver4j as third party dependency in README and ads Semver4j's MIT license.