### PR TITLE
Fix emitters with emitter sampling.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -228,7 +228,7 @@ public class PathTracer implements RayTracer {
     Vector3 emittance = new Vector3();
     Vector4 indirectEmitterColor = new Vector4(0, 0, 0, 0);
 
-    if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
+    if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 1) && currentMat.emittance > Ray.EPSILON) {
 
       // Quadratic emittance mapping, so a pixel that's 50% darker will emit only 25% as much light
       // This is arbitrary but gives pretty good results in most cases.


### PR DESCRIPTION
When emitter sampling is enabled and `Prevent normal emitter when using emitter sampling` is checked, direct hits on emitters don't glow. This fixes that.

Master:
![image](https://github.com/user-attachments/assets/aa6cf8d5-d7b8-4a41-9fd6-b434c1e71110)

Fix:
![image](https://github.com/user-attachments/assets/d4a7be0b-07c5-4628-8baf-a9ce0cdef52a)
