### PR TITLE
Use y-clipping settings from the map view when creating a new scene or loading chunks from it

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/SynchronousSceneManager.java
@@ -235,15 +235,21 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
 
   @Override public void loadFreshChunks(World world, Collection<ChunkPosition> chunksToLoad) {
     synchronized (scene) {
+      int yClipMin = scene.getYClipMin();
+      int yClipMax = scene.getYClipMax();
       scene.clear();
-      scene.loadChunks(taskTracker, world, chunksToLoad);
       scene.resetScene(null, context.getChunky().getSceneFactory());
+      scene.setYClipMin(yClipMin);
+      scene.setYClipMax(yClipMax);
       context.setSceneDirectory(new File(context.getChunky().options.sceneDir, scene.name));
+      scene.loadChunks(taskTracker, world, chunksToLoad);
       scene.refresh();
       scene.setResetReason(ResetReason.SCENE_LOADED);
       scene.setRenderMode(RenderMode.PREVIEW);
     }
+    System.out.println(scene.getYClipMin()+" min, 2 max "+scene.getYClipMax());
     onSceneLoaded.run();
+    System.out.println(scene.getYClipMin()+" min, 3 max "+scene.getYClipMax());
   }
 
   @Override public void loadChunks(World world, Collection<ChunkPosition> chunksToLoad) {
@@ -253,9 +259,9 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
       if (prevChunkCount == 0) {
         scene.moveCameraToCenter();
       }
-      scene.refresh();
       scene.setResetReason(ResetReason.SCENE_LOADED);
       scene.setRenderMode(RenderMode.PREVIEW);
+      scene.refresh();
     }
     onChunksLoaded.run();
   }
@@ -263,9 +269,9 @@ public class SynchronousSceneManager implements SceneProvider, SceneManager {
   @Override public void reloadChunks() {
     synchronized (scene) {
       scene.reloadChunks(taskTracker);
-      scene.refresh();
       scene.setResetReason(ResetReason.SCENE_LOADED);
       scene.setRenderMode(RenderMode.PREVIEW);
+      scene.refresh();
     }
     onChunksLoaded.run();
   }

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -159,16 +159,22 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     newScene.setGraphic(new ImageView(Icon.sky.fxImage()));
     newScene.setOnAction(event -> {
       SceneManager sceneManager = controller.getRenderController().getSceneManager();
-      sceneManager
-          .loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
+      sceneManager.getSceneProvider().withEditSceneProtected(scene -> {
+        scene.setYClipMin(mapView.getYMin());
+        scene.setYClipMax(mapView.getYMax());
+      });
+      sceneManager.loadFreshChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
     });
     newScene.setDisable(chunkSelection.isEmpty());
 
     MenuItem loadSelection = new MenuItem("Load selected chunks");
     loadSelection.setOnAction(event -> {
       SceneManager sceneManager = controller.getRenderController().getSceneManager();
-      sceneManager
-          .loadChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
+      sceneManager.getSceneProvider().withEditSceneProtected(scene -> {
+        scene.setYClipMin(mapView.getYMin());
+        scene.setYClipMax(mapView.getYMax());
+      });
+      sceneManager.loadChunks(mapLoader.getWorld(), controller.getChunkSelection().getSelection());
     });
     loadSelection.setDisable(chunkSelection.isEmpty());
 

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -187,6 +187,12 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
     canvasSizeInput.setSize(scene.canvasConfig.getCropWidth(), scene.canvasConfig.getCropHeight());
   }
 
+  @Override
+  public void onChunksLoaded() {
+    yMin.set(scene.getYClipMin());
+    yMax.set(scene.getYClipMax());
+  }
+
   @Override public String getTabTitle() {
     return "Scene";
   }


### PR DESCRIPTION
Also fixes requiring two reloads after changing the y-clipping settings of a scene.

Closes #1741 