### PR TITLE
Refactor resource pack loading

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/ChiseledBookshelfTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/ChiseledBookshelfTexture.java
@@ -54,7 +54,7 @@ public class ChiseledBookshelfTexture extends Texture {
   }
   @Override
   public float[] getColor(int x, int y) {
-    if(empty.usesAverageColor())
+    if(useAverageColor)
       return empty.getAvgColorFlat();
     float[] result = new float[4];
     boolean shouldOverlay = bookPresentAt(x, y);

--- a/chunky/src/java/se/llbit/chunky/resources/LayeredResourcePacks.java
+++ b/chunky/src/java/se/llbit/chunky/resources/LayeredResourcePacks.java
@@ -1,0 +1,141 @@
+package se.llbit.chunky.resources;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LayeredResourcePacks implements Closeable {
+  private final List<ResourcePack> resourcePacks = new ArrayList<>();
+
+  public void addResourcePack(File resourcePackFile) throws IOException {
+    this.resourcePacks.add(new ResourcePack(resourcePackFile));
+  }
+
+  public List<File> getResourcePackFiles() {
+    return Collections.unmodifiableList(resourcePacks.stream().map(ResourcePack::getFile).collect(Collectors.toList()));
+  }
+
+  public Optional<InputStream> getInputStream(String path) throws IOException {
+    Optional<Entry> entry = getFirstEntry(path);
+    if (entry.isPresent()) {
+      return Optional.ofNullable(entry.get().getInputStream());
+    }
+    return Optional.empty();
+  }
+
+  public Optional<Entry> getFirstEntry(String path) {
+    for (ResourcePack pack : resourcePacks) {
+      try {
+        Path resolvedPath = pack.getRootPath().resolve(path);
+        if (Files.exists(resolvedPath)) {
+          return Optional.of(new Entry(pack, resolvedPath));
+        }
+      } catch (IOException e) {
+        // ignore
+      }
+    }
+    return Optional.empty();
+  }
+
+  public Iterable<Entry> getAllEntries(String path) {
+    List<Entry> entries = new ArrayList<>();
+    for (ResourcePack pack : resourcePacks) {
+      Path resolvedPath;
+      try {
+        resolvedPath = pack.getRootPath().resolve(path);
+      } catch (IOException e) {
+        continue;
+      }
+      if (Files.exists(resolvedPath)) {
+        entries.add(new Entry(pack, resolvedPath));
+      }
+    }
+    return entries;
+  }
+
+  @Override
+  public void close() throws IOException {
+    for (ResourcePack resourcePack : resourcePacks) {
+      resourcePack.close();
+    }
+  }
+
+  public static class ResourcePack implements Closeable {
+    public File file;
+    private FileSystem fileSystem;
+    private Path rootPath;
+
+    private ResourcePack(File resourcePackFile) {
+      this.file = resourcePackFile;
+    }
+
+    public File getFile() {
+      return file;
+    }
+
+    private FileSystem getFileSystem() throws IOException {
+      if (fileSystem != null && fileSystem.isOpen()) {
+        return fileSystem;
+      }
+      return fileSystem = ResourcePackLoader.getPackFileSystem(file);
+    }
+
+    public Path getRootPath() throws IOException {
+      if (rootPath == null) {
+        Path rootPath = ResourcePackLoader.getPackRootPath(file, getFileSystem());
+        String baseName = file.getName();
+        if (baseName.toLowerCase().endsWith(".zip")) {
+          // The assets directory can be inside a top-level directory with
+          // the same name as the resource pack zip file.
+          baseName = baseName.substring(0, baseName.length() - 4);
+          if (Files.exists(rootPath.resolve(baseName).resolve("assets"))) {
+            rootPath = rootPath.resolve(baseName);
+          }
+        }
+        this.rootPath = rootPath;
+      }
+
+      return rootPath;
+    }
+
+    @Override
+    public void close() throws IOException {
+      try {
+        fileSystem.close();
+      } catch (UnsupportedOperationException e) {
+        // default file systems do not support closing
+      }
+    }
+  }
+
+  public static class Entry {
+    private final ResourcePack pack;
+    private final Path path;
+
+    public Entry(ResourcePack pack, Path path) {
+      this.pack = pack;
+      this.path = path;
+    }
+
+    public ResourcePack getPack() {
+      return pack;
+    }
+
+    public Path getPath() {
+      return path;
+    }
+
+    public InputStream getInputStream() throws IOException {
+      return Files.newInputStream(path);
+    }
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/resources/ResourcePackBiomeLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/ResourcePackBiomeLoader.java
@@ -24,7 +24,8 @@ import se.llbit.chunky.world.biome.BiomeBuilder;
 import se.llbit.chunky.world.biome.Biomes;
 import se.llbit.log.Log;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -33,7 +34,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 public class ResourcePackBiomeLoader implements ResourcePackLoader.PackLoader {
-  public ResourcePackBiomeLoader() {}
+  public ResourcePackBiomeLoader() {
+  }
 
   protected static final Gson GSON = new GsonBuilder()
     .disableJdkUnsafe()
@@ -54,10 +56,9 @@ public class ResourcePackBiomeLoader implements ResourcePackLoader.PackLoader {
   }
 
   @Override
-  public boolean load(Path pack, String baseName) {
-    Path data = pack.resolve("data");
-    if (Files.exists(data)) {
-      try (Stream<Path> namespaces = Files.list(data)) {
+  public boolean load(LayeredResourcePacks resourcePacks) {
+    for (LayeredResourcePacks.Entry data : resourcePacks.getAllEntries("data")) {
+      try (Stream<Path> namespaces = Files.list(data.getPath())) {
         namespaces.forEach(ns -> {
           String namespace = String.valueOf(ns.getFileName());
 

--- a/chunky/src/java/se/llbit/chunky/resources/ResourcePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/ResourcePackLoader.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.*;
@@ -46,7 +47,7 @@ public class ResourcePackLoader {
      * @return True if this loader has found and loaded _all_ the things it is responsible for.
      * False if there is more to load (by a fallback resource pack).
      */
-    boolean load(Path pack, String baseName);
+    boolean load(LayeredResourcePacks resourcePacks);
 
     /**
      * All resources that failed to load. Empty if all resources were loaded.
@@ -64,13 +65,13 @@ public class ResourcePackLoader {
     PackLoader create();
   }
 
-  private static List<File> loadedResourcePacks = Collections.emptyList();
+  private static LayeredResourcePacks resourcePacks = new LayeredResourcePacks();
 
   /**
-   * @return loaded resource packs without default pack
+   * @return loaded resource packs
    */
   public static List<File> getLoadedResourcePacks() {
-    return Collections.unmodifiableList(loadedResourcePacks);
+    return resourcePacks.getResourcePackFiles();
   }
 
   public static List<File> getAvailableResourcePacks() {
@@ -119,15 +120,54 @@ public class ResourcePackLoader {
     TextureCache.reset();
     Biomes.reset();
 
-    loadedResourcePacks = resourcePacks.stream()
-      .distinct()
-      .collect(Collectors.toList());
+    if (ResourcePackLoader.resourcePacks != null) {
+      try {
+        ResourcePackLoader.resourcePacks.close();
+      } catch (IOException e) {
+        // ignore
+      }
+    }
+
+    LayeredResourcePacks packs = new LayeredResourcePacks();
+    for (File packFile : resourcePacks) {
+      try {
+        packs.addResourcePack(packFile);
+      } catch (IOException e) {
+        Log.warnf(
+          "Failed to open %s (%s): %s",
+          getResourcePackDescriptor(packFile),
+          packFile.getAbsolutePath(),
+          e.getMessage()
+        );
+      }
+    }
+    if (!PersistentSettings.getDisableDefaultTextures()) {
+      File file = MinecraftFinder.getMinecraftJar();
+      if (file != null) {
+        try {
+          packs.addResourcePack(file);
+        } catch (IOException e) {
+          Log.warn("Minecraft Jar could not be opened: falling back to placeholder textures.");
+        }
+      } else {
+        Log.warn("Minecraft Jar not found: falling back to placeholder textures.");
+      }
+    }
+    ResourcePackLoader.resourcePacks = packs;
+
+    Log.infof(
+      "Loading resource packs: \n%s",
+      resourcePacks.stream()
+        .map(File::toString)
+        .map(s -> "- " + s)
+        .collect(Collectors.joining("\n"))
+    );
 
     List<PackLoader> loaders = PACK_LOADER_FACTORIES.stream()
       .map(PackLoaderFactory::create)
       .collect(Collectors.toList());
 
-    if (!reloadResourcePacks(loaders)) {
+    if (!loadResources(loaders)) {
       Log.info(buildMissingResourcesErrorMessage(loaders));
     }
   }
@@ -138,88 +178,22 @@ public class ResourcePackLoader {
    * @return True if all resources have been found and loaded.
    */
   public static boolean loadResources(PackLoader... loaders) {
-    return reloadResourcePacks(Arrays.asList(loaders));
-  }
-
-  private static boolean reloadResourcePacks(List<PackLoader> loaders) {
-    List<File> resourcePacks = new ArrayList<>(getLoadedResourcePacks());
-
-    if (!PersistentSettings.getDisableDefaultTextures()) {
-      File file = MinecraftFinder.getMinecraftJar();
-      if (file != null) {
-        resourcePacks.add(file);
-      } else {
-        Log.warn("Minecraft Jar not found: falling back to placeholder textures.");
-      }
-    }
-
-    return loadResourcePacks(resourcePacks, loaders);
-  }
-
-  private static boolean loadResourcePacks(List<File> resourcePacks, List<PackLoader> loaders) {
-    Log.infof(
-      "Loading resource packs: \n%s",
-      resourcePacks.stream()
-        .map(File::toString)
-        .map(s -> "- " + s)
-        .collect(Collectors.joining("\n"))
-    );
-    return loadResourcePacks(
-      resourcePacks.iterator(),
-      loaders
-    );
+    return loadResources(Arrays.asList(loaders));
   }
 
   /**
-   * Load resources from the given resource packs.
-   * Resource pack files are loaded in list order - if a texture is not found in a pack,
-   * the next packs is checked as a fallback.
+   * Load resources from all resource packs.
    *
-   * @return True if all resources have been found and loaded.
+   * @return True if all resources have been found in the packs and no fallback is required.
    */
-  private static boolean loadResourcePacks(Iterator<File> resourcePacks, List<PackLoader> loaders) {
-    while (resourcePacks.hasNext()) {
-      File resourcePack = resourcePacks.next();
-      if (resourcePack.isFile() || resourcePack.isDirectory()) {
-        if (loadSingleResourcePack(resourcePack, loaders)) {
-          return true;
-        }
-        Log.infof("Missing %d resources in: %s", countMissingResources(loaders), resourcePack.getAbsolutePath());
-      } else {
-        Log.errorf("Invalid path to resource pack: %s", resourcePack.getAbsolutePath());
+  private static boolean loadResources(List<PackLoader> loaders) {
+    boolean complete = true;
+    for (PackLoader loader : loaders) {
+      if (!loader.load(resourcePacks)) {
+        complete = false;
       }
     }
-    return false;
-  }
-
-  /**
-   * Load resources from a single resource pack.
-   *
-   * @return True if all resources have been found in this pack and no fallback is required.
-   */
-  private static boolean loadSingleResourcePack(File pack, List<PackLoader> loaders) {
-    Log.infof("Loading %s %s", getResourcePackDescriptor(pack), pack.getAbsolutePath());
-    try (FileSystem resourcePack = getPackFileSystem(pack)) {
-      Path root = getPackRootPath(pack, resourcePack);
-
-      boolean complete = true;
-      for (PackLoader loader : loaders) {
-        if (!loader.load(root, pack.getName())) {
-          complete = false;
-        }
-      }
-      return complete;
-    } catch (UnsupportedOperationException uoex) {
-      // default file systems do not support closing
-    } catch (IOException ioex) {
-      Log.warnf(
-        "Failed to open %s (%s): %s",
-        getResourcePackDescriptor(pack),
-        pack.getAbsolutePath(),
-        ioex.getMessage()
-      );
-    }
-    return false;
+    return complete;
   }
 
   public static String getResourcePackDescriptor(File pack) {
@@ -240,6 +214,9 @@ public class ResourcePackLoader {
       // This catch is required for Java 8. This error appears safe to catch.
       // https://stackoverflow.com/a/51715939
       throw new IOException(e);
+    } catch (FileSystemAlreadyExistsException e) {
+      // for resource packs in jar or zip files (re-use existing fs)
+      return FileSystems.getFileSystem(URI.create("jar:" + pack.toURI()));
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/ResourcePackTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/ResourcePackTextureLoader.java
@@ -22,117 +22,110 @@ import se.llbit.resources.ImageLoader;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class ResourcePackTextureLoader implements ResourcePackLoader.PackLoader {
-    private final HashMap<String, TextureLoader> texturesToLoad;
+  private final HashMap<String, TextureLoader> texturesToLoad;
 
-    /**
-     * Create a texture loader.
-     * @param textures Textures to load. This map will be duplicated and will not be modified.
-     */
-    public ResourcePackTextureLoader(Map<String, TextureLoader> textures) {
-        texturesToLoad = new HashMap<>(textures);
+  /**
+   * Create a texture loader.
+   *
+   * @param textures Textures to load. This map will be duplicated and will not be modified.
+   */
+  public ResourcePackTextureLoader(Map<String, TextureLoader> textures) {
+    texturesToLoad = new HashMap<>(textures);
+  }
+
+  /**
+   * Create a texture loader for a single texture.
+   */
+  public static ResourcePackTextureLoader singletonLoader(String textureId, TextureLoader loader) {
+    return new ResourcePackTextureLoader(Collections.singletonMap(textureId, loader));
+  }
+
+  @Override
+  public boolean load(LayeredResourcePacks resourcePacks) {
+    if (texturesToLoad.isEmpty()) {
+      return true;
     }
 
-    /**
-     * Create a texture loader for a single texture.
-     */
-    public static ResourcePackTextureLoader singletonLoader(String textureId, TextureLoader loader) {
-        return new ResourcePackTextureLoader(Collections.singletonMap(textureId, loader));
+    // Keep track of which textures have been loaded and may be removed
+    ArrayList<String> toRemove = new ArrayList<>();
+
+    for (Map.Entry<String, TextureLoader> texture : texturesToLoad.entrySet()) {
+      if (texture.getValue().load(resourcePacks)) {
+        toRemove.add(texture.getKey());
+      }
     }
+    loadTerrainTextures(resourcePacks, toRemove);
 
-    @Override
-    public boolean load(Path pack, String baseName) {
-        if (texturesToLoad.isEmpty()) {
-            return true;
+    // Remove all textures which have been loaded
+    toRemove.forEach(texturesToLoad::remove);
+
+    return texturesToLoad.isEmpty();
+  }
+
+  @Override
+  public Collection<String> notLoaded() {
+    return Collections.unmodifiableCollection(texturesToLoad.keySet());
+  }
+
+  private void loadTerrainTextures(LayeredResourcePacks root, ArrayList<String> toRemove) {
+    Optional<InputStream> in = Optional.empty();
+    try {
+      in = root.getInputStream("terrain.png");
+      if (!in.isPresent()) {
+        return;
+      }
+      BitmapImage spriteMap = ImageLoader.read(in.get());
+      BitmapImage[] terrainTextures = getTerrainTextures(spriteMap);
+
+      for (Map.Entry<String, TextureLoader> texture : texturesToLoad.entrySet()) {
+        if (texture.getValue().loadFromTerrain(terrainTextures)) {
+          toRemove.add(texture.getKey());
         }
-
-        Path root = null;
-        if (Files.exists(pack.resolve("assets"))) {
-            root = pack;
-        } else if (baseName.toLowerCase().endsWith(".zip")) {
-            // The assets directory can be inside a top-level directory with
-            // the same name as the resource pack zip file.
-            baseName = baseName.substring(0, baseName.length()-4);
-            if (Files.exists(pack.resolve(baseName).resolve("assets"))) {
-                root = pack.resolve(baseName);
-            }
-        }
-        if (root == null) {
-            return false;
-        }
-
-        // Keep track of which textures have been loaded and may be removed
-        ArrayList<String> toRemove = new ArrayList<>();
-
-        for (Map.Entry<String, TextureLoader> texture : texturesToLoad.entrySet()) {
-            if (texture.getValue().load(pack)) {
-                toRemove.add(texture.getKey());
-            }
-        }
-        loadTerrainTextures(root, toRemove);
-
-        // Remove all textures which have been loaded
-        toRemove.forEach(texturesToLoad::remove);
-
-        return texturesToLoad.isEmpty();
-    }
-
-    @Override
-    public Collection<String> notLoaded() {
-        return Collections.unmodifiableCollection(texturesToLoad.keySet());
-    }
-
-    private void loadTerrainTextures(Path root, ArrayList<String> toRemove) {
-        try (InputStream in = Files.newInputStream(root.resolve("terrain.png"))) {
-            BitmapImage spriteMap = ImageLoader.read(in);
-            BitmapImage[] terrainTextures = getTerrainTextures(spriteMap);
-
-            for (Map.Entry<String, TextureLoader> texture : texturesToLoad.entrySet()) {
-                if (texture.getValue().loadFromTerrain(terrainTextures)) {
-                    toRemove.add(texture.getKey());
-                }
-            }
+      }
+    } catch (IOException e) {
+      // Failed to load terrain textures - this is handled implicitly.
+    } finally {
+      if (in.isPresent()) {
+        try {
+          in.get().close();
         } catch (IOException e) {
-            // Failed to load terrain textures - this is handled implicitly.
+          // ignore
         }
+      }
+    }
+  }
+
+  /**
+   * Load a 16x16 spritemap.
+   *
+   * @return A bufferedImage containing the spritemap
+   * @throws IOException if the image dimensions are incorrect
+   */
+  private static BitmapImage[] getTerrainTextures(BitmapImage spritemap) throws IOException {
+    if (spritemap.width != spritemap.height || spritemap.width % 16 != 0) {
+      throw new IOException(
+        "Error: terrain.png file must have equal width and height, divisible by 16!");
     }
 
-    /**
-     * Load a 16x16 spritemap.
-     *
-     * @return A bufferedImage containing the spritemap
-     * @throws IOException if the image dimensions are incorrect
-     */
-    private static BitmapImage[] getTerrainTextures(BitmapImage spritemap) throws IOException {
-        if (spritemap.width != spritemap.height || spritemap.width % 16 != 0) {
-            throw new IOException(
-                    "Error: terrain.png file must have equal width and height, divisible by 16!");
-        }
+    int imgW = spritemap.width;
+    int spriteW = imgW / 16;
+    BitmapImage[] tex = new BitmapImage[256];
 
-        int imgW = spritemap.width;
-        int spriteW = imgW / 16;
-        BitmapImage[] tex = new BitmapImage[256];
-
-        for (int i = 0; i < 256; ++i) {
-            tex[i] = new BitmapImage(spriteW, spriteW);
-        }
-
-        for (int y = 0; y < imgW; ++y) {
-            int sy = y / spriteW;
-            for (int x = 0; x < imgW; ++x) {
-                int sx = x / spriteW;
-                BitmapImage texture = tex[sx + sy * 16];
-                texture.setPixel(x % spriteW, y % spriteW, spritemap.getPixel(x, y));
-            }
-        }
-        return tex;
+    for (int i = 0; i < 256; ++i) {
+      tex[i] = new BitmapImage(spriteW, spriteW);
     }
+
+    for (int y = 0; y < imgW; ++y) {
+      int sy = y / spriteW;
+      for (int x = 0; x < imgW; ++x) {
+        int sx = x / spriteW;
+        BitmapImage texture = tex[sx + sy * 16];
+        texture.setPixel(x % spriteW, y % spriteW, spritemap.getPixel(x, y));
+      }
+    }
+    return tex;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1517,12 +1517,13 @@ public class Texture {
 
   public static final Texture armorStand = new Texture();
 
+  protected static boolean useAverageColor = PersistentSettings.getSingleColorTextures();
+
   @NotNull protected BitmapImage image;
   protected int width;
   protected int height;
   protected int avgColor;
   private float[] avgColorLinear;
-  private boolean usesAverageColor = false;
   private float[] avgColorFlat;
 
   private Image fxImage = null;
@@ -1537,14 +1538,6 @@ public class Texture {
 
   public Texture(BitmapImage img) {
     setTexture(img);
-    useAverageColor(PersistentSettings.getSingleColorTextures());
-  }
-
-  public void useAverageColor(boolean enable) {
-    usesAverageColor = enable;
-  }
-  public boolean usesAverageColor() {
-    return usesAverageColor;
   }
 
   public void setTexture(Texture texture) {
@@ -1621,7 +1614,7 @@ public class Texture {
    * @return color
    */
   public float[] getColor(int x, int y) {
-    if(usesAverageColor)
+    if(useAverageColor)
       return avgColorFlat;
     float[] result = new float[4];
     ColorUtil.getRGBAComponentsGammaCorrected(image.data[width*y + x], result);
@@ -1723,5 +1716,9 @@ public class Texture {
 
   public BitmapImage getBitmap() {
     return image;
+  }
+
+  public static void setUseAverageColor(boolean useAverageColor) {
+    Texture.useAverageColor = useAverageColor;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/AllTextures.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/AllTextures.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,7 +31,7 @@ public class AllTextures extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     int loaded = 0;
     for (TextureLoader alternative : textures) {
       if (alternative.load(texturePack)) {

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/AlternateTextures.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/AlternateTextures.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,7 +50,7 @@ public class AlternateTextures extends TextureLoader {
         "It is pointless to create an alternative texture loader with only one alternative.");
   }
 
-  @Override public boolean load(Path texturePack) {
+  @Override public boolean load(LayeredResourcePacks texturePack) {
     for (TextureLoader alternative : alternatives) {
       if (alternative.load(texturePack)) {
         return true;

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/AnimatedTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/AnimatedTextureLoader.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -50,7 +51,7 @@ public class AnimatedTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/AsciiFontTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/AsciiFontTextureLoader.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.resources.texturepack.FontTexture.Glyph;
 import se.llbit.resources.ImageLoader;
@@ -38,7 +39,7 @@ public class AsciiFontTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/BedTextureAdapter.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/BedTextureAdapter.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.log.Log;
 
@@ -78,7 +79,7 @@ public class BedTextureAdapter extends TextureLoader {
         new IndexedTexture(0x98, bedHeadEnd));
   }
 
-  @Override public boolean load(Path texturePack) {
+  @Override public boolean load(LayeredResourcePacks texturePack) {
     boolean allLoaded = true;
     int scale = 1;
     BitmapImage bitmap = new BitmapImage(64, 64);

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/ChestTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/ChestTexture.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -152,7 +153,7 @@ public class ChestTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/CloudsTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/CloudsTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.world.Clouds;
 import se.llbit.resources.ImageLoader;
 
@@ -49,8 +50,9 @@ public class CloudsTexture extends TextureLoader {
     return true;
   }
 
-  @Override public boolean load(Path texturePack) {
-    return load(file, texturePack);
+  @Override
+  public boolean load(LayeredResourcePacks texturePack) {
+    return super.load(file, texturePack);
   }
 }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/ColoredTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/ColoredTexture.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.ColorUtil;
 import se.llbit.resources.ImageLoader;
@@ -61,7 +62,7 @@ public class ColoredTexture extends TextureLoader {
     return true;
   }
 
-  @Override public boolean load(Path texturePack) {
+  @Override public boolean load(LayeredResourcePacks texturePack) {
     return load(textureName, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/ConditionalTextures.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/ConditionalTextures.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,8 +23,8 @@ public class ConditionalTextures extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
-    if (Files.exists(texturePack.resolve(testFor))) {
+  public boolean load(LayeredResourcePacks texturePack) {
+    if (texturePack.getFirstEntry(testFor).isPresent()) {
       return then.load(texturePack);
     }
     return otherwise.load(texturePack);

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/EntityTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/EntityTextureLoader.java
@@ -18,6 +18,7 @@ package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.chunky.resources.EntityTexture;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.resources.ImageLoader;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class EntityTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/FoliageColorTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/FoliageColorTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.world.biome.Biomes;
 import se.llbit.resources.ImageLoader;
 
@@ -45,7 +46,7 @@ public class FoliageColorTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/GrassColorTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/GrassColorTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.world.biome.Biomes;
 import se.llbit.resources.ImageLoader;
 
@@ -45,7 +46,7 @@ public class GrassColorTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/IndexedTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/IndexedTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class IndexedTexture extends TextureLoader {
     return true;
   }
 
-  @Override public boolean load(Path texturePack) {
+  @Override public boolean load(LayeredResourcePacks texturePack) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/LargeChestTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/LargeChestTexture.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -105,7 +106,7 @@ public class LargeChestTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/LayeredTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/LayeredTextureLoader.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.log.Log;
 import se.llbit.resources.ImageLoader;
@@ -72,7 +73,7 @@ public class LayeredTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return baseTexture.load(texturePack)
             && load(textureName, texturePack);
   }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingBackTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingBackTexture.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -57,7 +58,7 @@ public class PaintingBackTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingTexture.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -46,7 +47,7 @@ public class PaintingTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingTextureAdapter.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/PaintingTextureAdapter.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.nio.file.Path;
 public class PaintingTextureAdapter extends TextureLoader {
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     PaintingsAtlas paintings = new PaintingsAtlas();
     if (new SimpleTexture("assets/minecraft/textures/painting/paintings_kristoffer_zetterstrand",
             paintings).load(texturePack)) {

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/PlayerTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/PlayerTextureLoader.java
@@ -19,6 +19,7 @@ package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.renderer.scene.PlayerModel;
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.PlayerTexture;
 import se.llbit.resources.ImageLoader;
 
@@ -53,7 +54,7 @@ public class PlayerTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/RotatedTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/RotatedTextureLoader.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 
 import java.io.IOException;
@@ -39,7 +40,7 @@ public class RotatedTextureLoader extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     if (!loader.load(texturePack)) {
       return false;
     }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/ShulkerTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/ShulkerTextureLoader.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.ShulkerTexture;
 import se.llbit.resources.ImageLoader;
 
@@ -123,7 +124,7 @@ public class ShulkerTextureLoader extends TextureLoader {
     return image;
   }
 
-  @Override public boolean load(Path texturePack) {
+  @Override public boolean load(LayeredResourcePacks texturePack) {
     return load(entityTexture, texturePack);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/SimpleTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/SimpleTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -62,7 +63,7 @@ public class SimpleTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/SplitLargeChestTexture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/SplitLargeChestTexture.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.resources.texturepack;
 
 import se.llbit.chunky.resources.BitmapImage;
+import se.llbit.chunky.resources.LayeredResourcePacks;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.resources.ImageLoader;
 
@@ -96,7 +97,7 @@ public class SplitLargeChestTexture extends TextureLoader {
   }
 
   @Override
-  public boolean load(Path texturePack) {
+  public boolean load(LayeredResourcePacks texturePack) {
     return load(file, texturePack);
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -29,10 +29,10 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.geometry.HPos;
 import javafx.scene.Node;
-import javafx.scene.control.*;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.*;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
@@ -56,17 +56,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.ResourceBundle;
+import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
@@ -211,7 +206,7 @@ public class ResourcePackChooserController implements Initializable {
       this.setContextMenu(new ContextMenu(
         buildMenuItem("Open in system file browser",
           evt -> {
-            if(getItem() == null)
+            if (getItem() == null)
               return;
             try {
               File texturePackFile = getItem().file;
@@ -240,7 +235,7 @@ public class ResourcePackChooserController implements Initializable {
             }
           },
           menuItem -> {
-            if(Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
               menuItem.disableProperty().bind(itemProperty().isNull());
             } else {
               menuItem.setDisable(true);
@@ -256,8 +251,10 @@ public class ResourcePackChooserController implements Initializable {
     }
 
     private MenuItem buildMenuItem(String label, EventHandler<ActionEvent> eventHandler) {
-      return buildMenuItem(label,eventHandler, menuItem -> {});
+      return buildMenuItem(label, eventHandler, menuItem -> {
+      });
     }
+
     private MenuItem buildMenuItem(String label, EventHandler<ActionEvent> eventHandler, Consumer<MenuItem> init) {
       MenuItem item = new MenuItem(label);
       item.setOnAction(eventHandler);
@@ -363,10 +360,10 @@ public class ResourcePackChooserController implements Initializable {
       "pack.mcmeta"
     ));
     File dir = MinecraftFinder.getResourcePacksDirectory();
-    if(dir.isDirectory()) {
+    if (dir.isDirectory()) {
       fileChooser.setInitialDirectory(dir);
     }
-    
+
     List<File> newlyAddedFiles = fileChooser.showOpenMultipleDialog(addNewTargetPackBtn.getScene().getWindow());
     if (newlyAddedFiles == null)
       return;
@@ -474,10 +471,7 @@ public class ResourcePackChooserController implements Initializable {
     public static Image MISSING_PACK_PNG = null;
 
     private static void loadMissingPackPng(File minecraftJar) {
-      try (FileSystem zipFs = FileSystems.newFileSystem(
-        URI.create("jar:" + minecraftJar.toURI()),
-        Collections.emptyMap()
-      )) {
+      try (FileSystem zipFs = ResourcePackLoader.getPackFileSystem(minecraftJar)) {
         Path unknownPackPng = zipFs.getPath("assets/minecraft/textures/misc/unknown_pack.png");
         try (InputStream unknownPackPngStream = Files.newInputStream(unknownPackPng)) {
           MISSING_PACK_PNG = new Image(unknownPackPngStream);
@@ -518,8 +512,8 @@ public class ResourcePackChooserController implements Initializable {
 
     public String getFormatVersionString() {
       return formatVersion <= 0
-         ? ""
-         : ("v" + formatVersion);
+        ? ""
+        : ("v" + formatVersion);
     }
 
     public PackListItem(File resourcePackFile) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/TexturesTab.java
@@ -33,6 +33,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.RenderController;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.renderer.scene.SceneManager;
+import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.ui.IntegerAdjuster;
 import se.llbit.chunky.ui.controller.RenderControlsFxController;
 import se.llbit.chunky.ui.dialogs.ResourcePackChooser;
@@ -87,6 +88,7 @@ public class TexturesTab extends ScrollPane implements RenderControlsTab, Initia
     singleColorBtn.selectedProperty().addListener((observable, oldValue, newValue) -> {
       Scene scene = sceneManager.getScene();
       PersistentSettings.setSingleColorTextures(newValue);
+      Texture.setUseAverageColor(newValue);
       scene.refresh();
       scene.rebuildBvh();
     });


### PR DESCRIPTION
For now, this makes loading painting variant and biome registries less hacky. In the future, this enables loading other files, eg. model json files, PBR maps or animation metadata. 

Related to #751, #1332 and #1728 