### PR TITLE
Fix not logging any INFO level messages in UI mode

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -83,6 +83,7 @@ import se.llbit.chunky.world.World;
 import se.llbit.fx.ToolPane;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.fxutil.GroupedChangeListener;
+import se.llbit.log.ConsoleReceiver;
 import se.llbit.log.Level;
 import se.llbit.log.Log;
 import se.llbit.math.Vector3;
@@ -453,6 +454,7 @@ public class ChunkyFxController
       }
     });
 
+    Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO);
     Log.setReceiver(new UILogReceiver(), Level.ERROR, Level.WARNING);
 
     mapLoader = new WorldMapLoader(this, mapView);


### PR DESCRIPTION
Previously it was always the buffered one, it never output any INFO level logs to anywhere.
This makes them output to the console if enabled, which was the behaviour before the buffered receiver

`INFO` logs are hidden behind the `logLevel` system property, so it's not surprising that no one noticed