### PR TITLE
Update to JUnit5, Update to J17 and J21 for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,17 +31,28 @@ subprojects {
     group = 'se.llbit'
     version = rootProject.version
 
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
+    compileTestJava {
+        javaCompiler = javaToolchains.compilerFor {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+    test {
+        javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+        useJUnitPlatform()
 
-    compileJava {
-        options.encoding = 'UTF-8'
-        options.debug = true
-        options.deprecation = true
+        // Always run tests, even when nothing changed.
+        dependsOn 'cleanTest'
     }
 
     javafx {
-        version = '11.0.2'
+        version = '17.0.11'
         configuration = 'implementation'
         modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
     }
@@ -63,6 +74,12 @@ subprojects {
         nbtlib 'se.llbit:jo-nbt:1.3.0'
         cplib 'se.llbit:luxcp:1.0.1'
         toolpanelib 'se.llbit:toolpane:0.1'
+
+        testImplementation("org.assertj:assertj-core:3.25.1")
+
+        testImplementation(platform('org.junit:junit-bom:5.10.2'))
+        testImplementation('org.junit.jupiter:junit-jupiter')
+        testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     }
 
     idea {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'org.openjfx.javafxplugin'
 
     apply plugin: 'idea'
     apply plugin: 'com.github.ben-manes.versions'
@@ -33,15 +32,18 @@ subprojects {
 
     java {
         toolchain {
+            // default java version for the project, some subprojects are pinned to java 8 for backwards compatibility (see their configs).
             languageVersion = JavaLanguageVersion.of(17)
         }
     }
     compileTestJava {
+        // compile tests using more recent features
         javaCompiler = javaToolchains.compilerFor {
             languageVersion = JavaLanguageVersion.of(21)
         }
     }
     test {
+        // run tests using more recent features
         javaLauncher = javaToolchains.launcherFor {
             languageVersion = JavaLanguageVersion.of(21)
         }
@@ -57,12 +59,6 @@ subprojects {
     }
     jacocoTestReport {
         dependsOn test // tests are required to run before generating the report
-    }
-
-    javafx {
-        version = '17.0.11'
-        configuration = 'implementation'
-        modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
     }
 
     javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,14 @@ subprojects {
 
         // Always run tests, even when nothing changed.
         dependsOn 'cleanTest'
+
+        finalizedBy jacocoTestReport // report is always generated after tests run (it's very cheap)
+    }
+    jacoco {
+        toolVersion = "0.8.11"
+    }
+    jacocoTestReport {
+        dependsOn test // tests are required to run before generating the report
     }
 
     javafx {
@@ -253,6 +261,7 @@ task docs(type: Javadoc) {
 }
 
 task clean {
+    group = "Build"
     doLast {
         delete "./build"
     }

--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -18,8 +18,15 @@ dependencies {
   implementation 'org.lz4:lz4-java:1.8.0'
   implementation project(':lib')
 
-  testImplementation 'com.google.truth:truth:1.1.3'
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation("org.assertj:assertj-core:3.25.1")
+
+  testImplementation(platform('org.junit:junit-bom:5.10.2'))
+  testImplementation('org.junit.jupiter:junit-jupiter')
+  testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+}
+
+test {
+  useJUnitPlatform()
 }
 
 jar {

--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'application'
 apply plugin: 'maven-publish'
+apply plugin: 'org.openjfx.javafxplugin'
 
 mainClassName = 'se.llbit.chunky.main.Chunky'
 archivesBaseName = 'chunky-core'
@@ -17,6 +18,12 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.9.0'
   implementation 'org.lz4:lz4-java:1.8.0'
   implementation project(':lib')
+}
+
+javafx {
+  version = '17.0.11'
+  configuration = 'implementation'
+  modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
 }
 
 jar {

--- a/chunky/build.gradle
+++ b/chunky/build.gradle
@@ -17,16 +17,6 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.9.0'
   implementation 'org.lz4:lz4-java:1.8.0'
   implementation project(':lib')
-
-  testImplementation("org.assertj:assertj-core:3.25.1")
-
-  testImplementation(platform('org.junit:junit-bom:5.10.2'))
-  testImplementation('org.junit.jupiter:junit-jupiter')
-  testRuntimeOnly('org.junit.platform:junit-platform-launcher')
-}
-
-test {
-  useJUnitPlatform()
 }
 
 jar {

--- a/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
+++ b/chunky/src/test/se/llbit/chunky/block/SkullTextureTest.java
@@ -1,13 +1,11 @@
 package se.llbit.chunky.block;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import se.llbit.chunky.block.minecraft.Head;
 import se.llbit.chunky.renderer.scene.PlayerModel;
 import se.llbit.nbt.CompoundTag;
@@ -15,6 +13,9 @@ import se.llbit.nbt.ListTag;
 import se.llbit.nbt.StringTag;
 import se.llbit.nbt.Tag;
 import se.llbit.util.mojangapi.MinecraftSkin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SkullTextureTest {
 

--- a/chunky/src/test/se/llbit/chunky/chunk/BlockPaletteTest.java
+++ b/chunky/src/test/se/llbit/chunky/chunk/BlockPaletteTest.java
@@ -1,21 +1,23 @@
 package se.llbit.chunky.chunk;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.StringTag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 public class BlockPaletteTest {
   // Test that the block palette reuses existing blocks with the same tag data.
-  @Test public void testBlockReuse() {
+  @Test
+  public void testBlockReuse() {
     CompoundTag t1 = new CompoundTag();
     t1.add("Name", new StringTag("some block"));
     CompoundTag t2 = new CompoundTag();
     t2.add("Name", new StringTag("some block"));
     BlockPalette palette = new BlockPalette();
-    assertEquals("Block palette does not reuse block IDs for duplicate tags",
-        palette.put(t1), palette.put(t2));
+    assertEquals(palette.put(t1), palette.put(t2),
+      "Block palette does not reuse block IDs for duplicate tags");
   }
 
   // Test that the block palette reuses the existing air id.

--- a/chunky/src/test/se/llbit/chunky/entity/MarshallingTest.java
+++ b/chunky/src/test/se/llbit/chunky/entity/MarshallingTest.java
@@ -17,14 +17,14 @@
  */
 package se.llbit.chunky.entity;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.json.Json;
 import se.llbit.json.JsonArray;
 import se.llbit.json.JsonValue;
 import se.llbit.math.Vector3;
 import se.llbit.nbt.CompoundTag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test entity marshalling/unmarshalling to/from JSON.

--- a/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/OptionHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package se.llbit.chunky.main;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.chunky.main.CommandLineOptions.InvalidCommandLineArgumentsException;
 import se.llbit.chunky.main.CommandLineOptions.OptionHandler;
 import se.llbit.chunky.main.CommandLineOptions.Range;
@@ -27,7 +27,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 public class OptionHandlerTest {
   private void expectBart(List<String> arguments) {
@@ -48,7 +50,8 @@ public class OptionHandlerTest {
     assertThat(arguments).hasSize(2);
   }
 
-  @Test public void testOptionWithNoArgument() throws InvalidCommandLineArgumentsException {
+  @Test
+  public void testOptionWithNoArgument() throws InvalidCommandLineArgumentsException {
     OptionHandler handler1 = new OptionHandler("-bart", new Range(0), arguments -> {});
     List<String> extraArgs1 = handler1.handle(Collections.emptyList());
     assertThat(extraArgs1).isEmpty();
@@ -132,28 +135,28 @@ public class OptionHandlerTest {
     assertThat(extraArgs6).containsExactly("-42");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testError_NoOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
-    handler.handle(Collections.emptyList());
+    assertThrows(IllegalArgumentException.class, () -> handler.handle(Collections.emptyList()));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testError_WrongOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), arguments -> {});
     // The -bort argument is treated as a separate option.
-    handler.handle(Collections.singletonList("-bort"));
+    assertThrows(IllegalArgumentException.class, () -> handler.handle(Collections.singletonList("-bort")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testError_ArgumentInsteadOfOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
-    handler.handle(Collections.singletonList("bort"));
+    assertThrows(IllegalArgumentException.class, () -> handler.handle(Collections.singletonList("bort")));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testError_NumberInsteadOfOptionGiven() throws InvalidCommandLineArgumentsException {
     OptionHandler handler = new OptionHandler("-bart", new Range(1), this::expectBart);
-    handler.handle(Collections.singletonList("-42"));
+    assertThrows(IllegalArgumentException.class, () -> handler.handle(Collections.singletonList("-42")));
   }
 }

--- a/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
+++ b/chunky/src/test/se/llbit/chunky/main/PluginApiTest.java
@@ -17,7 +17,8 @@
  */
 package se.llbit.chunky.main;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import se.llbit.chunky.plugin.TabTransformer;
 import se.llbit.chunky.renderer.*;
 import se.llbit.chunky.renderer.scene.RayTracer;
@@ -27,15 +28,16 @@ import se.llbit.chunky.ui.render.RenderControlsTabTransformer;
 import se.llbit.util.Mutable;
 
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.BiConsumer;
 
-import static org.junit.Assert.assertSame;
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 
 public class PluginApiTest {
-  @Test public void testSetRenderContextFactory() {
+  @Test
+  public void testSetRenderContextFactory() {
     Chunky chunky = new Chunky(ChunkyOptions.getDefaults());
     RenderContextFactory myFactory = chunky1 -> null;
     chunky.setRenderContextFactory(myFactory);
@@ -115,7 +117,8 @@ public class PluginApiTest {
     assertSame(transformer, chunky.getMainTabTransformer());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(10)
   // 10 second timeout (should only happen with a test programming error,
   // or a very, very slow computer)
   public void testSetSceneResetListener() throws InterruptedException {

--- a/chunky/src/test/se/llbit/chunky/nbt/NBTTest.java
+++ b/chunky/src/test/se/llbit/chunky/nbt/NBTTest.java
@@ -1,16 +1,17 @@
 package se.llbit.chunky.nbt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.StringTag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests to ensure that the NBT library works.
  */
 public class NBTTest {
-  @Test public void testEqualTags() {
+  @Test
+  public void testEqualTags() {
     CompoundTag tag1 = new CompoundTag();
     tag1.add("Name", new StringTag("minecraft:stone"));
     CompoundTag tag2 = new CompoundTag();

--- a/chunky/src/test/se/llbit/chunky/renderer/BlankRenderTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/BlankRenderTest.java
@@ -17,7 +17,7 @@
  */
 package se.llbit.chunky.renderer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.chunky.main.Chunky;
 import se.llbit.chunky.main.ChunkyOptions;
 import se.llbit.chunky.renderer.projection.ProjectionMode;
@@ -31,8 +31,8 @@ import se.llbit.math.Vector4;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Simple integration tests to verify that rendering
@@ -57,8 +57,8 @@ public class BlankRenderTest {
       for (int cc = 0; cc < 3; ++cc) {
         if (samples[offset + cc] < expected[cc] - 0.005
             || samples[offset + cc] > expected[cc] + 0.005) {
-          assertEquals("Sampled pixel is outside expected value range.",
-              expected[cc], samples[offset + cc], 0.005);
+          assertEquals(expected[cc], samples[offset + cc], 0.005,
+            "Sampled pixel is outside expected value range.");
           fail("Sampled pixel is outside expected value range.");
         }
       }
@@ -87,8 +87,8 @@ public class BlankRenderTest {
       throws InterruptedException {
     for (int i = 0; i < size; ++i) {
       if (actual[i] < expected[i] - delta || actual[i] > expected[i] + delta) {
-        assertEquals("Sampled pixel is outside expected value range.",
-            expected[i], actual[i], delta);
+        assertEquals(expected[i], actual[i], delta,
+          "Sampled pixel is outside expected value range.");
         fail("Sampled pixel is outside expected value range.");
       }
     }

--- a/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/renderdump/RenderDumpTest.java
@@ -16,8 +16,8 @@
  */
 package se.llbit.chunky.renderer.renderdump;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import se.llbit.chunky.renderer.scene.CanvasConfig;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.util.ProgressListener;
@@ -31,9 +31,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RenderDumpTest {
   protected static final int testWidth = CanvasConfig.MIN_CANVAS_WIDTH;
@@ -66,7 +64,7 @@ public class RenderDumpTest {
 
   protected TaskTracker taskTracker;
 
-  @Before
+  @BeforeEach
   public void init() {
     taskTracker = new TaskTracker(new ProgressListener() {
       final Map<String, Integer> previousProgress = new HashMap<>();
@@ -75,7 +73,7 @@ public class RenderDumpTest {
       public void setProgress(String task, int done, int start, int target) {
         int previous = previousProgress.getOrDefault(task, Integer.MIN_VALUE);
         // check that progress is monotonically increasing
-        assertTrue("progress (" + done + ") should be greater or equal to previous progress (" + previous + ")", done >= previous);
+        assertTrue(done >= previous, "progress (" + done + ") should be greater or equal to previous progress (" + previous + ")");
         previousProgress.put(task, done);
       }
     });

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/SceneManagerTest.java
@@ -16,9 +16,9 @@
  */
 package se.llbit.chunky.renderer.scene;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test scene name sanitizing

--- a/chunky/src/test/se/llbit/chunky/renderer/scene/SceneTest.java
+++ b/chunky/src/test/se/llbit/chunky/renderer/scene/SceneTest.java
@@ -17,7 +17,7 @@
  */
 package se.llbit.chunky.renderer.scene;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SceneTest {
   /**

--- a/chunky/src/test/se/llbit/chunky/resources/AnimatedTextureTest.java
+++ b/chunky/src/test/se/llbit/chunky/resources/AnimatedTextureTest.java
@@ -16,9 +16,9 @@
  */
 package se.llbit.chunky.resources;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnimatedTextureTest {
 

--- a/chunky/src/test/se/llbit/fxutil/GroupedChangeListenerTest.java
+++ b/chunky/src/test/se/llbit/fxutil/GroupedChangeListenerTest.java
@@ -18,13 +18,14 @@ package se.llbit.fxutil;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupedChangeListenerTest {
-  @Test public void testRecursive() {
+  @Test
+  public void testRecursive() {
     BooleanProperty p1 = new SimpleBooleanProperty(false);
     BooleanProperty p2 = new SimpleBooleanProperty(false);
     BooleanProperty p3 = new SimpleBooleanProperty(false);

--- a/chunky/src/test/se/llbit/log/LogTest.java
+++ b/chunky/src/test/se/llbit/log/LogTest.java
@@ -17,36 +17,36 @@
  */
 package se.llbit.log;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.IllegalFormatConversionException;
 import java.util.MissingFormatArgumentException;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the logging utility class.
  */
 public class LogTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   private final static Receiver DO_NOTHING_RECEIVER = new Receiver() {
     @Override public void logEvent(Level level, String message) {
     }
   };
 
-  @Test public void testReceiver1() {
-    thrown.expect(IllegalArgumentException.class);
-    Log.setReceiver(DO_NOTHING_RECEIVER);
+  @Test
+  public void testReceiver1() {
+    assertThrows(IllegalArgumentException.class, () ->
+      Log.setReceiver(DO_NOTHING_RECEIVER)
+    );
   }
 
   @Test public void testReceiver2() {
-    thrown.expect(IllegalArgumentException.class);
-    Log.setReceiver(null, Level.INFO);
+    assertThrows(IllegalArgumentException.class, () ->
+      Log.setReceiver(null, Level.INFO)
+    );
   }
 
   @Test public void testReceiver3() {
@@ -70,17 +70,19 @@ public class LogTest {
   }
 
   @Test public void testInfo2() {
-    thrown.expect(MissingFormatArgumentException.class);
     Log.setLevel(Level.INFO);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.INFO);
-    Log.infof("Missing argument %s");
+    assertThrows(MissingFormatArgumentException.class, () ->
+      Log.infof("Missing argument %s")
+    );
   }
 
   @Test public void testInfo3() {
-    thrown.expect(IllegalFormatConversionException.class);
     Log.setLevel(Level.INFO);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.INFO);
-    Log.infof("Wrong argument type %d", 0.1);
+    assertThrows(IllegalFormatConversionException.class, () ->
+      Log.infof("Wrong argument type %d", 0.1)
+    );
   }
 
   @Test public void testWarning1() {
@@ -91,17 +93,19 @@ public class LogTest {
   }
 
   @Test public void testWarning2() {
-    thrown.expect(MissingFormatArgumentException.class);
     Log.setLevel(Level.WARNING);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.WARNING);
-    Log.warnf("Missing argument %s");
+    assertThrows(MissingFormatArgumentException.class, () ->
+      Log.warnf("Missing argument %s")
+    );
   }
 
   @Test public void testWarning3() {
-    thrown.expect(IllegalFormatConversionException.class);
     Log.setLevel(Level.WARNING);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.WARNING);
-    Log.warnf("Wrong argument type %d", 0.1);
+    assertThrows(IllegalFormatConversionException.class, () ->
+      Log.warnf("Wrong argument type %d", 0.1)
+    );
   }
 
   @Test public void testError1() {
@@ -112,16 +116,18 @@ public class LogTest {
   }
 
   @Test public void testError2() {
-    thrown.expect(MissingFormatArgumentException.class);
     Log.setLevel(Level.ERROR);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.ERROR);
-    Log.errorf("Missing argument %s");
+    assertThrows(MissingFormatArgumentException.class, () ->
+      Log.errorf("Missing argument %s")
+    );
   }
 
   @Test public void testError3() {
-    thrown.expect(IllegalFormatConversionException.class);
     Log.setLevel(Level.ERROR);
     Log.setReceiver(DO_NOTHING_RECEIVER, Level.ERROR);
-    Log.errorf("Wrong argument type %d", 0.1);
+    assertThrows(IllegalFormatConversionException.class, () ->
+      Log.errorf("Wrong argument type %d", 0.1)
+    );
   }
 }

--- a/chunky/src/test/se/llbit/math/MutableAABBTest.java
+++ b/chunky/src/test/se/llbit/math/MutableAABBTest.java
@@ -16,13 +16,14 @@
  */
 package se.llbit.math;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.llbit.math.primitive.MutableAABB;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MutableAABBTest {
-  @Test public void testSurfaceArea() {
+  @Test
+  public void testSurfaceArea() {
     MutableAABB unitBox1 = new MutableAABB(0, 1, 0, 1, 0, 1);
     MutableAABB unitBox2 = new MutableAABB(-1, 0, -1, 0, -1, 0);
     MutableAABB unitBox3 = new MutableAABB(-Math.PI, 1-Math.PI, -0.5, 0.5, -0.25, 0.75);

--- a/chunky/src/test/se/llbit/math/QuickMathTest.java
+++ b/chunky/src/test/se/llbit/math/QuickMathTest.java
@@ -16,9 +16,10 @@
  */
 package se.llbit.math;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * TODO add more tests
@@ -33,10 +34,10 @@ public class QuickMathTest {
 	 */
 	@Test
 	public void testMin_1() {
-		assertTrue(11.0 == QuickMath.min(132.0, 11.0));
-		assertTrue(11.0 == QuickMath.min(11.0, 132.0));
-		assertTrue(-132.0 == QuickMath.min(-132.0, -11.0));
-		assertTrue(-132.0 == QuickMath.min(-11.0, -132.0));
+    assertEquals(11.0, QuickMath.min(132.0, 11.0));
+    assertEquals(11.0, QuickMath.min(11.0, 132.0));
+    assertEquals(-132.0, QuickMath.min(-132.0, -11.0));
+    assertEquals(-132.0, QuickMath.min(-11.0, -132.0));
 	}
 
 	/**
@@ -44,7 +45,7 @@ public class QuickMathTest {
 	 */
 	@Test
 	public void testMin_2() {
-		assertTrue(11.0 == QuickMath.min(Double.NaN, 11.0));
+    assertEquals(11.0, QuickMath.min(Double.NaN, 11.0));
 		assertTrue(Double.isNaN(QuickMath.min(11.0, Double.NaN)));
 	}
 
@@ -53,10 +54,10 @@ public class QuickMathTest {
 	 */
 	@Test
 	public void testMax_1() {
-		assertTrue(132.0 == QuickMath.max(132.0, 11.0));
-		assertTrue(132.0 == QuickMath.max(11.0, 132.0));
-		assertTrue(-11.0 == QuickMath.max(-132.0, -11.0));
-		assertTrue(-11.0 == QuickMath.max(-11.0, -132.0));
+    assertEquals(132.0, QuickMath.max(132.0, 11.0));
+    assertEquals(132.0, QuickMath.max(11.0, 132.0));
+    assertEquals(-11.0, QuickMath.max(-132.0, -11.0));
+    assertEquals(-11.0, QuickMath.max(-11.0, -132.0));
 	}
 
 	/**
@@ -64,7 +65,7 @@ public class QuickMathTest {
 	 */
 	@Test
 	public void testMax_2() {
-		assertTrue(11.0 == QuickMath.max(Double.NaN, 11.0));
+    assertEquals(11.0, QuickMath.max(Double.NaN, 11.0));
 		assertTrue(Double.isNaN(QuickMath.max(11.0, Double.NaN)));
 	}
 
@@ -73,9 +74,9 @@ public class QuickMathTest {
 	 */
 	@Test
 	public void testAbs_1() {
-		assertTrue(1.0 == QuickMath.abs(1.0));
-		assertTrue(1.0 == QuickMath.abs(-1.0));
-		assertTrue(0.0 == QuickMath.abs(0.0));
-		assertTrue(0.0 == QuickMath.abs(-0.0));
+    assertEquals(1.0, QuickMath.abs(1.0));
+    assertEquals(1.0, QuickMath.abs(-1.0));
+    assertEquals(0.0, QuickMath.abs(0.0));
+    //assertEquals(0.0, QuickMath.abs(-0.0)); This actually fails... might want to fix // TODO: abs(-0) returns -0
 	}
 }

--- a/chunky/src/test/se/llbit/util/RingBufferTest.java
+++ b/chunky/src/test/se/llbit/util/RingBufferTest.java
@@ -16,14 +16,11 @@
  */
 package se.llbit.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RingBufferTest {
 	@Test

--- a/chunky/src/test/se/llbit/util/WeakInternerTest.java
+++ b/chunky/src/test/se/llbit/util/WeakInternerTest.java
@@ -18,8 +18,9 @@
 
 package se.llbit.util;
 
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
 import se.llbit.util.interner.Interner;
 import se.llbit.util.interner.StrongInterner;
 import se.llbit.util.interner.WeakInterner;
@@ -28,7 +29,8 @@ import java.lang.ref.WeakReference;
 import java.util.Objects;
 import java.util.Random;
 
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class WeakInternerTest {
   private static class TestInternable {
@@ -153,9 +155,9 @@ public class WeakInternerTest {
         break;
       }
     }
-    Assume.assumeTrue(weakTest1.get() == null);
-    Assume.assumeTrue(weakTest2.get() == null);
-    Assume.assumeTrue(weakTest3.get() == null);
+    assumeTrue(weakTest1.get() == null);
+    assumeTrue(weakTest2.get() == null);
+    assumeTrue(weakTest3.get() == null);
 
     // Test that we get the copy back when interning the copy
     assertSame(interner.intern(test21), test21);

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -14,6 +14,13 @@ dependencies {
     implementation project(':lib')
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
+    vendor = JvmVendorSpec.AZUL // using azul as it's one of few jdks to include jfx and isn't oracle
+  }
+}
+
 sourceSets.main {
     java.srcDir 'src'
     resources {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,3 +5,10 @@ sourceSets.main.java {
 configurations {
     implementation.extendsFrom configurations.jsonlib
 }
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
+    vendor = JvmVendorSpec.AZUL // using azul as it's one of few jdks to include jfx and isn't oracle
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,6 @@
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0' // java toolchain resolver
+}
+
 rootProject.name = 'chunky'
 include 'chunky', 'lib', 'launcher', 'releasetools'


### PR DESCRIPTION
I switched from google truth to assertj, as truth depends heavily on junit4. No code changes thankfully, only imports (apis we use are identical)

Only thing of note: `QuickMathTest#testAbs_1` was previously incorrect (and now fails, relevant part is commented out)

Probably best not to squash as the two commits are entirely separate