### PR TITLE
Skip rendering tiles that only contain sky.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
@@ -66,6 +66,8 @@ public class PathTracingRenderer extends TileBasedRenderer {
     double halfWidth = fullWidth / (2.0 * fullHeight);
     double invHeight = 1.0 / fullHeight;
 
+    resetTiles(manager); // reset previously skipped tiles
+
     double[] sampleBuffer = scene.getSampleBuffer();
 
     while (scene.spp < scene.getTargetSpp()) {

--- a/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/PreviewRenderer.java
@@ -75,6 +75,8 @@ public class PreviewRenderer extends TileBasedRenderer {
     int ty = (int) Math.floor(target.o.y + target.d.y * Ray.OFFSET);
     int tz = (int) Math.floor(target.o.z + target.d.z * Ray.OFFSET);
 
+    resetTiles(manager); // reset previously skipped tiles
+
     double[] sampleBuffer = scene.getSampleBuffer();
 
     for (int i = 0; i < 2; i++) {

--- a/chunky/src/java/se/llbit/chunky/renderer/WorkerState.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/WorkerState.java
@@ -28,4 +28,5 @@ public class WorkerState {
   public Ray ray;
   public Vector4 attenuation = new Vector4();
   public Random random;
+  public boolean hit = false;
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -69,6 +69,7 @@ public class PathTracer implements RayTracer {
         if (ray.getPrevMaterial().isWater()) {
           ray.color.set(0, 0, 0, 1);
           hit = true;
+          state.hit = true;
         } else if (ray.depth == 0) {
           // Direct sky hit.
           if (!scene.transparentSky()) {
@@ -81,11 +82,13 @@ public class PathTracer implements RayTracer {
           scene.sky.getSkyColor(ray, true);
           addSkyFog(scene, ray, state, ox, od);
           hit = true;
+          state.hit = true;
         } else {
           // Indirect sky hit - diffuse color.
           scene.sky.getSkyColorDiffuseSun(ray, scene.getSunSamplingStrategy().isDiffuseSun());
           // Skip sky fog - likely not noticeable in diffuse reflection.
           hit = true;
+          state.hit = true;
         }
         break;
       }


### PR DESCRIPTION
Many scenes contain a lot of sky. Currently, Chunky renders these areas to the full SPP, although their color will never change as we don't have any effects that would apply to a ray that doesn't hit a block.

This PR skips tiles (8x8 pixels by default) that only have immediate sky hits for the first _samples per pass_ (defaults to 1) samples for future samples. This could lead to anti-aliasing errors due to the first pass not hitting a block for a pixel but future passes (for a different sub-pixel )would hit the block. This could be mitigated by increasing _spp per pass_.

For example in the following scene, the greyed out pixels would only be rendered once whereas all other areas are rendered as usual.
![image](https://github.com/user-attachments/assets/b5a90f24-4acd-45ad-b3d6-fad6a75c0f13)

Depending on the amount of sky in the scene, this can decrease the rendering time. Needs benchmarks, though.

