### PR TITLE
Fix build issues on windows due to azul not including JFX on windows

### DIFF
--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
-    vendor = JvmVendorSpec.AZUL // using azul as it's one of few jdks to include jfx and isn't oracle
+    vendor = JvmVendorSpec.AMAZON // using corretto as it's one of few jdks to include jfx (on windows+linux) and isn't oracle
   }
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,6 +9,6 @@ configurations {
 java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
-    vendor = JvmVendorSpec.AZUL // using azul as it's one of few jdks to include jfx and isn't oracle
+    vendor = JvmVendorSpec.AMAZON // using corretto as it's one of few jdks to include jfx (on windows+linux) and isn't oracle
   }
 }


### PR DESCRIPTION
Neither oracle nor azul include jfx on both windows & linux in their java 8 jdks.

Corretto documentation says that its [mac jdk doesn't include jfx](https://aws.amazon.com/corretto/faqs/), so we still have a build problem on apple systems

If someone can tell me a mac jdk8 that includes jfx I'll PR another fix.