### PR TITLE
Add russian roulette to kill rays that don't contribute much to the scene.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -127,6 +127,17 @@ public class PathTracer implements RayTracer {
         break;
       }
       ray.depth += 1;
+
+      // Russian Roulette
+      if (!firstReflection) {
+        double q = (1 - Math.max(ray.color.x, Math.max(ray.color.y, ray.color.z)));
+        if (random.nextDouble() < q) {
+          break;
+        } else {
+          ray.color.scale(1. / (1. - q));
+        }
+      }
+
       Vector4 cumulativeColor = new Vector4(0, 0, 0, 0);
       Ray next = new Ray();
       float pMetal = currentMat.metalness;


### PR DESCRIPTION
Fixes #1018

This needs more testing. Somehow this breaks for first reflection (emitters become way too bright) and it also makes emitters brighter (maybe related to branching?).