### PR TITLE
Add new redstone torch model

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Comparator.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Comparator.java
@@ -20,36 +20,18 @@ package se.llbit.chunky.block.minecraft;
 
 import se.llbit.chunky.block.AbstractModelBlock;
 import se.llbit.chunky.model.minecraft.ComparatorModel;
+import se.llbit.chunky.model.minecraft.ComparatorModel1212;
 import se.llbit.chunky.resources.Texture;
 
-// TODO: render locked repeaters.
 public class Comparator extends AbstractModelBlock {
-
   private final String description;
 
-  public Comparator(String facingString, String modeString, boolean powered) {
-    super("comparator", Texture.redstoneRepeaterOn);
-    this.description = String.format("facing=%s, mode=%s, powered=%s",
-        facingString, modeString, powered);
-    int mode = modeString.equals("compare") ? 0 : 1;
-    int facing;
-    switch (facingString) {
-      default:
-      case "north":
-        facing = 2;
-        break;
-      case "south":
-        facing = 0;
-        break;
-      case "west":
-        facing = 1;
-        break;
-      case "east":
-        facing = 3;
-        break;
-    }
-
-    this.model = new ComparatorModel(facing, mode, powered ? 1 : 0);
+  public Comparator(String facing, String mode, boolean powered) {
+    super("comparator", Texture.comparatorOn);
+    description = String.format("facing=%s, mode=%s, powered=%s", facing, mode, powered);
+    model = System.getProperty("chunky.blockModels.redstoneTorch", "1.21.2").equals("pre-1.21.2")
+      ? new ComparatorModel(facing, mode, powered)
+      : new ComparatorModel1212(facing, mode, powered);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneTorch.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneTorch.java
@@ -18,14 +18,18 @@
 
 package se.llbit.chunky.block.minecraft;
 
+import se.llbit.chunky.block.AbstractModelBlock;
+import se.llbit.chunky.model.minecraft.RedstoneTorchModel;
 import se.llbit.chunky.resources.Texture;
 
-public class RedstoneTorch extends Torch {
+public class RedstoneTorch extends AbstractModelBlock {
   private final boolean lit;
 
   public RedstoneTorch(boolean lit) {
     super("redstone_torch", lit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
     this.lit = lit;
+    solid = false;
+    model = new RedstoneTorchModel(lit);
   }
 
   public boolean isLit() {

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneTorch.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneTorch.java
@@ -20,6 +20,7 @@ package se.llbit.chunky.block.minecraft;
 
 import se.llbit.chunky.block.AbstractModelBlock;
 import se.llbit.chunky.model.minecraft.RedstoneTorchModel;
+import se.llbit.chunky.model.minecraft.TorchModel;
 import se.llbit.chunky.resources.Texture;
 
 public class RedstoneTorch extends AbstractModelBlock {
@@ -28,8 +29,9 @@ public class RedstoneTorch extends AbstractModelBlock {
   public RedstoneTorch(boolean lit) {
     super("redstone_torch", lit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
     this.lit = lit;
-    solid = false;
-    model = new RedstoneTorchModel(lit);
+    model = System.getProperty("chunky.blockModels.redstoneTorch", "1.21.2").equals("pre-1.21.2")
+      ? new TorchModel(texture, "none")
+      : new RedstoneTorchModel(lit);
   }
 
   public boolean isLit() {

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneWallTorch.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/RedstoneWallTorch.java
@@ -18,14 +18,22 @@
 
 package se.llbit.chunky.block.minecraft;
 
+import se.llbit.chunky.block.AbstractModelBlock;
+import se.llbit.chunky.model.minecraft.RedstoneWallTorchModel;
+import se.llbit.chunky.model.minecraft.TorchModel;
 import se.llbit.chunky.resources.Texture;
 
-public class RedstoneWallTorch extends WallTorch {
+public class RedstoneWallTorch extends AbstractModelBlock {
   private final boolean lit;
+  private final String facing;
 
   public RedstoneWallTorch(String facing, boolean lit) {
-    super("redstone_wall_torch", lit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff, facing);
+    super("redstone_wall_torch", lit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
     this.lit = lit;
+    this.facing = facing;
+    model = System.getProperty("chunky.blockModels.redstoneTorch", "1.21.2").equals("pre-1.21.2")
+      ? new TorchModel(texture, facing)
+      : new RedstoneWallTorchModel(lit, facing);
   }
 
   public boolean isLit() {

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Repeater.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Repeater.java
@@ -20,38 +20,29 @@ package se.llbit.chunky.block.minecraft;
 
 import se.llbit.chunky.block.AbstractModelBlock;
 import se.llbit.chunky.model.minecraft.RedstoneRepeaterModel;
+import se.llbit.chunky.model.minecraft.RedstoneRepeaterModel1212;
 import se.llbit.chunky.resources.Texture;
 
-// TODO: render locked repeaters.
 public class Repeater extends AbstractModelBlock {
-  private final int facing;
+  private final String facing;
   private final String description;
 
-  public Repeater(int delay, String facingString, boolean powered, boolean locked) {
+  public Repeater(int delay, String facing, boolean powered, boolean locked) {
     super("repeater", Texture.redstoneRepeaterOn);
-    this.description = String.format("delay=%d, facing=%s, powered=%s, locked=%s",
-        delay, facingString, powered, locked);
-    switch (facingString) {
-      default:
-      case "north":
-        facing = 2;
-        break;
-      case "south":
-        facing = 0;
-        break;
-      case "west":
-        facing = 1;
-        break;
-      case "east":
-        facing = 3;
-        break;
-    }
-    this.model = new RedstoneRepeaterModel(3 & (delay - 1), facing, powered ? 1 : 0,
-        locked ? 1 : 0);
+    description = String.format("delay=%d, facing=%s, powered=%s, locked=%s", delay, facing, powered, locked);
+    this.facing = facing;
+    model = System.getProperty("chunky.blockModels.redstoneTorch", "1.21.2").equals("pre-1.21.2")
+      ? new RedstoneRepeaterModel(facing, delay, powered, locked)
+      : new RedstoneRepeaterModel1212(facing, delay, powered, locked);
   }
 
   public int getFacing() {
-    return facing;
+    return switch (facing) {
+      case "south" -> 0;
+      case "west" -> 1;
+      case "east" -> 3;
+      default -> 2;
+    };
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Torch.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Torch.java
@@ -30,6 +30,6 @@ public class Torch extends AbstractModelBlock {
   public Torch(String name, Texture texture) {
     super(name, texture);
     solid = false;
-    model = new TorchModel(texture, 5);
+    model = new TorchModel(texture, "none");
   }
 }

--- a/chunky/src/java/se/llbit/chunky/block/minecraft/WallTorch.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/WallTorch.java
@@ -32,23 +32,7 @@ public class WallTorch extends AbstractModelBlock {
     super(name, texture);
     this.facing = facing;
     solid = false;
-    int facingInt;
-    switch (facing) {
-      default:
-      case "north":
-        facingInt = 4;
-        break;
-      case "south":
-        facingInt = 3;
-        break;
-      case "west":
-        facingInt = 2;
-        break;
-      case "east":
-        facingInt = 1;
-        break;
-    }
-    model = new TorchModel(texture, facingInt);
+    model = new TorchModel(texture, facing);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/ComparatorModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/ComparatorModel.java
@@ -29,64 +29,64 @@ import java.util.Arrays;
 public class ComparatorModel extends QuadModel {
   // The comparator base-plate facing north:
   private static final Quad[] north = {
-      // Front face.
-      new Quad(new Vector3(1, 0, 0), new Vector3(0, 0, 0), new Vector3(1, .125, 0),
-          new Vector4(1, 0, 0, .125)),
+    // Front face.
+    new Quad(new Vector3(1, 0, 0), new Vector3(0, 0, 0), new Vector3(1, .125, 0),
+      new Vector4(1, 0, 0, .125)),
 
-      // Back face.
-      new Quad(new Vector3(0, 0, 1), new Vector3(1, 0, 1), new Vector3(0, .125, 1),
-          new Vector4(0, 1, 0, .125)),
+    // Back face.
+    new Quad(new Vector3(0, 0, 1), new Vector3(1, 0, 1), new Vector3(0, .125, 1),
+      new Vector4(0, 1, 0, .125)),
 
-      // Right face.
-      new Quad(new Vector3(0, 0, 0), new Vector3(0, 0, 1), new Vector3(0, .125, 0),
-          new Vector4(0, 1, 0, .125)),
+    // Right face.
+    new Quad(new Vector3(0, 0, 0), new Vector3(0, 0, 1), new Vector3(0, .125, 0),
+      new Vector4(0, 1, 0, .125)),
 
-      // Left face.
-      new Quad(new Vector3(1, 0, 1), new Vector3(1, 0, 0), new Vector3(1, .125, 1),
-          new Vector4(1, 0, 0, .125)),
+    // Left face.
+    new Quad(new Vector3(1, 0, 1), new Vector3(1, 0, 0), new Vector3(1, .125, 1),
+      new Vector4(1, 0, 0, .125)),
 
-      // Top face.
-      new Quad(new Vector3(1, .125, 0), new Vector3(0, .125, 0), new Vector3(1, .125, 1),
-          new Vector4(1, 0, 1, 0)),
+    // Top face.
+    new Quad(new Vector3(1, .125, 0), new Vector3(0, .125, 0), new Vector3(1, .125, 1),
+      new Vector4(1, 0, 1, 0)),
   };
 
   private static final Quad[] torchHigh = {
-      new Quad(new Vector3(.75, 2 / 16., 7 / 16.), new Vector3(4 / 16., 2 / 16., 7 / 16.),
-          new Vector3(.75, 13 / 16., 7 / 16.), new Vector4(12 / 16., 4 / 16., 5 / 16., 1)),
+    new Quad(new Vector3(.75, 2 / 16., 7 / 16.), new Vector3(4 / 16., 2 / 16., 7 / 16.),
+      new Vector3(.75, 13 / 16., 7 / 16.), new Vector4(12 / 16., 4 / 16., 5 / 16., 1)),
 
-      new Quad(new Vector3(4 / 16., 2 / 16., 9 / 16.), new Vector3(.75, 2 / 16., 9 / 16.),
-          new Vector3(4 / 16., 13 / 16., 9 / 16.), new Vector4(4 / 16., .75, 5 / 16., 1)),
+    new Quad(new Vector3(4 / 16., 2 / 16., 9 / 16.), new Vector3(.75, 2 / 16., 9 / 16.),
+      new Vector3(4 / 16., 13 / 16., 9 / 16.), new Vector4(4 / 16., .75, 5 / 16., 1)),
 
-      new Quad(new Vector3(7 / 16., 2 / 16., 4 / 16.), new Vector3(7 / 16., 2 / 16., .75),
-          new Vector3(7 / 16., 13 / 16., 4 / 16.), new Vector4(4 / 16., .75, 5 / 16., 1)),
+    new Quad(new Vector3(7 / 16., 2 / 16., 4 / 16.), new Vector3(7 / 16., 2 / 16., .75),
+      new Vector3(7 / 16., 13 / 16., 4 / 16.), new Vector4(4 / 16., .75, 5 / 16., 1)),
 
-      new Quad(new Vector3(9 / 16., 2 / 16., .75), new Vector3(9 / 16., 2 / 16., 4 / 16.),
-          new Vector3(9 / 16., 13 / 16., .75), new Vector4(.75, 4 / 16., 5 / 16., 1)),
+    new Quad(new Vector3(9 / 16., 2 / 16., .75), new Vector3(9 / 16., 2 / 16., 4 / 16.),
+      new Vector3(9 / 16., 13 / 16., .75), new Vector4(.75, 4 / 16., 5 / 16., 1)),
 
-      // Top face.
-      new Quad(new Vector3(7 / 16., 7 / 16., 9 / 16.), new Vector3(9 / 16., 7 / 16., 9 / 16.),
-          new Vector3(7 / 16., 7 / 16., 7 / 16.),
-          new Vector4(7 / 16., 9 / 16., 8 / 16., .625))
+    // Top face.
+    new Quad(new Vector3(7 / 16., 7 / 16., 9 / 16.), new Vector3(9 / 16., 7 / 16., 9 / 16.),
+      new Vector3(7 / 16., 7 / 16., 7 / 16.),
+      new Vector4(7 / 16., 9 / 16., 8 / 16., .625))
   };
 
   // The lowered torch is 3 texels lower than the high version.
   private static final Quad[] torchLow = {
-      new Quad(new Vector3(.75, 2 / 16., 7 / 16.), new Vector3(4 / 16., 2 / 16., 7 / 16.),
-          new Vector3(.75, 10 / 16., 7 / 16.), new Vector4(12 / 16., 4 / 16., 8 / 16., 1)),
+    new Quad(new Vector3(.75, 2 / 16., 7 / 16.), new Vector3(4 / 16., 2 / 16., 7 / 16.),
+      new Vector3(.75, 10 / 16., 7 / 16.), new Vector4(12 / 16., 4 / 16., 8 / 16., 1)),
 
-      new Quad(new Vector3(4 / 16., 2 / 16., 9 / 16.), new Vector3(.75, 2 / 16., 9 / 16.),
-          new Vector3(4 / 16., 10 / 16., 9 / 16.), new Vector4(4 / 16., .75, 8 / 16., 1)),
+    new Quad(new Vector3(4 / 16., 2 / 16., 9 / 16.), new Vector3(.75, 2 / 16., 9 / 16.),
+      new Vector3(4 / 16., 10 / 16., 9 / 16.), new Vector4(4 / 16., .75, 8 / 16., 1)),
 
-      new Quad(new Vector3(7 / 16., 2 / 16., 4 / 16.), new Vector3(7 / 16., 2 / 16., .75),
-          new Vector3(7 / 16., 10 / 16., 4 / 16.), new Vector4(4 / 16., .75, 8 / 16., 1)),
+    new Quad(new Vector3(7 / 16., 2 / 16., 4 / 16.), new Vector3(7 / 16., 2 / 16., .75),
+      new Vector3(7 / 16., 10 / 16., 4 / 16.), new Vector4(4 / 16., .75, 8 / 16., 1)),
 
-      new Quad(new Vector3(9 / 16., 2 / 16., .75), new Vector3(9 / 16., 2 / 16., 4 / 16.),
-          new Vector3(9 / 16., 10 / 16., .75), new Vector4(.75, 4 / 16., 8 / 16., 1)),
+    new Quad(new Vector3(9 / 16., 2 / 16., .75), new Vector3(9 / 16., 2 / 16., 4 / 16.),
+      new Vector3(9 / 16., 10 / 16., .75), new Vector4(.75, 4 / 16., 8 / 16., 1)),
 
-      // Top face.
-      new Quad(new Vector3(7 / 16., 4 / 16., 9 / 16.), new Vector3(9 / 16., 4 / 16., 9 / 16.),
-          new Vector3(7 / 16., 4 / 16., 7 / 16.),
-          new Vector4(7 / 16., 9 / 16., 8 / 16., .625))
+    // Top face.
+    new Quad(new Vector3(7 / 16., 4 / 16., 9 / 16.), new Vector3(9 / 16., 4 / 16., 9 / 16.),
+      new Vector3(7 / 16., 4 / 16., 7 / 16.),
+      new Vector4(7 / 16., 9 / 16., 8 / 16., .625))
   };
 
   private static final Quad[][][] torch1 = new Quad[2][4][];
@@ -139,16 +139,24 @@ public class ComparatorModel extends QuadModel {
   private final Quad[] quads;
   private final Texture[] textures;
 
-  public ComparatorModel(int direction, int active, int powered) {
+  public ComparatorModel(String facing, String mode, boolean powered) {
+    int direction = switch (facing) {
+      case "north" -> 2;
+      case "south" -> 0;
+      case "west" -> 1;
+      case "east" -> 3;
+      default -> 0;
+    };
+    int active = mode.equals("subtract") ? 1 : 0;
     quads = Model.join(rot[direction], torch1[active][direction],
-                       torch2[active][direction], torch3[active][direction]);
+      torch2[active][direction], torch3[active][direction]);
     textures = new Texture[quads.length];
-    Arrays.fill(textures, torchTex[powered]);
-    Arrays.fill(textures, 0, rot[direction].length, blockTex[powered]);
+    Arrays.fill(textures, torchTex[powered ? 1 : 0]);
+    Arrays.fill(textures, 0, rot[direction].length, blockTex[powered ? 1 : 0]);
     Arrays.fill(textures,
-        rot[direction].length,
-        rot[direction].length + torch1[active][direction].length,
-        torchTex[active]);
+      rot[direction].length,
+      rot[direction].length + torch1[active][direction].length,
+      torchTex[active]);
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/ComparatorModel1212.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/ComparatorModel1212.java
@@ -1,0 +1,820 @@
+/*
+ * Copyright (c) 2013-2023 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.model.minecraft;
+
+import se.llbit.chunky.model.Model;
+import se.llbit.chunky.model.QuadModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+/**
+ * The new Comparator model introduced in Minecraft 1.21.2 (24w33a).
+ */
+public class ComparatorModel1212 extends QuadModel {
+  private static final Texture slab = Texture.smoothStone;
+  private static final Texture topOff = Texture.comparatorOff;
+  private static final Texture topOn = Texture.comparatorOn;
+  private static final Texture unlit = Texture.redstoneTorchOff;
+  private static final Texture lit = Texture.redstoneTorchOn;
+
+  private static final Texture[] comparatorTex = new Texture[]{
+    topOff, slab, slab, slab, slab, slab, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit
+  };
+
+  private static final Quad[] comparator = new Quad[]{
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    )
+  };
+
+  private static final Texture[] comparatorOnTex = new Texture[]{
+    topOn, slab, slab, slab, slab, slab, lit, lit, lit, lit, lit, unlit, unlit, unlit, unlit, unlit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit
+  };
+
+  private static final Quad[] comparatorOn = new Quad[]{
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    )
+  };
+  private static final Texture[] comparatorSubtractTex = new Texture[]{
+    topOff, slab, slab, slab, slab, slab, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, unlit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit
+  };
+
+  private static final Quad[] comparatorSubtract = new Quad[]{
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    )
+  };
+
+  private static final Texture[] comparatorSubtractOnTex = new Texture[]{
+    topOn, slab, slab, slab, slab, slab, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit, lit
+  };
+
+  private static final Quad[] comparatorSubtractOn = new Quad[]{
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 5 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 5 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(4 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(6 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(4 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(4 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(6 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(10 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(12 / 16.0, 7 / 16.0, 11 / 16.0),
+      new Vector3(10 / 16.0, 2 / 16.0, 11 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(12 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(10 / 16.0, 7 / 16.0, 13 / 16.0),
+      new Vector3(12 / 16.0, 2 / 16.0, 13 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(3.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(3.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 10.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 13.5 / 16.0),
+      new Vector3(12.5 / 16.0, 7.5 / 16.0, 10.5 / 16.0),
+      new Vector3(12.5 / 16.0, 4.5 / 16.0, 13.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 2.5 / 16.0, 1.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 5.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 2.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+    )
+  };
+
+  private final Quad[] quads;
+  private final Texture[] textures;
+
+  public ComparatorModel1212(String facing, String mode, boolean powered) {
+    Quad[] model;
+    if (mode.equals("subtract")) {
+      model = powered ? comparatorSubtractOn : comparatorSubtract;
+      textures = powered ? comparatorSubtractOnTex : comparatorSubtractTex;
+    } else {
+      model = powered ? comparatorOn : comparator;
+      textures = powered ? comparatorOnTex : comparatorTex;
+    }
+    quads = switch (facing) {
+      case "west" -> Model.rotateY(model);
+      case "north" -> Model.rotateY(Model.rotateY(model));
+      case "east" -> Model.rotateNegY(model);
+      default -> model;
+    };
+  }
+
+  @Override
+  public Quad[] getQuads() {
+    return quads;
+  }
+
+  @Override
+  public Texture[] getTextures() {
+    return textures;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    return RedstoneTorchModel.intersectWithGlow(ray, scene, this);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel.java
@@ -150,22 +150,22 @@ public class RedstoneRepeaterModel extends QuadModel {
     torch2[0][3][2] = Model.rotateY(torch2[0][3][1]);
     torch2[0][3][3] = Model.rotateY(torch2[0][3][2]);
 
-    torch2[1][0][0] = Model.translate(lock, 0, 0, -1 / 16.);
+    torch2[1][0][0] = Model.translate(lock, 0, 0, -2 / 16.);
     torch2[1][0][1] = Model.rotateY(torch2[1][0][0]);
     torch2[1][0][2] = Model.rotateY(torch2[1][0][1]);
     torch2[1][0][3] = Model.rotateY(torch2[1][0][2]);
 
-    torch2[1][1][0] = Model.translate(lock, 0, 0, 1 / 16.);
+    torch2[1][1][0] = Model.translate(lock, 0, 0, 0 / 16.);
     torch2[1][1][1] = Model.rotateY(torch2[1][1][0]);
     torch2[1][1][2] = Model.rotateY(torch2[1][1][1]);
     torch2[1][1][3] = Model.rotateY(torch2[1][1][2]);
 
-    torch2[1][2][0] = Model.translate(lock, 0, 0, 3 / 16.);
+    torch2[1][2][0] = Model.translate(lock, 0, 0, 2 / 16.);
     torch2[1][2][1] = Model.rotateY(torch2[1][2][0]);
     torch2[1][2][2] = Model.rotateY(torch2[1][2][1]);
     torch2[1][2][3] = Model.rotateY(torch2[1][2][2]);
 
-    torch2[1][3][0] = Model.translate(lock, 0, 0, 5 / 16.);
+    torch2[1][3][0] = Model.translate(lock, 0, 0, 4 / 16.);
     torch2[1][3][1] = Model.rotateY(torch2[1][3][0]);
     torch2[1][3][2] = Model.rotateY(torch2[1][3][1]);
     torch2[1][3][3] = Model.rotateY(torch2[1][3][2]);

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel.java
@@ -29,81 +29,81 @@ import java.util.Arrays;
 public class RedstoneRepeaterModel extends QuadModel {
   //region Body
   private static final Quad[] north = {
-      // Front.
-      new Quad(new Vector3(1, 0, 0), new Vector3(0, 0, 0), new Vector3(1, .125, 0),
-          new Vector4(1, 0, 0, .125)),
+    // Front.
+    new Quad(new Vector3(1, 0, 0), new Vector3(0, 0, 0), new Vector3(1, .125, 0),
+      new Vector4(1, 0, 0, .125)),
 
-      // Back.
-      new Quad(new Vector3(0, 0, 1), new Vector3(1, 0, 1), new Vector3(0, .125, 1),
-          new Vector4(0, 1, 0, .125)),
+    // Back.
+    new Quad(new Vector3(0, 0, 1), new Vector3(1, 0, 1), new Vector3(0, .125, 1),
+      new Vector4(0, 1, 0, .125)),
 
-      // Right.
-      new Quad(new Vector3(0, 0, 0), new Vector3(0, 0, 1), new Vector3(0, .125, 0),
-          new Vector4(0, 1, 0, .125)),
+    // Right.
+    new Quad(new Vector3(0, 0, 0), new Vector3(0, 0, 1), new Vector3(0, .125, 0),
+      new Vector4(0, 1, 0, .125)),
 
-      // Left.
-      new Quad(new Vector3(1, 0, 1), new Vector3(1, 0, 0), new Vector3(1, .125, 1),
-          new Vector4(1, 0, 0, .125)),
+    // Left.
+    new Quad(new Vector3(1, 0, 1), new Vector3(1, 0, 0), new Vector3(1, .125, 1),
+      new Vector4(1, 0, 0, .125)),
 
-      // Top.
-      new Quad(new Vector3(1, .125, 0), new Vector3(0, .125, 0), new Vector3(1, .125, 1),
-          new Vector4(1, 0, 1, 0)),
+    // Top.
+    new Quad(new Vector3(1, .125, 0), new Vector3(0, .125, 0), new Vector3(1, .125, 1),
+      new Vector4(1, 0, 1, 0)),
   };
   //endregion
 
   //region Torch
   private static final Quad[] torch = {
-      new Quad(new Vector3(.75, 2 / 16., .4375), new Vector3(.25, 2 / 16., .4375),
-          new Vector3(.75, 14 / 16., .4375), new Vector4(.75, .25, 4 / 16., 1)),
+    new Quad(new Vector3(.75, 2 / 16., .4375), new Vector3(.25, 2 / 16., .4375),
+      new Vector3(.75, 14 / 16., .4375), new Vector4(.75, .25, 4 / 16., 1)),
 
-      new Quad(new Vector3(.25, 2 / 16., .5625), new Vector3(.75, 2 / 16., .5625),
-          new Vector3(.25, 14 / 16., .5625), new Vector4(.25, .75, 4 / 16., 1)),
+    new Quad(new Vector3(.25, 2 / 16., .5625), new Vector3(.75, 2 / 16., .5625),
+      new Vector3(.25, 14 / 16., .5625), new Vector4(.25, .75, 4 / 16., 1)),
 
-      new Quad(new Vector3(.4375, 2 / 16., .25), new Vector3(.4375, 2 / 16., .75),
-          new Vector3(.4375, 14 / 16., .25), new Vector4(.25, .75, 4 / 16., 1)),
+    new Quad(new Vector3(.4375, 2 / 16., .25), new Vector3(.4375, 2 / 16., .75),
+      new Vector3(.4375, 14 / 16., .25), new Vector4(.25, .75, 4 / 16., 1)),
 
-      new Quad(new Vector3(.5625, 2 / 16., .75), new Vector3(.5625, 2 / 16., .25),
-          new Vector3(.5625, 14 / 16., .75), new Vector4(.75, .25, 4 / 16., 1)),
+    new Quad(new Vector3(.5625, 2 / 16., .75), new Vector3(.5625, 2 / 16., .25),
+      new Vector3(.5625, 14 / 16., .75), new Vector4(.75, .25, 4 / 16., 1)),
 
-      // Top.
-      new Quad(new Vector3(.4375, 8 / 16., .5625), new Vector3(.5625, 8 / 16., .5625),
-          new Vector3(.4375, 8 / 16., .4375), new Vector4(.4375, .5625, .5, .625)),
+    // Top.
+    new Quad(new Vector3(.4375, 8 / 16., .5625), new Vector3(.5625, 8 / 16., .5625),
+      new Vector3(.4375, 8 / 16., .4375), new Vector4(.4375, .5625, .5, .625)),
   };
   //endregion
 
   //region Lock
   // {"elements":[{"from":[2,2,8],"to":[14,4,10],"faces":{"up":{"uv":[7,2,9,14],"texture":"#lock","rotation":1},"down":{"uv":[7,2,9,14],"texture":"#lock","rotation":1},"east":{"uv":[6,7,8,9],"texture":"#lock"},"west":{"uv":[6,7,8,9],"texture":"#lock"},"north":{"uv":[2,7,14,9],"texture":"#lock"},"south":{"uv":[2,7,14,9],"texture":"#lock"}}}]}
   private static final Quad[] lock = {
-      new Quad(
-          new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
-          new Vector3(2 / 16.0, 4 / 16.0, 10 / 16.0),
-          new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 2 / 16.0, 14 / 16.0)),
-      new Quad(
-          new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
-          new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 2 / 16.0, 14 / 16.0)),
-      new Quad(
-          new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector3(14 / 16.0, 2 / 16.0, 8 / 16.0),
-          new Vector3(14 / 16.0, 4 / 16.0, 10 / 16.0),
-          new Vector4(6 / 16.0, 8 / 16.0, 7 / 16.0, 9 / 16.0)),
-      new Quad(
-          new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
-          new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
-          new Vector4(6 / 16.0, 8 / 16.0, 7 / 16.0, 9 / 16.0)),
-      new Quad(
-          new Vector3(14 / 16.0, 2 / 16.0, 8 / 16.0),
-          new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
-          new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
-          new Vector4(2 / 16.0, 14 / 16.0, 7 / 16.0, 9 / 16.0)),
-      new Quad(
-          new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
-          new Vector3(2 / 16.0, 4 / 16.0, 10 / 16.0),
-          new Vector4(2 / 16.0, 14 / 16.0, 7 / 16.0, 9 / 16.0)),
+    new Quad(
+      new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 10 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 2 / 16.0, 14 / 16.0)),
+    new Quad(
+      new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 2 / 16.0, 14 / 16.0)),
+    new Quad(
+      new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector3(14 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 10 / 16.0),
+      new Vector4(6 / 16.0, 8 / 16.0, 7 / 16.0, 9 / 16.0)),
+    new Quad(
+      new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector4(6 / 16.0, 8 / 16.0, 7 / 16.0, 9 / 16.0)),
+    new Quad(
+      new Vector3(14 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector4(2 / 16.0, 14 / 16.0, 7 / 16.0, 9 / 16.0)),
+    new Quad(
+      new Vector3(2 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector3(14 / 16.0, 2 / 16.0, 10 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 10 / 16.0),
+      new Vector4(2 / 16.0, 14 / 16.0, 7 / 16.0, 9 / 16.0)),
   };
   //endregion
 
@@ -115,8 +115,8 @@ public class RedstoneRepeaterModel extends QuadModel {
   private static final Texture[] tex = {Texture.redstoneRepeaterOff, Texture.redstoneRepeaterOn,};
 
   private static final Texture[][] torchTex = {
-      { Texture.redstoneTorchOff, Texture.redstoneTorchOn, },
-      { Texture.bedrock, Texture.bedrock, },
+    {Texture.redstoneTorchOff, Texture.redstoneTorchOn,},
+    {Texture.bedrock, Texture.bedrock,},
   };
 
   static {
@@ -174,12 +174,20 @@ public class RedstoneRepeaterModel extends QuadModel {
   private final Quad[] quads;
   private final Texture[] textures;
 
-  public RedstoneRepeaterModel(int delay, int direction, int on, int locked) {
-    this.quads = Model.join(rot[direction], torch1[direction], torch2[locked][delay][direction]);
+  public RedstoneRepeaterModel(String facing, int delay, boolean powered, boolean locked) {
+    int delayIndex = 3 & (delay - 1);
+    int direction = switch (facing) {
+      case "south" -> 0;
+      case "west" -> 1;
+      case "east" -> 3;
+      default -> 2;
+    };
+
+    this.quads = Model.join(rot[direction], torch1[direction], torch2[locked ? 1 : 0][delayIndex][direction]);
     this.textures = new Texture[this.quads.length];
-    Arrays.fill(textures, 0, rot[direction].length, tex[on]);
-    Arrays.fill(textures, rot[direction].length, rot[direction].length+torch1[direction].length, torchTex[0][on]);
-    Arrays.fill(textures, rot[direction].length+torch1[direction].length, this.textures.length, torchTex[locked][on]);
+    Arrays.fill(textures, 0, rot[direction].length, tex[powered ? 1 : 0]);
+    Arrays.fill(textures, rot[direction].length, rot[direction].length + torch1[direction].length, torchTex[0][powered ? 1 : 0]);
+    Arrays.fill(textures, rot[direction].length + torch1[direction].length, this.textures.length, torchTex[locked ? 1 : 0][powered ? 1 : 0]);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel1212.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneRepeaterModel1212.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2012-2023 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.model.minecraft;
+
+import se.llbit.chunky.model.Model;
+import se.llbit.chunky.model.QuadModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The new Repeater model introduced in Minecraft 1.21.2 (24w33a).
+ */
+public class RedstoneRepeaterModel1212 extends QuadModel {
+  private static final Texture slab = Texture.smoothStone;
+  private static final Texture top = Texture.redstoneRepeaterOff;
+  private static final Texture topOn = Texture.redstoneRepeaterOn;
+  private static final Texture[] baseTex = new Texture[]{top, slab, slab, slab, slab, slab};
+  private static final Texture[] baseOnTex = new Texture[]{topOn, slab, slab, slab, slab, slab};
+
+  //region Body
+  private static final Quad[] north = {
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(0 / 16.0, 16 / 16.0, 0 / 16.0, 16 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(16 / 16.0, 2 / 16.0, 0 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(0 / 16.0, 2 / 16.0, 16 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 2 / 16.0, 0 / 16.0)
+    )
+  };
+  //endregion
+
+  //region Torch (off)
+  private static final Quad[] torch = {
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    )
+  };
+  //endregion
+
+  //region Torch (on)
+  private static final Quad[] torchOn = {
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(9 / 16.0, 7 / 16.0, 2 / 16.0),
+      new Vector3(7 / 16.0, 2 / 16.0, 2 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(7 / 16.0, 7 / 16.0, 4 / 16.0),
+      new Vector3(9 / 16.0, 2 / 16.0, 4 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 5 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 1.5 / 16.0),
+      new Vector4(8 / 16.0, 9 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 8 / 16.0, 10 / 16.0, 11 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 1.5 / 16.0),
+      new Vector4(10 / 16.0, 9 / 16.0, 10 / 16.0, 9 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 10 / 16.0, 9 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 4.5 / 16.0),
+      new Vector3(6.5 / 16.0, 4.5 / 16.0, 1.5 / 16.0),
+      new Vector4(10 / 16.0, 9 / 16.0, 9 / 16.0, 8 / 16.0)
+    ),
+    new RedstoneTorchModel.GlowQuad(
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 4.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 1.5 / 16.0),
+      new Vector3(9.5 / 16.0, 4.5 / 16.0, 4.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 9 / 16.0, 8 / 16.0)
+    )
+  };
+  //endregion
+
+  //region Lock
+  private static final Quad[] lock = {
+    new Quad(
+      new Vector3(2 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 2 / 16.0, 14 / 16.0)
+    ),
+    new Quad(
+      new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector3(2 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector4(8 / 16.0, 6 / 16.0, 9 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(14 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 2 / 16.0, 6 / 16.0),
+      new Vector4(8 / 16.0, 6 / 16.0, 9 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(2 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector3(14 / 16.0, 4 / 16.0, 6 / 16.0),
+      new Vector3(2 / 16.0, 2 / 16.0, 6 / 16.0),
+      new Vector4(14 / 16.0, 2 / 16.0, 9 / 16.0, 7 / 16.0)
+    ),
+    new Quad(
+      new Vector3(14 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(2 / 16.0, 4 / 16.0, 8 / 16.0),
+      new Vector3(14 / 16.0, 2 / 16.0, 8 / 16.0),
+      new Vector4(14 / 16.0, 2 / 16.0, 9 / 16.0, 7 / 16.0)
+    )
+  };
+  //endregion
+
+  private final Quad[] quads;
+  private final Texture[] textures;
+
+  public RedstoneRepeaterModel1212(String facing, int delay, boolean powered, boolean locked) {
+    List<Quad> model = new ArrayList<>();
+    Collections.addAll(model, north);
+    Collections.addAll(model, powered ? torchOn : torch);
+    if (locked) {
+      Collections.addAll(model, Model.translate(lock, 0, 0, (delay - 1) * 2 / 16.));
+    } else {
+      Collections.addAll(model, Model.translate(powered ? torchOn : torch, 0, 0, 2 / 16. + delay * 2 / 16.));
+    }
+    quads = switch (facing) {
+      case "west" -> Model.rotateY(model.toArray(new Quad[0]));
+      case "north" -> Model.rotateY(Model.rotateY(model.toArray(new Quad[0])));
+      case "east" -> Model.rotateNegY(model.toArray(new Quad[0]));
+      default -> model.toArray(new Quad[0]);
+    };
+    this.textures = new Texture[this.quads.length];
+    System.arraycopy(powered ? baseOnTex : baseTex, 0, this.textures, 0, 6);
+    Arrays.fill(textures, 6, 6 + (powered ? torchOn : torch).length, powered ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
+    if (locked) {
+      Arrays.fill(textures, 6 + (powered ? torchOn : torch).length, 6 + (powered ? torchOn : torch).length + lock.length, Texture.bedrock);
+    } else {
+      Arrays.fill(textures, 6 + (powered ? torchOn : torch).length, 6 + 2 * (powered ? torchOn : torch).length, powered ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
+    }
+  }
+
+  @Override
+  public Quad[] getQuads() {
+    return quads;
+  }
+
+  @Override
+  public Texture[] getTextures() {
+    return textures;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    return RedstoneTorchModel.intersectWithGlow(ray, scene, this);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneTorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneTorchModel.java
@@ -1,0 +1,158 @@
+package se.llbit.chunky.model.minecraft;
+
+import se.llbit.chunky.model.QuadModel;
+import se.llbit.chunky.renderer.scene.Scene;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Ray;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+import java.util.Arrays;
+
+public class RedstoneTorchModel extends QuadModel {
+  private static final Quad[] quads = new Quad[]{
+    new Quad(
+      new Vector3(7 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(9 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(7 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector3(9 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector3(7 / 16.0, 0 / 16.0, 9 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(7 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector3(7 / 16.0, 0 / 16.0, 9 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector3(9 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(9 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector3(9 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector3(7 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(7 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(9 / 16.0, 0 / 16.0, 9 / 16.0),
+      new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 9.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 9.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 6.5 / 16.0),
+      new Vector4(8 / 16.0, 9 / 16.0, 10 / 16.0, 11 / 16.0),
+      true
+    ),
+    new Quad(
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(9.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 9.5 / 16.0),
+      new Vector4(7 / 16.0, 8 / 16.0, 10 / 16.0, 11 / 16.0),
+      true
+    ),
+    new Quad(
+      new Vector3(9.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 6.5 / 16.0),
+      new Vector4(10 / 16.0, 9 / 16.0, 10 / 16.0, 9 / 16.0),
+      true
+    ),
+    new Quad(
+      new Vector3(9.5 / 16.0, 10.5 / 16.0, 9.5 / 16.0),
+      new Vector3(9.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(9.5 / 16.0, 7.5 / 16.0, 9.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 9 / 16.0, 8 / 16.0),
+      true
+    ),
+    new Quad(
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 9.5 / 16.0),
+      new Vector3(9.5 / 16.0, 10.5 / 16.0, 9.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 9.5 / 16.0),
+      new Vector4(7 / 16.0, 6 / 16.0, 10 / 16.0, 9 / 16.0),
+      true
+    ),
+    new Quad(
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 6.5 / 16.0),
+      new Vector3(6.5 / 16.0, 10.5 / 16.0, 9.5 / 16.0),
+      new Vector3(6.5 / 16.0, 7.5 / 16.0, 6.5 / 16.0),
+      new Vector4(10 / 16.0, 9 / 16.0, 9 / 16.0, 8 / 16.0),
+      true
+    )
+  };
+
+  private final Texture[] textures;
+
+  public RedstoneTorchModel(boolean isLit) {
+    this.textures = new Texture[quads.length];
+    Arrays.fill(this.textures, isLit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
+  }
+
+  @Override
+  public Quad[] getQuads() {
+    return quads;
+  }
+
+  @Override
+  public Texture[] getTextures() {
+    return textures;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    boolean hit = false;
+    int hitQuadIndex = -1;
+    ray.t = Double.POSITIVE_INFINITY;
+
+    Quad[] quads = getQuads();
+    Texture[] textures = getTextures();
+
+    float[] color = null;
+    int count = 0;
+    for (int i = 0; i < quads.length; ++i) {
+      Quad quad = quads[i];
+      if (quad.intersect(ray)) {
+        if (i>=6) {
+          count++;
+        }
+        float[] c = textures[i].getColor(ray.u, ray.v);
+        if (c[3] > Ray.EPSILON) {
+          if (ray.d.dot(quad.n) < 0) {
+            color = c;
+            ray.t = ray.tNext;
+            ray.setNormal(quad.n);
+            hit = true;
+            hitQuadIndex = i;
+          }
+        }
+      }
+    }
+
+    if (hit && (count != 1 || hitQuadIndex < 6)) {
+      double px = ray.o.x - Math.floor(ray.o.x + ray.d.x * Ray.OFFSET) + ray.d.x * ray.tNext;
+      double py = ray.o.y - Math.floor(ray.o.y + ray.d.y * Ray.OFFSET) + ray.d.y * ray.tNext;
+      double pz = ray.o.z - Math.floor(ray.o.z + ray.d.z * Ray.OFFSET) + ray.d.z * ray.tNext;
+      if (px < E0 || px > E1 || py < E0 || py > E1 || pz < E0 || pz > E1) {
+        // TODO this check is only really needed for wall torches
+        return false;
+      }
+
+      ray.color.set(color);
+      ray.distance += ray.t;
+      ray.o.scaleAdd(ray.t, ray.d);
+      return true;
+    }
+    return false;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneWallTorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneWallTorchModel.java
@@ -1,0 +1,159 @@
+package se.llbit.chunky.model.minecraft;
+
+import se.llbit.chunky.model.Model;
+import se.llbit.chunky.model.QuadModel;
+import se.llbit.chunky.resources.Texture;
+import se.llbit.math.Quad;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector4;
+
+import java.util.Arrays;
+
+public class RedstoneWallTorchModel extends QuadModel {
+  private static final Quad[] wallTorchNorth = Model.join(
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+          new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+        ),
+        new Quad(
+          new Vector3(-1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+          new Vector3(1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+          new Vector3(-1 / 16.0, 3.5 / 16.0, 9 / 16.0),
+          new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
+        ),
+        new Quad(
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+          new Vector3(-1 / 16.0, 3.5 / 16.0, 9 / 16.0),
+          new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+        ),
+        new Quad(
+          new Vector3(1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+          new Vector3(1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+          new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+        ),
+        new Quad(
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+          new Vector3(1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+          new Vector3(-1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+          new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+        ),
+        new Quad(
+          new Vector3(1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+          new Vector3(1 / 16.0, 3.5 / 16.0, 9 / 16.0),
+          new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(-1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
+          new Vector3(1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
+          new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
+          new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
+          new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
+          new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
+          new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
+          new Vector3(1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
+          new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    ),
+    Model.rotateZ(
+      new Quad[]{
+        new Quad(
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
+          new Vector3(-1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
+          new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
+        )
+      },
+      Math.toRadians(-22.5),
+      new Vector3(0, 3.5 / 16., 0)
+    )
+  );
+
+  private final Texture[] textures;
+  private Quad[] quads;
+
+  public RedstoneWallTorchModel(boolean isLit, String facing) {
+    textures = new Texture[wallTorchNorth.length];
+    quads = wallTorchNorth;
+    switch (facing) {
+      case "east":
+        quads = Model.rotateNegY(quads);
+        break;
+      case "south":
+        quads = Model.rotateY(quads, Math.toRadians(180));
+        break;
+      case "west":
+        quads = Model.rotateY(quads);
+        break;
+    }
+    Arrays.fill(this.textures, isLit ? Texture.redstoneTorchOn : Texture.redstoneTorchOff);
+  }
+
+  @Override
+  public Quad[] getQuads() {
+    return wallTorchNorth;
+  }
+
+  @Override
+  public Texture[] getTextures() {
+    return textures;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneWallTorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/RedstoneWallTorchModel.java
@@ -2,8 +2,10 @@ package se.llbit.chunky.model.minecraft;
 
 import se.llbit.chunky.model.Model;
 import se.llbit.chunky.model.QuadModel;
+import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.Texture;
 import se.llbit.math.Quad;
+import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector4;
 
@@ -48,74 +50,38 @@ public class RedstoneWallTorchModel extends QuadModel {
           new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
           new Vector3(1 / 16.0, 3.5 / 16.0, 9 / 16.0),
           new Vector4(9 / 16.0, 7 / 16.0, 10 / 16.0, 0 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(-1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
           new Vector3(1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
           new Vector3(-1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
           new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
           new Vector4(6 / 16.0, 7 / 16.0, 10 / 16.0, 11 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
           new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
           new Vector3(1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
           new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
           new Vector3(1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
           new Vector3(-1.5 / 16.0, 11 / 16.0, 9.5 / 16.0),
           new Vector4(7 / 16.0, 6 / 16.0, 11 / 16.0, 10 / 16.0)
-        )
-      },
-      Math.toRadians(-22.5),
-      new Vector3(0, 3.5 / 16., 0)
-    ),
-    Model.rotateZ(
-      new Quad[]{
-        new Quad(
+        ),
+        new RedstoneTorchModel.GlowQuad(
           new Vector3(-1.5 / 16.0, 14 / 16.0, 6.5 / 16.0),
           new Vector3(-1.5 / 16.0, 14 / 16.0, 9.5 / 16.0),
           new Vector3(-1.5 / 16.0, 11 / 16.0, 6.5 / 16.0),
@@ -155,5 +121,10 @@ public class RedstoneWallTorchModel extends QuadModel {
   @Override
   public Texture[] getTextures() {
     return textures;
+  }
+
+  @Override
+  public boolean intersect(Ray ray, Scene scene) {
+    return RedstoneTorchModel.intersectWithGlow(ray, scene, this);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/model/minecraft/TorchModel.java
+++ b/chunky/src/java/se/llbit/chunky/model/minecraft/TorchModel.java
@@ -27,81 +27,81 @@ import se.llbit.math.Vector4;
 public class TorchModel extends QuadModel {
 
   private static final Quad[] quadsGround = new Quad[]{
-      new Quad(
-          new Vector3(7 / 16.0, 10 / 16.0, 9 / 16.0),
-          new Vector3(9 / 16.0, 10 / 16.0, 9 / 16.0),
-          new Vector3(7 / 16.0, 10 / 16.0, 7 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
-      ),
-      new Quad(
-          new Vector3(7 / 16.0, 0 / 16.0, 7 / 16.0),
-          new Vector3(9 / 16.0, 0 / 16.0, 7 / 16.0),
-          new Vector3(7 / 16.0, 0 / 16.0, 9 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
-      ),
-      new Quad(
-          new Vector3(7 / 16.0, 16 / 16.0, 16 / 16.0),
-          new Vector3(7 / 16.0, 16 / 16.0, 0 / 16.0),
-          new Vector3(7 / 16.0, 0 / 16.0, 16 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(9 / 16.0, 16 / 16.0, 0 / 16.0),
-          new Vector3(9 / 16.0, 16 / 16.0, 16 / 16.0),
-          new Vector3(9 / 16.0, 0 / 16.0, 0 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(0 / 16.0, 16 / 16.0, 7 / 16.0),
-          new Vector3(16 / 16.0, 16 / 16.0, 7 / 16.0),
-          new Vector3(0 / 16.0, 0 / 16.0, 7 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(16 / 16.0, 16 / 16.0, 9 / 16.0),
-          new Vector3(0 / 16.0, 16 / 16.0, 9 / 16.0),
-          new Vector3(16 / 16.0, 0 / 16.0, 9 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      )
+    new Quad(
+      new Vector3(7 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(9 / 16.0, 10 / 16.0, 9 / 16.0),
+      new Vector3(7 / 16.0, 10 / 16.0, 7 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector3(9 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector3(7 / 16.0, 0 / 16.0, 9 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
+    ),
+    new Quad(
+      new Vector3(7 / 16.0, 16 / 16.0, 16 / 16.0),
+      new Vector3(7 / 16.0, 16 / 16.0, 0 / 16.0),
+      new Vector3(7 / 16.0, 0 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(9 / 16.0, 16 / 16.0, 0 / 16.0),
+      new Vector3(9 / 16.0, 16 / 16.0, 16 / 16.0),
+      new Vector3(9 / 16.0, 0 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(0 / 16.0, 16 / 16.0, 7 / 16.0),
+      new Vector3(16 / 16.0, 16 / 16.0, 7 / 16.0),
+      new Vector3(0 / 16.0, 0 / 16.0, 7 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(16 / 16.0, 16 / 16.0, 9 / 16.0),
+      new Vector3(0 / 16.0, 16 / 16.0, 9 / 16.0),
+      new Vector3(16 / 16.0, 0 / 16.0, 9 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    )
   };
 
   private static final Quad[] quadsWall = Model.rotateZ(new Quad[]{
-      new Quad(
-          new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
-          new Vector3(1 / 16.0, 13.5 / 16.0, 9 / 16.0),
-          new Vector3(-1 / 16.0, 13.5 / 16.0, 7 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
-      ),
-      new Quad(
-          new Vector3(-1 / 16.0, 3.5 / 16.0, 7 / 16.0),
-          new Vector3(1 / 16.0, 3.5 / 16.0, 7 / 16.0),
-          new Vector3(-1 / 16.0, 3.5 / 16.0, 9 / 16.0),
-          new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
-      ),
-      new Quad(
-          new Vector3(-1 / 16.0, 19.5 / 16.0, 16 / 16.0),
-          new Vector3(-1 / 16.0, 19.5 / 16.0, 0 / 16.0),
-          new Vector3(-1 / 16.0, 3.5 / 16.0, 16 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(1 / 16.0, 19.5 / 16.0, 0 / 16.0),
-          new Vector3(1 / 16.0, 19.5 / 16.0, 16 / 16.0),
-          new Vector3(1 / 16.0, 3.5 / 16.0, 0 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(-8 / 16.0, 19.5 / 16.0, 7 / 16.0),
-          new Vector3(8 / 16.0, 19.5 / 16.0, 7 / 16.0),
-          new Vector3(-8 / 16.0, 3.5 / 16.0, 7 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      ),
-      new Quad(
-          new Vector3(8 / 16.0, 19.5 / 16.0, 9 / 16.0),
-          new Vector3(-8 / 16.0, 19.5 / 16.0, 9 / 16.0),
-          new Vector3(8 / 16.0, 3.5 / 16.0, 9 / 16.0),
-          new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
-      )
+    new Quad(
+      new Vector3(-1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+      new Vector3(1 / 16.0, 13.5 / 16.0, 9 / 16.0),
+      new Vector3(-1 / 16.0, 13.5 / 16.0, 7 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 8 / 16.0, 10 / 16.0)
+    ),
+    new Quad(
+      new Vector3(-1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+      new Vector3(1 / 16.0, 3.5 / 16.0, 7 / 16.0),
+      new Vector3(-1 / 16.0, 3.5 / 16.0, 9 / 16.0),
+      new Vector4(7 / 16.0, 9 / 16.0, 1 / 16.0, 3 / 16.0)
+    ),
+    new Quad(
+      new Vector3(-1 / 16.0, 19.5 / 16.0, 16 / 16.0),
+      new Vector3(-1 / 16.0, 19.5 / 16.0, 0 / 16.0),
+      new Vector3(-1 / 16.0, 3.5 / 16.0, 16 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(1 / 16.0, 19.5 / 16.0, 0 / 16.0),
+      new Vector3(1 / 16.0, 19.5 / 16.0, 16 / 16.0),
+      new Vector3(1 / 16.0, 3.5 / 16.0, 0 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(-8 / 16.0, 19.5 / 16.0, 7 / 16.0),
+      new Vector3(8 / 16.0, 19.5 / 16.0, 7 / 16.0),
+      new Vector3(-8 / 16.0, 3.5 / 16.0, 7 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    ),
+    new Quad(
+      new Vector3(8 / 16.0, 19.5 / 16.0, 9 / 16.0),
+      new Vector3(-8 / 16.0, 19.5 / 16.0, 9 / 16.0),
+      new Vector3(8 / 16.0, 3.5 / 16.0, 9 / 16.0),
+      new Vector4(16 / 16.0, 0 / 16.0, 16 / 16.0, 0 / 16.0)
+    )
   }, Math.toRadians(-22.5), new Vector3(0, 3.5 / 16, 8 / 16.));
 
   private static final Quad[][] rotatedQuadsWall = new Quad[6][];
@@ -117,9 +117,15 @@ public class TorchModel extends QuadModel {
 
   private final int rotation;
 
-  public TorchModel(Texture texture, int rotation) {
+  public TorchModel(Texture texture, String facing) {
     this.textures = new Texture[]{texture, texture, texture, texture, texture, texture};
-    this.rotation = rotation;
+    this.rotation = switch (facing) {
+      case "north" -> 4;
+      case "south" -> 3;
+      case "west" -> 2;
+      case "east" -> 1;
+      default -> 5;
+    };
   }
 
   @Override


### PR DESCRIPTION
This adds the new redstone torch model from Minecraft 1.21.2 (added in 24w33a). Credits to @Peregrine05 :clap: 

Related #1780
Closes #1781 and #1782

Once this PR updates the comparator and repeater models, this also fixes #1783