### PR TITLE
Fix "transmission without refraction" logic

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -104,7 +104,7 @@ public class PathTracer implements RayTracer {
 
       float pSpecular = currentMat.specular;
 
-      double pDiffuse = scene.fancierTranslucency ? 1 - Math.pow(1 - ray.color.w, Math.max(ray.color.x, Math.max(ray.color.y, ray.color.z))) : ray.color.w;
+      double pDiffuse = scene.fancierTranslucency ? 1 - Math.pow(1 - ray.color.w, Math.max(Math.max(Ray.EPSILON, ray.color.x), Math.max(ray.color.y, ray.color.z))) : ray.color.w;
       double pAbsorb = scene.fancierTranslucency ? 1 - (1 - ray.color.w)/(1 - pDiffuse + Ray.EPSILON) : ray.color.w;
 
       float n1 = prevMat.ior;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -114,7 +114,7 @@ public class PathTracer implements RayTracer {
         airDistance = ray.distance;
       }
 
-      if (pDiffuse + pSpecular < Ray.EPSILON && n1 == n2) {
+      if (ray.color.w + pSpecular < Ray.EPSILON && n1 == n2) {
         // Transmission without refraction.
         // This can happen when the ray passes through a transparent
         // material into another. It can also happen for example

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -104,7 +104,7 @@ public class PathTracer implements RayTracer {
 
       float pSpecular = currentMat.specular;
 
-      double pDiffuse = scene.fancierTranslucency ? 1 - Math.pow(1 - ray.color.w, Math.max(Math.max(Ray.EPSILON, ray.color.x), Math.max(ray.color.y, ray.color.z))) : ray.color.w;
+      double pDiffuse = scene.fancierTranslucency ? 1 - Math.pow(1 - ray.color.w, Math.max(ray.color.x, Math.max(ray.color.y, ray.color.z))) : ray.color.w;
       double pAbsorb = scene.fancierTranslucency ? 1 - (1 - ray.color.w)/(1 - pDiffuse + Ray.EPSILON) : ray.color.w;
 
       float n1 = prevMat.ior;


### PR DESCRIPTION
Fixes #1718

Before: pure black pixels are transparent
![image](https://github.com/user-attachments/assets/5aa10986-b6b8-4c80-8848-e4717bee955d)

After: pure black pixels are opaque
![image](https://github.com/user-attachments/assets/b28db368-de74-455a-be15-a5c37390bb93)