### PR TITLE
Registerable WorldFormat api

### DIFF
--- a/chunky/src/java/se/llbit/chunky/map/MapTile.java
+++ b/chunky/src/java/se/llbit/chunky/map/MapTile.java
@@ -71,8 +71,9 @@ public class MapTile {
       }
     } else {
       RegionPosition regionPos = new RegionPosition(pos.x, pos.z); // intentionally don't convert, this position represented a region already.
-      boolean isValid = mapLoader.getWorld().currentDimension().regionExistsWithinRange(regionPos, view.yMin, view.yMax);
-      Region region = mapLoader.getWorld().currentDimension().getRegionWithinRange(regionPos, view.yMin, view.yMax);
+      HeightRange heightRange = new HeightRange(view.yMin, view.yMax);
+      boolean isValid = mapLoader.getWorld().currentDimension().hasRegionWithinRange(regionPos, heightRange);
+      Region region = mapLoader.getWorld().currentDimension().getRegionWithinRange(regionPos, heightRange);
       int pixelOffset = 0;
       for (int z = 0; z < 32; ++z) {
         for (int x = 0; x < 32; ++x) {

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -85,9 +85,9 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
 
     Optional<Dimension.Identifier> dimensionToLoad = Optional.of(world.currentDimension())
       .map(Dimension::getDimensionId)
-      .filter(dimension -> newWorld.availableDimensions().contains(dimension))
-      .or(newWorld::defaultDimension)
-      .or(() -> newWorld.availableDimensions().stream().findFirst());
+      .filter(dimension -> newWorld.getAvailableDimensions().contains(dimension))
+      .or(newWorld::getDefaultDimension)
+      .or(() -> newWorld.getAvailableDimensions().stream().findFirst());
 
     if (dimensionToLoad.isEmpty()) {
       Log.infof("No dimension loaded for world %s", newWorld.toString());
@@ -192,7 +192,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
   /**
    * Set the current dimension.
    *
-   * @param value Must be a valid dimension see {@link World#availableDimensions()}
+   * @param value Must be a valid dimension see {@link World#getAvailableDimensions()}
    */
   public void setDimension(Dimension.Identifier value) {
     if (value != currentDimensionId) {

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -22,12 +22,11 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.ChunkViewListener;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.chunky.world.*;
-import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.RegionChangeWatcher;
 import se.llbit.chunky.world.region.RegionParser;
 import se.llbit.chunky.world.region.RegionQueue;
 import se.llbit.chunky.world.listeners.ChunkTopographyListener;
-import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.chunky.world.worldformat.WorldFormats;
 import se.llbit.log.Log;
 import se.llbit.util.annotation.Nullable;
 
@@ -73,7 +72,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     if (worldLocation == null) {
       return;
     }
-    this.loadWorld(WorldFormat.loadWorld(worldLocation).orElse(EmptyWorld.INSTANCE));
+    this.loadWorld(WorldFormats.createWorld(worldLocation).orElse(EmptyWorld.INSTANCE));
   }
   /**
    * This is called when a new world is loaded

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.ChunkViewListener;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.RegionChangeWatcher;
 import se.llbit.chunky.world.region.RegionParser;
 import se.llbit.chunky.world.region.RegionQueue;
@@ -68,7 +69,7 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
    * This is called when a new world is loaded
    */
   public void loadWorld(File worldDir) {
-    if (World.isWorldDir(worldDir)) {
+    if (JavaWorld.isWorldDir(worldDir)) {
       if (world != null) {
         world.currentDimension().removeChunkTopographyListener(this);
       }

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.map;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.ChunkViewListener;
@@ -26,6 +27,9 @@ import se.llbit.chunky.world.region.RegionChangeWatcher;
 import se.llbit.chunky.world.region.RegionParser;
 import se.llbit.chunky.world.region.RegionQueue;
 import se.llbit.chunky.world.listeners.ChunkTopographyListener;
+import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.log.Log;
+import se.llbit.util.annotation.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -65,28 +69,44 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     topographyUpdater.start();
   }
 
+  public void loadWorldFromDirectory(@Nullable File worldLocation) {
+    if (worldLocation == null) {
+      return;
+    }
+    this.loadWorld(WorldFormat.loadWorld(worldLocation).orElse(EmptyWorld.INSTANCE));
+  }
   /**
    * This is called when a new world is loaded
    */
-  public void loadWorld(File worldDir) {
-    if (JavaWorld.isWorldDir(worldDir)) {
-      if (world != null) {
-        world.currentDimension().removeChunkTopographyListener(this);
-      }
-      boolean isSameWorld = !(world instanceof EmptyWorld) && worldDir.equals(world.getWorldDirectory());
-      World newWorld = World.loadWorld(worldDir, currentDimensionId, World.LoggedWarnings.NORMAL);
-      newWorld.currentDimension().addChunkTopographyListener(this);
-      synchronized (this) {
-        world = newWorld;
-        updateRegionChangeWatcher(newWorld.currentDimension());
-
-        File newWorldDir = world.getWorldDirectory();
-        if (newWorldDir != null && !newWorldDir.equals(PersistentSettings.getLastWorld())) {
-          PersistentSettings.setLastWorld(newWorldDir);
-        }
-      }
-      worldLoadListeners.forEach(listener -> listener.accept(newWorld, isSameWorld));
+  public void loadWorld(World newWorld) {
+    if (this.world != null) {
+      this.world.currentDimension().removeChunkTopographyListener(this);
     }
+    boolean isSameWorld = !(this.world instanceof EmptyWorld) && newWorld.getWorldDirectory().equals(this.world.getWorldDirectory());
+
+    Optional<Dimension.Identifier> dimensionToLoad = Optional.of(world.currentDimension())
+      .map(Dimension::getDimensionId)
+      .filter(dimension -> newWorld.availableDimensions().contains(dimension))
+      .or(newWorld::defaultDimension)
+      .or(() -> newWorld.availableDimensions().stream().findFirst());
+
+    if (dimensionToLoad.isEmpty()) {
+      Log.infof("No dimension loaded for world %s", newWorld.toString());
+      return;
+    }
+
+    Dimension loadedDim = newWorld.loadDimension(dimensionToLoad.get());
+    loadedDim.addChunkTopographyListener(this);
+    synchronized (this) {
+      this.world = newWorld;
+      updateRegionChangeWatcher(loadedDim);
+
+      File newWorldDir = this.world.getWorldDirectory();
+      if (!newWorldDir.equals(PersistentSettings.getLastWorld())) {
+        PersistentSettings.setLastWorld(newWorldDir);
+      }
+    }
+    worldLoadListeners.forEach(listener -> listener.accept(newWorld, isSameWorld));
   }
 
   /**
@@ -152,14 +172,12 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
   public void reloadWorld() {
     topographyUpdater.clearQueue();
     world.currentDimension().removeChunkTopographyListener(this);
-    World newWorld = World.loadWorld(world.getWorldDirectory(), currentDimensionId,
-        World.LoggedWarnings.NORMAL);
-    newWorld.currentDimension().addChunkTopographyListener(this);
+    world.loadDimension(currentDimensionId);
+    world.currentDimension().addChunkTopographyListener(this);
     synchronized (this) {
-      world = newWorld;
-      updateRegionChangeWatcher(newWorld.currentDimension());
+      updateRegionChangeWatcher(world.currentDimension());
     }
-    worldLoadListeners.forEach(listener -> listener.accept(newWorld, true));
+    worldLoadListeners.forEach(listener -> listener.accept(world, true));
     viewUpdated(mapView.getMapView()); // update visible chunks immediately
   }
 
@@ -174,6 +192,8 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
 
   /**
    * Set the current dimension.
+   *
+   * @param value Must be a valid dimension see {@link World#availableDimensions()}
    */
   public void setDimension(Dimension.Identifier value) {
     if (value != currentDimensionId) {

--- a/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
+++ b/chunky/src/java/se/llbit/chunky/map/WorldMapLoader.java
@@ -22,6 +22,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.renderer.ChunkViewListener;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.java.JavaWorldFormat;
 import se.llbit.chunky.world.region.RegionChangeWatcher;
 import se.llbit.chunky.world.region.RegionParser;
 import se.llbit.chunky.world.region.RegionQueue;
@@ -68,20 +69,27 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
     topographyUpdater.start();
   }
 
-  public void loadWorldFromDirectory(@Nullable File worldLocation) {
-    if (worldLocation == null) {
+  public void loadWorldFromDirectory(@Nullable File worldLocation, @Nullable String worldFormatId) {
+    if (worldLocation != null) {
+      if (worldFormatId == null || worldFormatId.isEmpty()) {
+        worldFormatId = JavaWorldFormat.ID;
+      }
+      Optional<World.Info> info = WorldFormats.getWorldFormat(worldFormatId)
+        .flatMap(format -> format.getWorldInfo(worldLocation.toPath())) // attempt to get the given format
+        .or(() -> WorldFormats.getInfos(worldLocation.toPath()).stream().findFirst()); // get any format
+      info.ifPresent(this::loadWorld);
       return;
     }
-    this.loadWorld(WorldFormats.createWorld(worldLocation).orElse(EmptyWorld.INSTANCE));
+    setWorld(EmptyWorld.INSTANCE);
   }
+
   /**
-   * This is called when a new world is loaded
+   * Load the world referred to by the {@link World.Info}
+   *
+   * @return The loaded world. May be {@link EmptyWorld} if loading failed.
    */
-  public void loadWorld(World newWorld) {
-    if (this.world != null) {
-      this.world.currentDimension().removeChunkTopographyListener(this);
-    }
-    boolean isSameWorld = !(this.world instanceof EmptyWorld) && newWorld.getWorldDirectory().equals(this.world.getWorldDirectory());
+  public World loadWorld(World.Info info) {
+    World newWorld = WorldFormats.createWorld(info);
 
     Optional<Dimension.Identifier> dimensionToLoad = Optional.of(world.currentDimension())
       .map(Dimension::getDimensionId)
@@ -89,21 +97,45 @@ public class WorldMapLoader implements ChunkTopographyListener, ChunkViewListene
       .or(newWorld::getDefaultDimension)
       .or(() -> newWorld.getAvailableDimensions().stream().findFirst());
 
-    if (dimensionToLoad.isEmpty()) {
-      Log.infof("No dimension loaded for world %s", newWorld.toString());
-      return;
+    if (dimensionToLoad.isPresent()) {
+      newWorld.loadDimension(dimensionToLoad.get());
+    } else {
+      Log.infof("No dimension loaded for world %s", info.toString());
     }
 
-    Dimension loadedDim = newWorld.loadDimension(dimensionToLoad.get());
+    setWorld(newWorld);
+    return this.world;
+  }
+
+  /**
+   * Sets the map view world.
+   * <p>This is intended to be called with worlds with a dimension already loaded, as it will not trigger dimension
+   * loading.</p>
+   *
+   * @param newWorld The world to set
+   */
+  public void setWorld(World newWorld) {
+    if (this.world != null) {
+      this.world.currentDimension().removeChunkTopographyListener(this);
+    }
+
+    boolean isSameWorld = !(this.world instanceof EmptyWorld) && newWorld.getInfo().path().equals(this.world.getInfo().path());
+
+    Dimension loadedDim = newWorld.currentDimension();
+    if (loadedDim == EmptyWorld.INSTANCE.currentDimension()) {
+      Log.warn("Map view world was set but it has no dimension!");
+    }
+
     loadedDim.addChunkTopographyListener(this);
     synchronized (this) {
       this.world = newWorld;
       updateRegionChangeWatcher(loadedDim);
 
-      File newWorldDir = this.world.getWorldDirectory();
+      File newWorldDir = this.world.getInfo().path().toFile();
       if (!newWorldDir.equals(PersistentSettings.getLastWorld())) {
         PersistentSettings.setLastWorld(newWorldDir);
       }
+      PersistentSettings.setLastWorldFormat(newWorld.getInfo().worldFormat().getId());
     }
     worldLoadListeners.forEach(listener -> listener.accept(newWorld, isSameWorld));
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -53,6 +53,7 @@ import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.Biome;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
+import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.json.*;
 import se.llbit.log.Log;
@@ -547,7 +548,7 @@ public class Scene implements JsonSerializable {
       loadedWorld = EmptyWorld.INSTANCE;
       if (!worldPath.isEmpty()) {
         File worldDirectory = new File(worldPath);
-        if (World.isWorldDir(worldDirectory)) {
+        if (JavaWorld.isWorldDir(worldDirectory)) {
           loadedWorld = World.loadWorld(worldDirectory, worldDimension, World.LoggedWarnings.NORMAL);
         } else {
           Log.info("Could not load world: " + worldPath);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -53,8 +53,8 @@ import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.Biome;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
+import se.llbit.chunky.world.region.Region;
 import se.llbit.chunky.world.worldformat.WorldFormats;
-import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.json.*;
 import se.llbit.log.Log;
 import se.llbit.math.*;
@@ -864,8 +864,8 @@ public class Scene implements JsonSerializable {
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
 
-      ChunkData[] regionParsingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
-      ChunkData[] chunkLoadingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
+      ChunkData[] regionParsingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
+      ChunkData[] chunkLoadingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
 
       BiFunction<RegionPosition, ChunkData[], Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition, chunkDataArray) -> executor.submit(() -> {
         List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -53,9 +53,8 @@ import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.Biome;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
-import se.llbit.chunky.world.java.JavaWorld;
+import se.llbit.chunky.world.worldformat.WorldFormats;
 import se.llbit.chunky.world.region.MCRegion;
-import se.llbit.chunky.world.worldformat.WorldFormat;
 import se.llbit.json.*;
 import se.llbit.log.Log;
 import se.llbit.math.*;
@@ -549,7 +548,7 @@ public class Scene implements JsonSerializable {
       loadedWorld = EmptyWorld.INSTANCE;
       if (!worldPath.isEmpty()) {
         File worldDirectory = new File(worldPath);
-        Optional<World> newWorld = WorldFormat.loadWorld(worldDirectory);
+        Optional<World> newWorld = WorldFormats.createWorld(worldDirectory);
         if (newWorld.isPresent()) {
           loadedWorld = newWorld.get();
           loadedWorld.loadDimension(this.worldDimension);
@@ -865,8 +864,8 @@ public class Scene implements JsonSerializable {
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
 
-      ChunkData[] regionParsingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
-      ChunkData[] chunkLoadingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
+      ChunkData[] regionParsingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
+      ChunkData[] chunkLoadingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
 
       BiFunction<RegionPosition, ChunkData[], Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition, chunkDataArray) -> executor.submit(() -> {
         List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -55,6 +55,7 @@ import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
 import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.worldformat.WorldFormat;
 import se.llbit.json.*;
 import se.llbit.log.Log;
 import se.llbit.math.*;
@@ -548,10 +549,13 @@ public class Scene implements JsonSerializable {
       loadedWorld = EmptyWorld.INSTANCE;
       if (!worldPath.isEmpty()) {
         File worldDirectory = new File(worldPath);
-        if (JavaWorld.isWorldDir(worldDirectory)) {
-          loadedWorld = World.loadWorld(worldDirectory, worldDimension, World.LoggedWarnings.NORMAL);
+        Optional<World> newWorld = WorldFormat.loadWorld(worldDirectory);
+        if (newWorld.isPresent()) {
+          loadedWorld = newWorld.get();
+          loadedWorld.loadDimension(this.worldDimension);
         } else {
           Log.info("Could not load world: " + worldPath);
+          loadedWorld = EmptyWorld.INSTANCE;
         }
       }
 
@@ -768,7 +772,7 @@ public class Scene implements JsonSerializable {
       Log.warn("Can not reload chunks for scene - world directory not found!");
       return;
     }
-    loadedWorld = World.loadWorld(loadedWorld.getWorldDirectory(), worldDimension, World.LoggedWarnings.NORMAL);
+    loadedWorld.loadDimension(worldDimension);
     loadChunks(taskTracker, loadedWorld, ChunkSelectionTracker.selectionByRegion(chunks));
     refresh();
   }
@@ -861,8 +865,8 @@ public class Scene implements JsonSerializable {
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
 
-      ChunkData[] regionParsingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
-      ChunkData[] chunkLoadingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
+      ChunkData[] regionParsingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
+      ChunkData[] chunkLoadingDataArray = new ChunkData[Region.CHUNKS_X * Region.CHUNKS_Z];
 
       BiFunction<RegionPosition, ChunkData[], Future<List<ObjectObjectImmutablePair<ChunkPosition, ChunkData>>>> createRegionDataFuture = (regionPosition, chunkDataArray) -> executor.submit(() -> {
         List<ChunkPosition> chunkPositionsToLoad = chunksToLoadByRegion.get(regionPosition);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -53,6 +53,7 @@ import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.Biome;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
+import se.llbit.chunky.world.java.JavaWorldFormat;
 import se.llbit.chunky.world.region.Region;
 import se.llbit.chunky.world.worldformat.WorldFormats;
 import se.llbit.json.*;
@@ -68,6 +69,7 @@ import se.llbit.util.io.ZipExport;
 import se.llbit.util.mojangapi.MinecraftProfile;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -193,6 +195,7 @@ public class Scene implements JsonSerializable {
    */
   protected int rayDepth = PersistentSettings.getRayDepthDefault();
   protected String worldPath = "";
+  protected String worldFormat = JavaWorldFormat.ID;
   protected Dimension.Identifier worldDimension = Dimension.Identifier.OVERWORLD;
   protected RenderMode mode = RenderMode.PREVIEW;
   protected int dumpFrequency = DEFAULT_DUMP_FREQUENCY;
@@ -405,6 +408,7 @@ public class Scene implements JsonSerializable {
     if (copyChunks) {
       loadedWorld = other.loadedWorld;
       worldPath = other.worldPath;
+      worldFormat = other.worldFormat;
       worldDimension = other.worldDimension;
 
       // The octree reference is overwritten to save time.
@@ -547,14 +551,17 @@ public class Scene implements JsonSerializable {
 
       loadedWorld = EmptyWorld.INSTANCE;
       if (!worldPath.isEmpty()) {
-        File worldDirectory = new File(worldPath);
-        Optional<World> newWorld = WorldFormats.createWorld(worldDirectory);
-        if (newWorld.isPresent()) {
-          loadedWorld = newWorld.get();
+        Path worldDirectory = Path.of(worldPath);
+        Optional<World.Info> info = WorldFormats.getWorldFormat(worldFormat) // only try to load the world as its known world format.
+          .flatMap(format -> format.getWorldInfo(worldDirectory));
+
+        if (info.isPresent()) {
+          World newWorld = WorldFormats.createWorld(info.get());
+          loadedWorld = newWorld;
           loadedWorld.loadDimension(this.worldDimension);
-        } else {
-          Log.info("Could not load world: " + worldPath);
-          loadedWorld = EmptyWorld.INSTANCE;
+          if (newWorld == EmptyWorld.INSTANCE) {
+            Log.info("Could not load world: " + worldPath);
+          }
         }
       }
 
@@ -807,7 +814,8 @@ public class Scene implements JsonSerializable {
       task.update(2, 1);
 
       loadedWorld = world;
-      worldPath = loadedWorld.getWorldDirectory().getAbsolutePath();
+      worldPath = loadedWorld.getInfo().path().toAbsolutePath().toString();
+      worldFormat = world.getInfo().worldFormat().getId();
       worldDimension = world.currentDimension().getDimensionId();
 
       if (chunksToLoadByRegion.isEmpty()) {
@@ -2674,6 +2682,7 @@ public class Scene implements JsonSerializable {
       // Save world info.
       JsonObject world = new JsonObject();
       world.add("path", worldPath);
+      world.add("worldType", loadedWorld.getInfo().worldFormat().getId());
       world.add("dimension", worldDimension.getNamespacedName());
       json.add("world", world);
     }
@@ -2996,7 +3005,7 @@ public class Scene implements JsonSerializable {
     if (json.get("world").isObject()) {
       JsonObject world = json.get("world").object();
       worldPath = world.get("path").stringValue(worldPath);
-
+      worldFormat = world.get("worldFormat").stringValue(JavaWorldFormat.ID);
       if (world.get("dimension") instanceof JsonString) {
         // dimension already is a string (or undefined)
         worldDimension = Dimension.Identifier.fromNamespacedName(world.get("dimension").stringValue("minecraft:overworld"));

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -19,22 +19,16 @@ package se.llbit.chunky.ui;
 
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
-import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.*;
-import javafx.scene.control.Button;
-import javafx.scene.control.Dialog;
 import javafx.scene.control.MenuItem;
-import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.ScrollEvent;
-import javafx.scene.layout.Border;
-import javafx.scene.layout.GridPane;
 import javafx.stage.PopupWindow;
 import se.llbit.chunky.map.MapBuffer;
 import se.llbit.chunky.map.MapView;
@@ -45,11 +39,10 @@ import se.llbit.chunky.renderer.scene.Camera;
 import se.llbit.chunky.renderer.scene.SceneManager;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.chunky.ui.dialogs.SelectChunksInRadiusDialog;
-import se.llbit.chunky.ui.elements.TextFieldLabelWrapper;
 import se.llbit.chunky.world.*;
 import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.listeners.ChunkUpdateListener;
-import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.region.Region;
 import se.llbit.log.Log;
 import se.llbit.math.*;
 
@@ -57,7 +50,6 @@ import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -227,8 +219,8 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     if (view.chunkScale >= 16) {
       int minChunkX = region.x << 5;
       int minChunkZ = region.z << 5;
-      for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
-        for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
+      for (int chunkX = minChunkX; chunkX < minChunkX + Region.CHUNKS_X; chunkX++) {
+        for (int chunkZ = minChunkZ; chunkZ < minChunkZ + Region.CHUNKS_Z; chunkZ++) {
           mapBuffer.drawTile(mapLoader, new ChunkPosition(chunkX, chunkZ), chunkSelection);
         }
       }

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -596,18 +596,16 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
     World world = mapLoader.getWorld();
     double blockScale = mapView.scale / 16.;
     for (PlayerEntityData player : world.currentDimension().getPlayerPositions()) {
-      if (player.dimension.equals(world.currentDimension().getDimensionId())) {
-        int px = (int) QuickMath.floor(player.x * blockScale);
-        int py = (int) QuickMath.floor(player.y);
-        int pz = (int) QuickMath.floor(player.z * blockScale);
-        int ppx = px - (int) QuickMath.floor(mapView.x0 * mapView.scale);
-        int ppy = pz - (int) QuickMath.floor(mapView.z0 * mapView.scale);
-        int pw = (int) QuickMath.max(16, QuickMath.min(32, blockScale * 4));
-        ppx = Math.min(mapView.width - pw, Math.max(0, ppx - pw / 2));
-        ppy = Math.min(mapView.height - pw, Math.max(0, ppy - pw / 2));
+      int px = (int) QuickMath.floor(player.x * blockScale);
+      int py = (int) QuickMath.floor(player.y);
+      int pz = (int) QuickMath.floor(player.z * blockScale);
+      int ppx = px - (int) QuickMath.floor(mapView.x0 * mapView.scale);
+      int ppy = pz - (int) QuickMath.floor(mapView.z0 * mapView.scale);
+      int pw = (int) QuickMath.max(16, QuickMath.min(32, blockScale * 4));
+      ppx = Math.min(mapView.width - pw, Math.max(0, ppx - pw / 2));
+      ppy = Math.min(mapView.height - pw, Math.max(0, ppy - pw / 2));
 
-        gc.drawImage(Icon.player.fxImage(), ppx, ppy, pw, pw);
-      }
+      gc.drawImage(Icon.player.fxImage(), ppx, ppy, pw, pw);
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -341,7 +341,7 @@ public class ChunkyFxController
               "This scene shows a different world than the one that is currently loaded. Do you want to load the world of this scene?");
             Dialogs.stayOnTop(loadWorldConfirm);
             if (loadWorldConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
-              mapLoader.loadWorld(newWorld.getWorldDirectory());
+              mapLoader.loadWorld(newWorld);
               getChunkSelection().setSelection(chunky.getSceneManager().getScene().getChunks());
             }
           }
@@ -652,7 +652,7 @@ public class ChunkyFxController
     mapOverlay.setOnKeyPressed(map::onKeyPressed);
     mapOverlay.setOnKeyReleased(map::onKeyReleased);
 
-    mapLoader.loadWorld(PersistentSettings.getLastWorld());
+    mapLoader.loadWorldFromDirectory(PersistentSettings.getLastWorld());
     IntIntPair heightRange = mapLoader.getWorld().currentDimension().heightRange();
     mapView.setYMin(heightRange.firstInt());
     mapView.setYMax(heightRange.secondInt());

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -23,16 +23,10 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.IdentityHashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.ResourceBundle;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import it.unimi.dsi.fastutil.ints.IntIntPair;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
@@ -287,7 +281,7 @@ public class ChunkyFxController
     fileChooser.setTitle("Export PNG");
     fileChooser
         .getExtensionFilters().add(new FileChooser.ExtensionFilter("PNG image", "*.png"));
-    mapLoader.withWorld(world -> fileChooser.setInitialFileName(world.levelName() + ".png"));
+    mapLoader.withWorld(world -> fileChooser.setInitialFileName(world.getInfo().name() + ".png"));
     if (prevPngDir != null) {
       fileChooser.setInitialDirectory(prevPngDir.toFile());
     }
@@ -327,7 +321,7 @@ public class ChunkyFxController
         World newWorld = scene.getWorld();
         World currentWorld = mapLoader.getWorld();
         boolean isSameWorld = currentWorld != EmptyWorld.INSTANCE &&
-          currentWorld.getWorldDirectory().equals(newWorld.getWorldDirectory());
+          currentWorld.getInfo().isSameWorld(newWorld.getInfo());
 
         if (isSameWorld) {
           getChunkSelection().setSelection(chunky.getSceneManager().getScene().getChunks());
@@ -341,7 +335,7 @@ public class ChunkyFxController
               "This scene shows a different world than the one that is currently loaded. Do you want to load the world of this scene?");
             Dialogs.stayOnTop(loadWorldConfirm);
             if (loadWorldConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
-              mapLoader.loadWorld(newWorld);
+              mapLoader.setWorld(newWorld);
               getChunkSelection().setSelection(chunky.getSceneManager().getScene().getChunks());
             }
           }
@@ -473,7 +467,7 @@ public class ChunkyFxController
                   ignoreYUpdate.set(false);
                 }
                 map.redrawMap();
-                mapName.setText(world.levelName());
+                mapName.setText(world.getInfo().name());
                 showWorldMap();
               });
         });
@@ -652,7 +646,7 @@ public class ChunkyFxController
     mapOverlay.setOnKeyPressed(map::onKeyPressed);
     mapOverlay.setOnKeyReleased(map::onKeyReleased);
 
-    mapLoader.loadWorldFromDirectory(PersistentSettings.getLastWorld());
+    mapLoader.loadWorldFromDirectory(PersistentSettings.getLastWorld(), PersistentSettings.getLastWorldFormat());
     HeightRange heightRange = mapLoader.getWorld().currentDimension().heightRange();
     mapView.setYMin(heightRange.min());
     mapView.setYMax(heightRange.max());

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -32,6 +32,7 @@ import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
@@ -459,19 +460,14 @@ public class ChunkyFxController
                 }
                 if (!reloaded) {
                   ignoreYUpdate.set(true);
-                  if (mapLoader.getWorld().getVersionId() >= World.VERSION_21W06A) {
-                    yMin.setRange(-64, 320);
-                    yMin.set(-64);
-                    yMax.setRange(-64, 320);
-                    yMax.set(320);
-                    mapView.setYMinMax(-64, 320);
-                  } else {
-                    yMin.setRange(0, 256);
-                    yMin.set(0);
-                    yMax.setRange(0, 256);
-                    yMax.set(256);
-                    mapView.setYMinMax(0, 256);
-                  }
+                  IntIntPair heightRange = mapLoader.getWorld().currentDimension().heightRange();
+                  int min = heightRange.firstInt();
+                  int max = heightRange.secondInt();
+                  yMin.setRange(min, max);
+                  yMin.set(min);
+                  yMax.setRange(min, max);
+                  yMax.set(max);
+                  mapView.setYMinMax(min, max);
                   yMin.getStyleClass().removeAll("invalid");
                   yMax.getStyleClass().removeAll("invalid");
                   ignoreYUpdate.set(false);
@@ -657,13 +653,9 @@ public class ChunkyFxController
     mapOverlay.setOnKeyReleased(map::onKeyReleased);
 
     mapLoader.loadWorld(PersistentSettings.getLastWorld());
-    if (mapLoader.getWorld().getVersionId() >= World.VERSION_21W06A) {
-      mapView.setYMin(-64);
-      mapView.setYMax(320);
-    } else {
-      mapView.setYMin(0);
-      mapView.setYMax(256);
-    }
+    IntIntPair heightRange = mapLoader.getWorld().currentDimension().heightRange();
+    mapView.setYMin(heightRange.firstInt());
+    mapView.setYMax(heightRange.secondInt());
 
     canvas = new RenderCanvasFx(this, chunky.getSceneManager().getScene(),
         chunky.getRenderController().getRenderManager());

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ChunkyFxController.java
@@ -460,9 +460,9 @@ public class ChunkyFxController
                 }
                 if (!reloaded) {
                   ignoreYUpdate.set(true);
-                  IntIntPair heightRange = mapLoader.getWorld().currentDimension().heightRange();
-                  int min = heightRange.firstInt();
-                  int max = heightRange.secondInt();
+                  HeightRange heightRange = mapLoader.getWorld().currentDimension().heightRange();
+                  int min = heightRange.min();
+                  int max = heightRange.max();
                   yMin.setRange(min, max);
                   yMin.set(min);
                   yMax.setRange(min, max);
@@ -653,9 +653,9 @@ public class ChunkyFxController
     mapOverlay.setOnKeyReleased(map::onKeyReleased);
 
     mapLoader.loadWorldFromDirectory(PersistentSettings.getLastWorld());
-    IntIntPair heightRange = mapLoader.getWorld().currentDimension().heightRange();
-    mapView.setYMin(heightRange.firstInt());
-    mapView.setYMax(heightRange.secondInt());
+    HeightRange heightRange = mapLoader.getWorld().currentDimension().heightRange();
+    mapView.setYMin(heightRange.min());
+    mapView.setYMax(heightRange.max());
 
     canvas = new RenderCanvasFx(this, chunky.getSceneManager().getScene(),
         chunky.getRenderController().getRenderManager());

--- a/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
@@ -31,16 +31,18 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.resources.MinecraftFinder;
 import se.llbit.chunky.resources.ResourcePackLoader;
-import se.llbit.chunky.resources.TexturePackLoader;
 import se.llbit.chunky.ui.TableSortConfigSerializer;
+import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.World;
+import se.llbit.chunky.world.worldformat.WorldFormat;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonArray;
 import se.llbit.log.Log;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.text.DateFormat;
 import java.util.*;
@@ -188,7 +190,7 @@ public class WorldChooserController implements Initializable {
     statusLabel.setText("Loading worlds list...");
     disableControls(true);
 
-    Task<List<World>> loadWorldsTask = new Task<List<World>>() {
+    Task<List<World>> loadWorldsTask = new Task<>() {
       @Override
       protected List<World> call() {
         List<World> worlds = new ArrayList<>();
@@ -196,10 +198,16 @@ public class WorldChooserController implements Initializable {
           File[] worldDirs = worldSavesDir.listFiles();
           if (worldDirs != null) {
             for (File dir : worldDirs) {
-              if (World.isWorldDir(dir)) {
-                World world = World.loadWorld(dir, Dimension.Identifier.OVERWORLD, World.LoggedWarnings.SILENT);
-                if (world != EmptyWorld.INSTANCE) {
-                  worlds.add(world);
+              for (WorldFormat worldFormat : WorldFormat.worldFormats) {
+                if (worldFormat.isValid(dir.toPath())) {
+                  try {
+                    World world = worldFormat.loadWorld(dir.toPath(), Dimension.Identifier.OVERWORLD);
+                    if (world != EmptyWorld.INSTANCE) {
+                      worlds.add(world);
+                    }
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
                 }
               }
             }

--- a/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
@@ -49,17 +49,17 @@ import java.util.*;
 public class WorldChooserController implements Initializable {
   @FXML private Label statusLabel;
 
-  @FXML private TableView<World> worldTbl;
+  @FXML private TableView<World.Info> worldTbl;
 
-  @FXML private TableColumn<World, String> worldNameCol;
+  @FXML private TableColumn<World.Info, String> worldNameCol;
 
-  @FXML private TableColumn<World, String> worldDirCol;
+  @FXML private TableColumn<World.Info, String> worldDirCol;
 
-  @FXML private TableColumn<World, String> gameModeCol;
+  @FXML private TableColumn<World.Info, String> gameModeCol;
 
-  @FXML private TableColumn<World, Number> seedCol;
+  @FXML private TableColumn<World.Info, Number> seedCol;
 
-  @FXML public TableColumn<World, Date> modifiedCol;
+  @FXML public TableColumn<World.Info, Date> modifiedCol;
 
   @FXML private Button changeWorldDirBtn;
 
@@ -70,15 +70,15 @@ public class WorldChooserController implements Initializable {
 
   @Override public void initialize(URL location, ResourceBundle resources) {
     worldNameCol
-        .setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().levelName()));
+        .setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().name()));
     worldDirCol.setCellValueFactory(
-        data -> new ReadOnlyStringWrapper(data.getValue().getWorldDirectory().getName()));
+        data -> new ReadOnlyStringWrapper(data.getValue().path().getFileName().toString()));
     gameModeCol.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().gameMode()));
-    seedCol.setCellValueFactory(data -> new ReadOnlyLongWrapper(data.getValue().getSeed()));
+    seedCol.setCellValueFactory(data -> new ReadOnlyLongWrapper(data.getValue().seed()));
 
     DateFormat localeFormat = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT);
-    modifiedCol.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(data.getValue().getLastModified()));
-    modifiedCol.setCellFactory(col -> new TableCell<World, Date>() {
+    modifiedCol.setCellValueFactory(data -> new ReadOnlyObjectWrapper<>(new Date(data.getValue().lastModified())));
+    modifiedCol.setCellFactory(col -> new TableCell<>() {
       public void updateItem(Date item, boolean empty) {
         if (item == this.getItem()) return;
         super.updateItem(item, empty);
@@ -97,7 +97,7 @@ public class WorldChooserController implements Initializable {
    */
   public void populate(WorldMapLoader mapLoader) {
     worldTbl.setRowFactory(tbl -> {
-      TableRow<World> row = new TableRow<>();
+      TableRow<World.Info> row = new TableRow<>();
       row.setOnMouseClicked(e -> {
         if (e.getClickCount() == 2 && !row.isEmpty()) {
           this.loadWorld(row.getItem(), mapLoader);
@@ -136,7 +136,12 @@ public class WorldChooserController implements Initializable {
       File directory = chooser.showDialog(stage);
       if (directory != null) {
         if (directory.isDirectory()) {
-          this.loadWorld(WorldFormats.createWorld(directory).orElse(EmptyWorld.INSTANCE), mapLoader);
+          Optional<World.Info> info = WorldFormats.getInfos(directory.toPath()).stream().findFirst(); // TODO: could ask which world format to load as
+          if (info.isPresent()) {
+            this.loadWorld(info.get(), mapLoader);
+          } else {
+            mapLoader.setWorld(EmptyWorld.INSTANCE);
+          }
           stage.close();
         } else {
           Log.warn("Non-directory selected.");
@@ -151,8 +156,9 @@ public class WorldChooserController implements Initializable {
     });
   }
 
-  private void loadWorld(World world, WorldMapLoader mapLoader) {
-    world.getResourcePack()
+  private void loadWorld(World.Info info, WorldMapLoader mapLoader) {
+    mapLoader.loadWorld(info)
+      .getResourcePack()
       .ifPresent(worldResourcePack -> {
         List<File> currentlyLoadedPacks = new ArrayList<>(ResourcePackLoader.getLoadedResourcePacks());
 
@@ -162,7 +168,7 @@ public class WorldChooserController implements Initializable {
           loadTexturesConfirm.getButtonTypes().addAll(ButtonType.YES, ButtonType.NO);
           loadTexturesConfirm.setTitle("Bundled resource pack");
           loadTexturesConfirm.setContentText(
-                  "The world \"" + world.levelName() + "\" contains a resource pack. Do you want to load it now?");
+            "The world \"" + info.name() + "\" contains a resource pack. Do you want to load it now?");
           Dialogs.stayOnTop(loadTexturesConfirm);
 
           if (loadTexturesConfirm.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.YES) {
@@ -172,7 +178,6 @@ public class WorldChooserController implements Initializable {
           }
         }
       });
-    mapLoader.loadWorld(world);
   }
 
   /**
@@ -189,15 +194,15 @@ public class WorldChooserController implements Initializable {
     statusLabel.setText("Loading worlds list...");
     disableControls(true);
 
-    Task<List<World>> loadWorldsTask = new Task<>() {
+    Task<List<World.Info>> loadWorldsTask = new Task<>() {
       @Override
-      protected List<World> call() {
-        List<World> worlds = new ArrayList<>();
+      protected List<World.Info> call() {
+        List<World.Info> worlds = new ArrayList<>();
         if (worldSavesDir != null) {
           File[] worldDirs = worldSavesDir.listFiles();
           if (worldDirs != null) {
             for (File dir : worldDirs) {
-              WorldFormats.createWorld(dir).ifPresent(worlds::add);
+              worlds.addAll(WorldFormats.getInfos(dir.toPath()));
             }
           }
         }
@@ -206,7 +211,7 @@ public class WorldChooserController implements Initializable {
     };
 
     loadWorldsTask.setOnSucceeded((WorkerStateEvent event) -> {
-      List<World> worlds = loadWorldsTask.getValue();
+      List<World.Info> worlds = loadWorldsTask.getValue();
 
       worldTbl.setItems(FXCollections.observableArrayList(worlds));
       if (!worlds.isEmpty()) {

--- a/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
@@ -36,7 +36,7 @@ import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.World;
-import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.chunky.world.worldformat.WorldFormats;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonArray;
 import se.llbit.log.Log;
@@ -136,7 +136,7 @@ public class WorldChooserController implements Initializable {
       File directory = chooser.showDialog(stage);
       if (directory != null) {
         if (directory.isDirectory()) {
-          this.loadWorld(WorldFormat.loadWorld(directory).orElse(EmptyWorld.INSTANCE), mapLoader);
+          this.loadWorld(WorldFormats.createWorld(directory).orElse(EmptyWorld.INSTANCE), mapLoader);
           stage.close();
         } else {
           Log.warn("Non-directory selected.");
@@ -197,7 +197,7 @@ public class WorldChooserController implements Initializable {
           File[] worldDirs = worldSavesDir.listFiles();
           if (worldDirs != null) {
             for (File dir : worldDirs) {
-              WorldFormat.loadWorld(dir).ifPresent(worlds::add);
+              WorldFormats.createWorld(dir).ifPresent(worlds::add);
             }
           }
         }

--- a/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
@@ -42,7 +42,6 @@ import se.llbit.json.JsonArray;
 import se.llbit.log.Log;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.text.DateFormat;
 import java.util.*;
@@ -137,7 +136,7 @@ public class WorldChooserController implements Initializable {
       File directory = chooser.showDialog(stage);
       if (directory != null) {
         if (directory.isDirectory()) {
-          this.loadWorld(World.loadWorld(directory, mapLoader.getDimension(), World.LoggedWarnings.NORMAL), mapLoader);
+          this.loadWorld(WorldFormat.loadWorld(directory).orElse(EmptyWorld.INSTANCE), mapLoader);
           stage.close();
         } else {
           Log.warn("Non-directory selected.");
@@ -173,7 +172,7 @@ public class WorldChooserController implements Initializable {
           }
         }
       });
-    mapLoader.loadWorld(world.getWorldDirectory());
+    mapLoader.loadWorld(world);
   }
 
   /**
@@ -198,18 +197,7 @@ public class WorldChooserController implements Initializable {
           File[] worldDirs = worldSavesDir.listFiles();
           if (worldDirs != null) {
             for (File dir : worldDirs) {
-              for (WorldFormat worldFormat : WorldFormat.worldFormats) {
-                if (worldFormat.isValid(dir.toPath())) {
-                  try {
-                    World world = worldFormat.loadWorld(dir.toPath(), Dimension.Identifier.OVERWORLD);
-                    if (world != EmptyWorld.INSTANCE) {
-                      worlds.add(world);
-                    }
-                  } catch (IOException e) {
-                    throw new RuntimeException(e);
-                  }
-                }
-              }
+              WorldFormat.loadWorld(dir).ifPresent(worlds::add);
             }
           }
         }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -17,6 +17,7 @@
  */
 package se.llbit.chunky.ui.render.tabs;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import javafx.beans.binding.Bindings;
 import javafx.beans.value.ChangeListener;
 import javafx.fxml.FXML;
@@ -592,12 +593,14 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
   }
 
   private void updateYClipSlidersRanges(World world) {
-    if (world != null && world.getVersionId() >= World.VERSION_21W06A) {
-      yMin.setRange(-64, 320);
-      yMax.setRange(-64, 320);
-    } else {
-      yMin.setRange(0, 256);
-      yMax.setRange(0, 256);
+    if (world != null) {
+      IntIntPair heightRange = world.currentDimension().heightRange();
+      int min = heightRange.firstInt();
+      int max = heightRange.secondInt();
+      yMin.setRange(min, max);
+      yMin.set(min);
+      yMax.setRange(min, max);
+      yMax.set(max);
     }
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -48,6 +48,7 @@ import se.llbit.chunky.ui.dialogs.SettingsExport;
 import se.llbit.chunky.ui.elements.SizeInput;
 import se.llbit.chunky.ui.render.RenderControlsTab;
 import se.llbit.chunky.world.EmptyWorld;
+import se.llbit.chunky.world.HeightRange;
 import se.llbit.chunky.world.Icon;
 import se.llbit.chunky.world.World;
 import se.llbit.fxutil.Dialogs;
@@ -594,9 +595,9 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
 
   private void updateYClipSlidersRanges(World world) {
     if (world != null) {
-      IntIntPair heightRange = world.currentDimension().heightRange();
-      int min = heightRange.firstInt();
-      int max = heightRange.secondInt();
+      HeightRange heightRange = world.currentDimension().heightRange();
+      int min = heightRange.min();
+      int max = heightRange.max();
       yMin.setRange(min, max);
       yMin.set(min);
       yMax.setRange(min, max);

--- a/chunky/src/java/se/llbit/chunky/world/Chunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/Chunk.java
@@ -17,34 +17,16 @@
 package se.llbit.chunky.world;
 
 import se.llbit.chunky.block.minecraft.Air;
-import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
 import se.llbit.chunky.block.Block;
 import se.llbit.chunky.block.minecraft.Lava;
 import se.llbit.chunky.block.minecraft.Water;
-import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.ChunkLoadingException;
-import se.llbit.chunky.chunk.EmptyChunkData;
-import se.llbit.chunky.chunk.biome.BiomeDataFactory;
 import se.llbit.chunky.map.*;
-import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.BiomePalette;
-import se.llbit.chunky.world.region.MCRegion;
-import se.llbit.chunky.world.region.Region;
-import se.llbit.log.Log;
-import se.llbit.math.QuickMath;
-import se.llbit.nbt.*;
-import se.llbit.util.BitBuffer;
 import se.llbit.util.Mutable;
 import se.llbit.util.annotation.NotNull;
-
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import static se.llbit.util.NbtUtil.getTagFromNames;
-import static se.llbit.util.NbtUtil.tagFromMap;
 
 /**
  * This class represents a loaded or not-yet-loaded chunk in the world.
@@ -53,7 +35,7 @@ import static se.llbit.util.NbtUtil.tagFromMap;
  *
  * @author Jesper Öqvist (jesper@llbit.se)
  */
-public class Chunk {
+public abstract class Chunk {
 
   public static final String DATAVERSION = ".DataVersion";
   public static final String LEVEL_HEIGHTMAP = ".Level.HeightMap";
@@ -87,7 +69,7 @@ public class Chunk {
   protected volatile AbstractLayer surface = IconLayer.UNKNOWN;
   protected volatile AbstractLayer biomes = IconLayer.UNKNOWN;
 
-  private final Dimension dimension;
+  protected final Dimension dimension;
 
   protected int dataTimestamp = 0;
   protected int surfaceTimestamp = 0;
@@ -113,27 +95,6 @@ public class Chunk {
   }
 
   /**
-   * @param request fresh request set
-   * @return loaded data, or null if something went wrong
-   */
-  private Map<String, Tag> getChunkTags(Set<String> request) throws ChunkLoadingException {
-    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
-    Mutable<Integer> timestamp = new Mutable<>(dataTimestamp);
-    Map<String, Tag> chunkTags = region.getChunkTags(this.position, request, timestamp);
-    this.dataTimestamp = timestamp.get();
-    return chunkTags;
-  }
-
-  /**
-   * @param request fresh request set
-   * @return loaded data, or null if something went wrong
-   */
-  private Map<String, Tag> getEntityTags(Set<String> request) throws ChunkLoadingException {
-    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
-    return region.getEntityTags(this.position, request);
-  }
-
-  /**
    * Reset the rendered layers in this chunk.
    */
   public synchronized void reset() {
@@ -148,208 +109,11 @@ public class Chunk {
   }
 
   /**
-   * Parse the chunk from the region file and render the current
-   * layer, surface and cave maps.
+   * Parse the chunk from the region file and render the current layer, surface and cave maps.
+   *
    * @return whether the input chunkdata was modified
    */
-  public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax) {
-    if (!shouldReloadChunk()) {
-      return false;
-    }
-
-    Set<String> request = new HashSet<>();
-    request.add(Chunk.DATAVERSION);
-    request.add(Chunk.LEVEL_SECTIONS);
-    request.add(Chunk.SECTIONS_POST_21W39A);
-    request.add(Chunk.LEVEL_BIOMES);
-    request.add(Chunk.BIOMES_POST_21W39A);
-    request.add(Chunk.LEVEL_HEIGHTMAP);
-
-    Map<String, Tag> dataMap;
-    try {
-      dataMap = getChunkTags(request);
-    } catch (ChunkLoadingException e) { // we don't want to crash the map view if a chunk fails to load, so we warn the user
-      Log.warn(String.format("Failed to load chunk %s", position), e);
-      return false;
-    }
-    // TODO: improve error handling here.
-    if (dataMap == null) {
-      return false;
-    }
-    Tag data = tagFromMap(dataMap);
-
-    surfaceTimestamp = dataTimestamp;
-    version = chunkVersion(data);
-    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
-    chunkData.set(this.dimension.createChunkData(chunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
-    loadSurface(data, chunkData.get(), yMin, yMax);
-    biomesTimestamp = dataTimestamp;
-
-    dimension.chunkUpdated(position);
-    return true;
-  }
-
-  private void loadSurface(@NotNull Tag data, ChunkData chunkData, int yMin, int yMax) {
-    if (data == null) {
-      surface = IconLayer.CORRUPT;
-      return;
-    }
-
-    Heightmap heightmap = dimension.getHeightmap();
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
-    if (sections.isList()) {
-      if (version == ChunkVersion.PRE_FLATTENING || version == ChunkVersion.POST_FLATTENING) {
-        BiomePalette biomePalette = new ArrayBiomePalette();
-        BiomeDataFactory.loadBiomeData(chunkData, data, biomePalette, yMin, yMax);
-        biomes = new BiomeLayer(chunkData, biomePalette);
-
-        BlockPalette palette = new BlockPalette();
-        palette.unsynchronize(); //only this RegionParser will use this palette
-        loadBlockData(data, chunkData, palette, yMin, yMax);
-
-        int[] heightmapData = extractHeightmapData(data, chunkData);
-        updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
-
-        surface = new SurfaceLayer(dimension.getDimensionId(), chunkData, palette, biomePalette, yMin, yMax, heightmapData);
-        queueTopography();
-      }
-    } else {
-      surface = IconLayer.CORRUPT;
-    }
-  }
-
-  private int[] extractHeightmapData(@NotNull Tag data, ChunkData chunkData) {
-    Tag heightmapTag = data.get(LEVEL_HEIGHTMAP);
-    if (heightmapTag.isIntArray(X_MAX * Z_MAX)) {
-      return heightmapTag.intArray();
-    } else {
-      int[] fallback = new int[X_MAX * Z_MAX];
-      for (int i = 0; i < fallback.length; ++i) {
-        fallback[i] = chunkData.maxY();
-      }
-      return fallback;
-    }
-  }
-
-  /** Detect Minecraft version that generated the chunk. */
-  private static ChunkVersion chunkVersion(@NotNull Tag data) {
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
-    if (sections.isList()) {
-      for (SpecificTag section : sections.asList()) {
-        if (!section.get("Palette").isList()) {
-          if (section.get("Blocks").isByteArray(SECTION_BYTES)) {
-            return ChunkVersion.PRE_FLATTENING;
-          }
-        }
-      }
-      return ChunkVersion.POST_FLATTENING;
-    }
-    return ChunkVersion.UNKNOWN;
-  }
-
-  private static void loadBlockData(@NotNull Tag data, @NotNull ChunkData chunkData,
-      BlockPalette blockPalette, int minY, int maxY) {
-
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
-    if (sections.isList()) {
-      for (SpecificTag section : sections.asList()) {
-        Tag yTag = section.get("Y");
-        int sectionY = yTag.byteValue();
-        int sectionMinBlockY = sectionY << 4;
-
-        if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
-          continue; //skip parsing sections that are outside requested bounds
-
-        Tag blockPaletteTag = getTagFromNames(section, "Palette", "block_states\\palette");
-        if (blockPaletteTag.isList()) {
-          ListTag localBlockPalette = blockPaletteTag.asList();
-          // Bits per block:
-          int bpb = 4;
-          if (localBlockPalette.size() > 16) {
-            bpb = QuickMath.log2(QuickMath.nextPow2(localBlockPalette.size()));
-          }
-
-          int dataSize = (4096 * bpb) / 64;
-          Tag blockStates = getTagFromNames(section, "BlockStates", "block_states\\data");
-
-          if (blockStates.isLongArray(dataSize)) {
-            // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
-            // unused bits per block state; if so, the array is longer than the expected data size
-            boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20W17A;
-            if (isAligned) {
-              // entries are 64-bit-padded, re-calculate the bits per block
-              // this is the dataSize calculation from above reverted, we know the actual data size
-              bpb = blockStates.longArray().length / 64;
-            }
-
-            int[] subpalette = new int[localBlockPalette.size()];
-            int paletteIndex = 0;
-            for (Tag item : localBlockPalette.asList()) {
-              subpalette[paletteIndex] = blockPalette.put(item);
-              paletteIndex += 1;
-            }
-            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb, isAligned);
-            for (int y = 0; y < SECTION_Y_MAX; y++) {
-              int blockY = sectionMinBlockY + y;
-              for (int z = 0; z < Z_MAX; z++) {
-                for(int x = 0; x < X_MAX; x++) {
-                  int b0 = buffer.read();
-                  if (b0 < subpalette.length) {
-                    chunkData.setBlockAt(x, blockY, z, subpalette[b0]);
-                  }
-                }
-              }
-            }
-          } else {
-            // Single block palette
-            if (localBlockPalette.size() == 1) {
-              // Check it is not air block
-              int block = blockPalette.put(localBlockPalette.get(0));
-              if (block != blockPalette.airId) {
-                // Set the entire section
-                for (int y = 0; y < SECTION_Y_MAX; y++) {
-                  int blockY = sectionMinBlockY + y;
-                  for (int z = 0; z < Z_MAX; z++) {
-                    for(int x = 0; x < X_MAX; x++) {
-                      chunkData.setBlockAt(x, blockY, z, block);
-                    }
-                  }
-                }
-              }
-            }
-          }
-        } else {
-          int yOffset = sectionY & 0xFF;
-
-          Tag dataTag = section.get("Data");
-          byte[] blockDataBytes = new byte[(Chunk.X_MAX * Chunk.Y_MAX * Chunk.Z_MAX) / 2];
-          if (dataTag.isByteArray(SECTION_HALF_NIBBLES)) {
-            System.arraycopy(dataTag.byteArray(), 0, blockDataBytes, SECTION_HALF_NIBBLES * yOffset,
-                SECTION_HALF_NIBBLES);
-          }
-
-          Tag blocksTag = section.get("Blocks");
-          if (blocksTag.isByteArray(SECTION_BYTES)) {
-            byte[] blocksBytes = new byte[Chunk.X_MAX * Chunk.Y_MAX * Chunk.Z_MAX];
-            System.arraycopy(blocksTag.byteArray(), 0, blocksBytes, SECTION_BYTES * yOffset,
-                SECTION_BYTES);
-
-            int offset = SECTION_BYTES * yOffset;
-            for (int y = 0; y < SECTION_Y_MAX; y++) {
-              int blockY = sectionMinBlockY + y;
-              for (int z = 0; z < Z_MAX; z++) {
-                for (int x = 0; x < X_MAX; x++) {
-                  chunkData.setBlockAt(x, blockY, z, blockPalette.put(
-                      LegacyBlocks.getTag(offset, blocksBytes, blockDataBytes)));
-                  offset += 1;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  public abstract boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax);
 
   /**
    * Load heightmap information from a chunk heightmap array
@@ -368,17 +132,6 @@ public class Chunk {
         heightmap.set(y, pos.x * 16 + x, pos.z * 16 + z);
       }
     }
-  }
-
-  protected boolean shouldReloadChunk() {
-    int timestamp = Integer.MAX_VALUE;
-    timestamp = Math.min(timestamp, surfaceTimestamp);
-    timestamp = Math.min(timestamp, biomesTimestamp);
-    if (timestamp == 0) {
-      return true;
-    }
-    Region region = dimension.getRegion(position.getRegionPosition());
-    return region.chunkChangedSince(position, timestamp);
   }
 
   protected void queueTopography() {
@@ -445,97 +198,7 @@ public class Chunk {
    * @param maxY The requested maximum Y to be loaded into the chunkData object. The chunk implementation does NOT have to respect it
    * @throws ChunkLoadingException If there is an issue loading the chunk, and it should be aborted
    */
-  public synchronized void getChunkData(@NotNull Mutable<ChunkData> reuseChunkData, BlockPalette palette, BiomePalette biomePalette, int minY, int maxY) throws ChunkLoadingException {
-    Set<String> request = new HashSet<>();
-    request.add(DATAVERSION);
-    request.add(LEVEL_SECTIONS);
-    request.add(SECTIONS_POST_21W39A);
-    request.add(LEVEL_BIOMES);
-    request.add(BIOMES_POST_21W39A);
-    request.add(LEVEL_ENTITIES);
-    request.add(LEVEL_TILEENTITIES);
-    request.add(BLOCK_ENTITIES_POST_21W43A);
-    Map<String, Tag> dataMap = getChunkTags(request);
-    // TODO: improve error handling here.
-    if (dataMap == null) {
-      throw new ChunkLoadingException(String.format("Got null data for chunk %s", this.position));
-    }
-    Tag data = tagFromMap(dataMap);
-
-    int dataVersion = data.get(DATAVERSION).intValue();
-
-    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
-
-    if(reuseChunkData.get() == null || reuseChunkData.get() instanceof EmptyChunkData) {
-      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
-    } else {
-      reuseChunkData.get().clear();
-    }
-    ChunkData chunkData = reuseChunkData.get(); //unwrap mutable, for ease of use
-
-    version = chunkVersion(data);
-    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
-    Tag entitiesTag = data.get(LEVEL_ENTITIES);
-    Tag tileEntitiesTag = getTagFromNames(data, LEVEL_TILEENTITIES, BLOCK_ENTITIES_POST_21W43A);
-
-    BiomeDataFactory.loadBiomeData(chunkData, data, biomePalette, minY, maxY);
-    if (sections.isList()) {
-      loadBlockData(data, chunkData, palette, minY, maxY);
-
-      if (entitiesTag.isList()) {
-        for (SpecificTag tag : (ListTag) entitiesTag) {
-          if (tag.isCompoundTag())
-            chunkData.addEntity((CompoundTag) tag);
-        }
-      }
-
-      if (tileEntitiesTag.isList()) {
-        for (SpecificTag tag : (ListTag) tileEntitiesTag) {
-          if (tag.isCompoundTag())
-            chunkData.addTileEntity((CompoundTag) tag);
-        }
-      }
-    }
-
-    // post 20w45A entities
-    if (dataVersion >= DATAVERSION_20W45A) {
-      Set<String> entitiesRequest = new HashSet<>();
-      entitiesRequest.add(ENTITIES_POST_20W45A);
-
-      Map<String, Tag> entitiesMap = getEntityTags(entitiesRequest);
-      if (entitiesMap != null) {
-        entitiesTag = entitiesMap.get(".Entities");
-        if (entitiesTag.isList()) {
-          for (SpecificTag tag : (ListTag) entitiesTag) {
-            if (tag.isCompoundTag())
-              chunkData.addEntity((CompoundTag) tag);
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * @return The min and max blockY for a given section array
-   */
-  private IntIntImmutablePair inclusiveChunkBounds(Tag chunkData) {
-    Tag sections = getTagFromNames(chunkData, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
-    int minSectionY = Integer.MAX_VALUE;
-    int maxSectionY = Integer.MIN_VALUE;
-    if (sections.isList()) {
-      for (SpecificTag section : sections.asList()) {
-        byte sectionY = (byte) section.get("Y").byteValue();
-        if (sectionY < minSectionY) {
-          minSectionY = sectionY;
-        }
-        if (sectionY > maxSectionY) {
-          maxSectionY = sectionY;
-        }
-      }
-    }
-
-    return new IntIntImmutablePair(minSectionY << 4, (maxSectionY << 4) + 15);
-  }
+  public abstract void getChunkData(@NotNull Mutable<ChunkData> reuseChunkData, BlockPalette palette, BiomePalette biomePalette, int minY, int maxY) throws ChunkLoadingException;
 
   /**
    * @return Integer index into a chunk YXZ array

--- a/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkSelectionTracker.java
@@ -20,7 +20,7 @@ package se.llbit.chunky.world;
 import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
 import se.llbit.chunky.world.listeners.ChunkDeletionListener;
 import se.llbit.chunky.world.listeners.ChunkUpdateListener;
-import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.region.Region;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,7 +42,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    */
   private boolean setChunk(ChunkPosition pos, boolean selected) {
     long regionPosLong = ChunkPosition.positionToLong(pos.x >> 5, pos.z >> 5);
-    BitSet selectedChunksForRegion = selectedChunksByRegion.computeIfAbsent(regionPosLong, p -> new BitSet(MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z));
+    BitSet selectedChunksForRegion = selectedChunksByRegion.computeIfAbsent(regionPosLong, p -> new BitSet(Region.CHUNKS_X * Region.CHUNKS_Z));
     int bitIndex = (pos.x & 31) + ((pos.z & 31) << 5);
     boolean previousValue = selectedChunksForRegion.get(bitIndex);
     if(previousValue != selected) {
@@ -75,7 +75,7 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
    * @return Whether the selection changed
    */
   private boolean setChunksWithinRegion(Dimension dimension, RegionPosition regionPos, int minX, int maxX, int minZ, int maxZ, boolean selected) {
-    BitSet selectedChunksForRegion = selectedChunksByRegion.computeIfAbsent(regionPos.getLong(), p -> new BitSet(MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z));
+    BitSet selectedChunksForRegion = selectedChunksByRegion.computeIfAbsent(regionPos.getLong(), p -> new BitSet(Region.CHUNKS_X * Region.CHUNKS_Z));
 
     Collection<ChunkPosition> changedChunks = new ArrayList<>();
     boolean selectionChanged = false;
@@ -249,15 +249,15 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
     boolean selectionChanged = false;
 
     // If selection area must contain complete regions
-    if(maxChunkX - minChunkX >= MCRegion.CHUNKS_X*2 && maxChunkZ - minChunkZ >= MCRegion.CHUNKS_Z*2) {
+    if(maxChunkX - minChunkX >= Region.CHUNKS_X*2 && maxChunkZ - minChunkZ >= Region.CHUNKS_Z*2) {
       // All full regions are set first, then any chunks on the borders are set, top and bottom include corners, left and right don't
 
       // left, right, top, bottom are unrelated to the actual map view, and are just treating XZ as if they were XY on traditional cartesian coordinate axes
-      int leftBorder = MCRegion.CHUNKS_X - (minChunkX & (MCRegion.CHUNKS_X-1)); // want the border from minimum region corner to minimum chunk corner, so 32 - borderSize
-      int rightBorder = maxChunkX & (MCRegion.CHUNKS_X-1);
+      int leftBorder = Region.CHUNKS_X - (minChunkX & (Region.CHUNKS_X-1)); // want the border from minimum region corner to minimum chunk corner, so 32 - borderSize
+      int rightBorder = maxChunkX & (Region.CHUNKS_X-1);
 
-      int bottomBorder = MCRegion.CHUNKS_Z - (minChunkZ & (MCRegion.CHUNKS_Z-1));
-      int topBorder = maxChunkZ & (MCRegion.CHUNKS_Z-1);
+      int bottomBorder = Region.CHUNKS_Z - (minChunkZ & (Region.CHUNKS_Z-1));
+      int topBorder = maxChunkZ & (Region.CHUNKS_Z-1);
 
       int minInnerRegionX = (minChunkX + leftBorder) >> 5;
       int maxInnerRegionX = (maxChunkX - rightBorder) >> 5;
@@ -397,9 +397,9 @@ public class ChunkSelectionTracker implements ChunkDeletionListener {
     selectedChunksByRegion.forEach((regionPosition, selectedChunksBitSet) -> {
       RegionPosition regionPos = new RegionPosition(regionPosition);
       List<ChunkPosition> positions = new ArrayList<>();
-      for (int localX = 0; localX < MCRegion.CHUNKS_X; localX++) {
-        for (int localZ = 0; localZ < MCRegion.CHUNKS_Z; localZ++) {
-          int idx = localX + (localZ * MCRegion.CHUNKS_X);
+      for (int localX = 0; localX < Region.CHUNKS_X; localX++) {
+        for (int localZ = 0; localZ < Region.CHUNKS_Z; localZ++) {
+          int idx = localX + (localZ * Region.CHUNKS_X);
           if(selectedChunksBitSet.get(idx)) {
             positions.add(regionPos.asChunkPosition(localX, localZ));
           }

--- a/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
@@ -53,11 +53,11 @@ public class CubicDimension extends JavaDimension {
     return new ImposterCubicRegion(pos, this);
   }
 
-  public synchronized Region getRegionWithinRange(RegionPosition pos, int minY, int maxY) {
+  public synchronized Region getRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
     return regionMap.computeIfAbsent(pos.getLong(), p -> {
       // check if the region is present in the world directory
       Region region = EmptyRegion.instance;
-      if (regionExistsWithinRange(pos, minY, maxY)) {
+      if (this.hasRegionWithinRange(pos, heightRange)) {
         region = createRegion(pos);
       }
       return region;
@@ -66,7 +66,7 @@ public class CubicDimension extends JavaDimension {
 
   /** no choice but to iterate over every file in the directory */
   @Override
-  public boolean regionExists(RegionPosition pos) {
+  public boolean hasRegion(RegionPosition pos) {
     File regionDirectory = getRegionDirectory();
     try (Stream<Path> list = Files.list(regionDirectory.toPath())) {
       return list.anyMatch(path -> {
@@ -86,13 +86,13 @@ public class CubicDimension extends JavaDimension {
   }
 
   @Override
-  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
+  public boolean hasRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
     int cubicRegionX = pos.x << 1;
     int cubicRegionZ = pos.z << 1;
 
     File regionDirectory = getRegionDirectory();
-    int minRegionY = cubeToCubicRegion(blockToCube(minY));
-    int maxRegionY = cubeToCubicRegion(blockToCube(maxY - 1));
+    int minRegionY = cubeToCubicRegion(blockToCube(heightRange().min()));
+    int maxRegionY = cubeToCubicRegion(blockToCube(heightRange.max() - 1));
     for (int y = minRegionY; y <= maxRegionY; y++) {
       for (int localX = 0; localX < ImposterCubicRegion.DIAMETER_IN_CUBIC_REGIONS; localX++) {
         for (int localZ = 0; localZ < ImposterCubicRegion.DIAMETER_IN_CUBIC_REGIONS; localZ++) {

--- a/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
@@ -8,6 +8,8 @@ import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.EmptyRegion;
 import se.llbit.chunky.world.region.ImposterCubicRegion;
 import se.llbit.chunky.world.region.Region;
+import se.llbit.math.Vector3i;
+import se.llbit.util.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,8 +26,8 @@ public class CubicDimension extends JavaDimension {
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  public CubicDimension(JavaWorld world, Dimension.Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
-    super(world, dimensionId, dimensionDirectory, playerEntities);
+  public CubicDimension(JavaWorld world, Dimension.Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+    super(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
@@ -26,7 +26,7 @@ public class CubicDimension extends JavaDimension {
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  public CubicDimension(JavaWorld world, Dimension.Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+  public CubicDimension(JavaWorld world, Dimension.Identifier dimensionId, Path dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
     super(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
   }
 
@@ -35,7 +35,7 @@ public class CubicDimension extends JavaDimension {
    */
   @Override
   public synchronized File getRegionDirectory() {
-    return new File(dimensionDirectory, "region3d");
+    return dimensionDirectory.resolve("region3d").toFile();
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/CubicDimension.java
@@ -3,6 +3,8 @@ package se.llbit.chunky.world;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.GenericChunkData;
 import se.llbit.chunky.chunk.biome.BiomeData2d;
+import se.llbit.chunky.world.java.JavaDimension;
+import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.region.EmptyRegion;
 import se.llbit.chunky.world.region.ImposterCubicRegion;
 import se.llbit.chunky.world.region.Region;
@@ -17,12 +19,12 @@ import java.util.stream.Stream;
 import static se.llbit.chunky.world.region.ImposterCubicRegion.blockToCube;
 import static se.llbit.chunky.world.region.ImposterCubicRegion.cubeToCubicRegion;
 
-public class CubicDimension extends Dimension {
+public class CubicDimension extends JavaDimension {
 
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  protected CubicDimension(World world, Dimension.Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
+  public CubicDimension(JavaWorld world, Dimension.Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
     super(world, dimensionId, dimensionDirectory, playerEntities);
   }
 
@@ -64,8 +66,7 @@ public class CubicDimension extends Dimension {
   @Override
   public boolean regionExists(RegionPosition pos) {
     File regionDirectory = getRegionDirectory();
-    try {
-      Stream<Path> list = Files.list(regionDirectory.toPath());
+    try (Stream<Path> list = Files.list(regionDirectory.toPath())) {
       return list.anyMatch(path -> {
         String[] split = path.getFileName().toString().split("[.]");
         if(split.length == 4) {

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -1,8 +1,5 @@
 package se.llbit.chunky.world;
 
-import it.unimi.dsi.fastutil.ints.IntIntPair;
-import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.chunk.ChunkData;
 import se.llbit.chunky.chunk.GenericChunkData;
@@ -138,21 +135,20 @@ public abstract class Dimension {
    */
   public abstract Region getRegion(RegionPosition pos);
 
-  public abstract Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax);
+  public abstract Region getRegionWithinRange(RegionPosition pos, HeightRange heightRange);
 
   /**
    * @param pos region position
    * @return {@code true} if a region file exists for the given position
    */
-  public abstract boolean regionExists(RegionPosition pos);
+  public abstract boolean hasRegion(RegionPosition pos);
 
   /**
    * @param pos  Position of the region to load
-   * @param minY Minimum block Y (inclusive)
-   * @param maxY Maximum block Y (exclusive)
+   * @param heightRange The height range of the request
    * @return Whether the region exists
    */
-  public abstract boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY);
+  public abstract boolean hasRegionWithinRange(RegionPosition pos, HeightRange heightRange);
 
   /**
    * WARNING: In some dimensions this could be from {@link Integer#MIN_VALUE} to {@link Integer#MAX_VALUE}
@@ -161,7 +157,7 @@ public abstract class Dimension {
    *
    * @return The height range of the dimension.
    */
-  public abstract IntIntPair heightRange();
+  public abstract HeightRange heightRange();
 
   /**
    * @return The chunk heightmap

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -1,5 +1,6 @@
 package se.llbit.chunky.world;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import se.llbit.chunky.PersistentSettings;
@@ -23,7 +24,7 @@ import java.util.*;
 /**
  *
  */
-public class Dimension {
+public abstract class Dimension {
   public record Identifier(String namespace, String name) {
     public static Identifier OVERWORLD = new Identifier("minecraft", "overworld");
     public static Identifier THE_NETHER = new Identifier("minecraft", "the_nether");
@@ -63,28 +64,23 @@ public class Dimension {
     }
   }
 
-  private final World world;
-
-  protected final Long2ObjectMap<Region> regionMap = new Long2ObjectOpenHashMap<>();
-
   protected final File dimensionDirectory;
-  private Set<PlayerEntityData> playerEntities;
+  protected final Set<PlayerEntityData> playerEntities;
 
-  private final Heightmap heightmap = new Heightmap();
+  protected final Heightmap heightmap = new Heightmap();
 
-  private final Identifier dimensionId;
+  protected final Identifier dimensionId;
 
-  private final Collection<ChunkDeletionListener> chunkDeletionListeners = new LinkedList<>();
-  private final Collection<ChunkTopographyListener> chunkTopographyListeners = new LinkedList<>();
-  private final Collection<ChunkUpdateListener> chunkUpdateListeners = new LinkedList<>();
+  protected final Collection<ChunkDeletionListener> chunkDeletionListeners = new LinkedList<>();
+  protected final Collection<ChunkTopographyListener> chunkTopographyListeners = new LinkedList<>();
+  protected final Collection<ChunkUpdateListener> chunkUpdateListeners = new LinkedList<>();
 
-  private Vector3i spawnPos = null;
+  protected Vector3i spawnPos = null;
 
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  protected Dimension(World world, Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
-    this.world = world;
+  protected Dimension(Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
     this.dimensionId = dimensionId;
     this.dimensionDirectory = dimensionDirectory;
     this.playerEntities = playerEntities;
@@ -95,45 +91,9 @@ public class Dimension {
   }
 
   /**
-   * Reload player data.
-   *
-   * @return {@code true} if player data was reloaded.
-   */
-  public synchronized boolean reloadPlayerData() {
-    return this.world.reloadPlayerData();
-  }
-
-  /**
-   * Add a chunk deletion listener.
-   */
-  public void addChunkDeletionListener(ChunkDeletionListener listener) {
-    synchronized (chunkDeletionListeners) {
-      chunkDeletionListeners.add(listener);
-    }
-  }
-
-  /**
-   * Add a region discovery listener.
-   */
-  public void addChunkUpdateListener(ChunkUpdateListener listener) {
-    synchronized (chunkUpdateListeners) {
-      chunkUpdateListeners.add(listener);
-    }
-  }
-
-  private void fireChunkDeleted(ChunkPosition chunk) {
-    synchronized (chunkDeletionListeners) {
-      for (ChunkDeletionListener listener : chunkDeletionListeners)
-        listener.chunkDeleted(chunk);
-    }
-  }
-
-  /**
    * @return The chunk at the given position
    */
-  public synchronized Chunk getChunk(ChunkPosition pos) {
-    return getRegion(pos.getRegionPosition()).getChunk(pos);
-  }
+  public abstract Chunk getChunk(ChunkPosition pos);
 
   /**
    * Returns a ChunkData instance that is compatible with the given chunk version.
@@ -153,48 +113,23 @@ public class Dimension {
     return new GenericChunkData();
   }
 
-  public Region createRegion(RegionPosition pos) {
-    return new MCRegion(pos, this);
-  }
+  public abstract Region createRegion(RegionPosition pos);
 
-  public RegionChangeWatcher createRegionChangeWatcher(WorldMapLoader worldMapLoader, MapView mapView) {
-    return new MCRegionChangeWatcher(worldMapLoader, mapView);
-  }
+  public abstract RegionChangeWatcher createRegionChangeWatcher(WorldMapLoader worldMapLoader, MapView mapView);
 
   /**
    * @param pos Region position
    * @return The region at the given position
    */
-  public synchronized Region getRegion(RegionPosition pos) {
-    return regionMap.computeIfAbsent(pos.getLong(), p -> {
-      // check if the region is present in the world directory
-      Region region = EmptyRegion.instance;
-      if (regionExists(pos)) {
-        region = createRegion(pos);
-      }
-      return region;
-    });
-  }
+  public abstract Region getRegion(RegionPosition pos);
 
-  public Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax) {
-    return getRegion(pos);
-  }
-
-  /**
-   * Set the region for the given position.
-   */
-  public synchronized void setRegion(RegionPosition pos, Region region) {
-    regionMap.put(pos.getLong(), region);
-  }
+  public abstract Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax);
 
   /**
    * @param pos region position
    * @return {@code true} if a region file exists for the given position
    */
-  public boolean regionExists(RegionPosition pos) {
-    File regionFile = new File(getRegionDirectory(), pos.getMcaName());
-    return regionFile.exists();
-  }
+  public abstract boolean regionExists(RegionPosition pos);
 
   /**
    * @param pos  Position of the region to load
@@ -202,42 +137,16 @@ public class Dimension {
    * @param maxY Maximum block Y (exclusive)
    * @return Whether the region exists
    */
-  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
-    return this.regionExists(pos);
-  }
+  public abstract boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY);
 
   /**
-   * Get the data directory for the given dimension.
+   * WARNING: In some dimensions this could be from {@link Integer#MIN_VALUE} to {@link Integer#MAX_VALUE}
+   * <p>
+   * Lower bound is inclusive, upper is exclusive
    *
-   * @return File object pointing to the data directory
+   * @return The height range of the dimension.
    */
-  protected synchronized File getDimensionDirectory() {
-    return dimensionDirectory;
-  }
-
-  /**
-   * @return File object pointing to the region file directory
-   */
-  public synchronized File getRegionDirectory() {
-    return new File(getDimensionDirectory(), "region");
-  }
-
-  /**
-   * Get the current player position as an optional vector.
-   *
-   * <p>The result is empty if this is not a single player world.
-   */
-  public synchronized Optional<Vector3> getPlayerPos() {
-    if (!playerEntities.isEmpty()) {
-      return world.getSingleplayerPlayerUuid()
-        .flatMap(uuid -> playerEntities.stream()
-          .filter(player -> player.uuid.equals(uuid))
-          .map(pos -> new Vector3(pos.x, pos.y, pos.z))
-          .findFirst());
-    } else {
-      return Optional.empty();
-    }
-  }
+  public abstract IntIntPair heightRange();
 
   /**
    * @return The chunk heightmap
@@ -246,19 +155,91 @@ public class Dimension {
     return heightmap;
   }
 
+  @Override
+  public String toString() {
+    return dimensionDirectory.getName();
+  }
+
+  public Optional<Vector3i> getSpawnPosition() {
+    return Optional.ofNullable(this.spawnPos);
+  }
+
+  public Date getLastModified() {
+    return new Date(this.dimensionDirectory.lastModified());
+  }
+
   /**
-   * Called when a new region has been discovered by the region parser.
+   * Reload player data.
+   *
+   * @return {@code true} if player data was reloaded.
    */
-  public void regionDiscovered(RegionPosition pos) {
-    synchronized (this) {
-      regionMap.computeIfAbsent(pos.getLong(), p -> createRegion(pos));
+  public abstract boolean reloadPlayerData();
+
+  /**
+   * Get the current player position as an optional vector.
+   *
+   * <p>The result is empty if this is not a single player world.
+   */
+  public abstract Optional<Vector3> getPlayerPos();
+
+  /**
+   * Load entities from world the file.
+   * This is usually the single player entity in a local save.
+   */
+  public synchronized Collection<PlayerEntity> getPlayerEntities() {
+    Collection<PlayerEntity> list = new LinkedList<>();
+    if (PersistentSettings.getLoadPlayers()) {
+      for (PlayerEntityData data : playerEntities) {
+        list.add(new PlayerEntity(data));
+      }
+    }
+    return list;
+  }
+
+  public synchronized void setPlayerEntities(Set<PlayerEntityData> playerEntities) {
+    this.playerEntities.clear();
+    this.playerEntities.addAll(playerEntities);
+  }
+
+  public synchronized Collection<PlayerEntityData> getPlayerPositions() {
+    return Collections.unmodifiableSet(playerEntities);
+  }
+
+  /**
+   * Add a chunk deletion listener.
+   */
+  public void addChunkDeletionListener(ChunkDeletionListener listener) {
+    synchronized (chunkDeletionListeners) {
+      chunkDeletionListeners.add(listener);
     }
   }
 
   /**
-   * Notify region update listeners.
+   * Called when chunks have been deleted from this world.
+   * Triggers the chunk deletion listeners.
+   *
+   * @param pos Position of deleted chunk
    */
-  private void fireChunkUpdated(ChunkPosition chunk) {
+  public void chunkDeleted(ChunkPosition pos) {
+    synchronized (chunkDeletionListeners) {
+      for (ChunkDeletionListener listener : chunkDeletionListeners)
+        listener.chunkDeleted(pos);
+    }
+  }
+
+  /**
+   * Add a region discovery listener.
+   */
+  public void addChunkUpdateListener(ChunkUpdateListener listener) {
+    synchronized (chunkUpdateListeners) {
+      chunkUpdateListeners.add(listener);
+    }
+  }
+
+  /**
+   * Called when a chunk has been updated.
+   */
+  public void chunkUpdated(ChunkPosition chunk) {
     synchronized (chunkUpdateListeners) {
       for (ChunkUpdateListener listener : chunkUpdateListeners) {
         listener.chunkUpdated(chunk);
@@ -267,33 +248,14 @@ public class Dimension {
   }
 
   /**
-   * Notify region update listeners.
+   * Called when a chunk has been updated.
    */
-  private void fireRegionUpdated(RegionPosition region) {
+  public void regionUpdated(RegionPosition region) {
     synchronized (chunkUpdateListeners) {
       for (ChunkUpdateListener listener : chunkUpdateListeners) {
         listener.regionUpdated(region);
       }
     }
-  }
-
-  @Override
-  public String toString() {
-    return dimensionDirectory.getName();
-  }
-
-  /**
-   * Called when a chunk has been updated.
-   */
-  public void chunkUpdated(ChunkPosition chunk) {
-    fireChunkUpdated(chunk);
-  }
-
-  /**
-   * Called when a chunk has been updated.
-   */
-  public void regionUpdated(RegionPosition region) {
-    fireRegionUpdated(region);
   }
 
   /**
@@ -323,49 +285,5 @@ public class Dimension {
     for (ChunkTopographyListener listener : chunkTopographyListeners) {
       listener.chunksTopographyUpdated(chunk);
     }
-  }
-
-  public Optional<Vector3i> getSpawnPosition() {
-    return Optional.ofNullable(this.spawnPos);
-  }
-
-  public void setSpawnPos(@Nullable Vector3i spawnPos) {
-    this.spawnPos = spawnPos;
-  }
-
-  /**
-   * Called when chunks have been deleted from this world.
-   * Triggers the chunk deletion listeners.
-   *
-   * @param pos Position of deleted chunk
-   */
-  public void chunkDeleted(ChunkPosition pos) {
-    fireChunkDeleted(pos);
-  }
-
-  public Date getLastModified() {
-    return new Date(this.dimensionDirectory.lastModified());
-  }
-
-  /**
-   * Load entities from world the file.
-   * This is usually the single player entity in a local save.
-   */
-  public synchronized Collection<PlayerEntity> getPlayerEntities() {
-    Collection<PlayerEntity> list = new LinkedList<>();
-    if (PersistentSettings.getLoadPlayers()) {
-      for (PlayerEntityData data : playerEntities) {
-        list.add(new PlayerEntity(data));
-      }
-    }
-    return list;
-  }
-
-  public synchronized Collection<PlayerEntityData> getPlayerPositions() {
-    return Collections.unmodifiableSet(playerEntities);
-  }
-
-  public synchronized void setPlayerEntities(Set<PlayerEntityData> playerEntities) {
-    this.playerEntities = playerEntities;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -15,7 +15,7 @@ import se.llbit.math.Vector3;
 import se.llbit.math.Vector3i;
 import se.llbit.util.annotation.Nullable;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -61,7 +61,7 @@ public abstract class Dimension {
     }
   }
 
-  protected final File dimensionDirectory;
+  protected final Path dimensionDirectory;
 
   protected final Heightmap heightmap = new Heightmap();
 
@@ -77,7 +77,7 @@ public abstract class Dimension {
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  protected Dimension(Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+  protected Dimension(Identifier dimensionId, Path dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
     this.dimensionId = dimensionId;
     this.playerEntities = playerEntities;
     this.dimensionDirectory = dimensionDirectory;
@@ -95,10 +95,11 @@ public abstract class Dimension {
 
   /**
    * Get the data directory for the given dimension.
+   * <p>This may be the same as the world directory for some dimensions</p>
    *
-   * @return File object pointing to the data directory
+   * @return The path to the dimension
    */
-  protected synchronized File getDimensionDirectory() {
+  protected synchronized Path getDimensionPath() {
     return dimensionDirectory;
   }
 
@@ -168,10 +169,6 @@ public abstract class Dimension {
 
   public Optional<Vector3i> getSpawnPosition() {
     return Optional.ofNullable(this.spawnPos);
-  }
-
-  public Date getLastModified() {
-    return new Date(this.dimensionDirectory.lastModified());
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -65,29 +65,39 @@ public abstract class Dimension {
   }
 
   protected final File dimensionDirectory;
-  protected final Set<PlayerEntityData> playerEntities;
 
   protected final Heightmap heightmap = new Heightmap();
 
   protected final Identifier dimensionId;
 
+  @Nullable protected final Vector3i spawnPos;
+  protected final Set<PlayerEntityData> playerEntities;
+
   protected final Collection<ChunkDeletionListener> chunkDeletionListeners = new LinkedList<>();
   protected final Collection<ChunkTopographyListener> chunkTopographyListeners = new LinkedList<>();
   protected final Collection<ChunkUpdateListener> chunkUpdateListeners = new LinkedList<>();
 
-  protected Vector3i spawnPos = null;
-
   /**
    * @param dimensionDirectory Minecraft world directory.
    */
-  protected Dimension(Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
+  protected Dimension(Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
     this.dimensionId = dimensionId;
-    this.dimensionDirectory = dimensionDirectory;
     this.playerEntities = playerEntities;
+    this.dimensionDirectory = dimensionDirectory;
+    this.spawnPos = spawnPos;
   }
 
   public Identifier getDimensionId() {
     return dimensionId;
+  }
+
+  /**
+   * Get the data directory for the given dimension.
+   *
+   * @return File object pointing to the data directory
+   */
+  protected synchronized File getDimensionDirectory() {
+    return dimensionDirectory;
   }
 
   /**
@@ -194,11 +204,6 @@ public abstract class Dimension {
       }
     }
     return list;
-  }
-
-  public synchronized void setPlayerEntities(Set<PlayerEntityData> playerEntities) {
-    this.playerEntities.clear();
-    this.playerEntities.addAll(playerEntities);
   }
 
   public synchronized Collection<PlayerEntityData> getPlayerPositions() {

--- a/chunky/src/java/se/llbit/chunky/world/Dimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/Dimension.java
@@ -87,6 +87,11 @@ public abstract class Dimension {
     this.spawnPos = spawnPos;
   }
 
+  /**
+   * @return A user presentable name of the dimension
+   */
+  public abstract String getName();
+
   public Identifier getDimensionId() {
     return dimensionId;
   }
@@ -163,11 +168,6 @@ public abstract class Dimension {
    */
   public Heightmap getHeightmap() {
     return heightmap;
-  }
-
-  @Override
-  public String toString() {
-    return dimensionDirectory.getName();
   }
 
   public Optional<Vector3i> getSpawnPosition() {

--- a/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyChunk.java
@@ -24,6 +24,7 @@ import se.llbit.chunky.map.MapTile;
 import se.llbit.chunky.ui.ChunkMap;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.util.Mutable;
+import se.llbit.util.annotation.NotNull;
 
 /**
  * Empty or non-existent chunk in a region that <b>does</b> exist.
@@ -86,7 +87,7 @@ public class EmptyChunk extends Chunk {
     // Do nothing.
   }
 
-  @Override public synchronized boolean loadChunk(Mutable<ChunkData> chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
@@ -1,14 +1,77 @@
 package se.llbit.chunky.world;
 
+import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
+import se.llbit.chunky.map.MapView;
+import se.llbit.chunky.map.WorldMapLoader;
+import se.llbit.chunky.world.region.EmptyRegion;
+import se.llbit.chunky.world.region.Region;
+import se.llbit.chunky.world.region.RegionChangeWatcher;
+import se.llbit.math.Vector3;
+
 import java.util.Collections;
+import java.util.Optional;
 
 public class EmptyDimension extends Dimension {
   EmptyDimension() {
-    super(EmptyWorld.INSTANCE, Dimension.Identifier.OVERWORLD, null, Collections.emptySet());
+    super(Dimension.Identifier.OVERWORLD, null, Collections.emptySet());
+  }
+
+  @Override
+  public Chunk getChunk(ChunkPosition pos) {
+    return EmptyChunk.INSTANCE;
+  }
+
+  @Override
+  public Region createRegion(RegionPosition pos) {
+    return EmptyRegion.instance;
+  }
+
+  @Override
+  public RegionChangeWatcher createRegionChangeWatcher(WorldMapLoader worldMapLoader, MapView mapView) {
+    return new RegionChangeWatcher(worldMapLoader, mapView, "Empty Region Change Watcher") {
+      @Override
+      public void run() {}
+    };
+  }
+
+  @Override
+  public Region getRegion(RegionPosition pos) {
+    return EmptyRegion.instance;
+  }
+
+  @Override
+  public Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax) {
+    return EmptyRegion.instance;
+  }
+
+  @Override
+  public boolean regionExists(RegionPosition pos) {
+    return false;
+  }
+
+  @Override
+  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
+    return false;
+  }
+
+  @Override
+  public IntIntPair heightRange() {
+    return new IntIntImmutablePair(0, 0);
   }
 
   @Override
   public String toString() {
     return "[empty dimension]";
+  }
+
+  @Override
+  public boolean reloadPlayerData() {
+    return false;
+  }
+
+  @Override
+  public Optional<Vector3> getPlayerPos() {
+    return Optional.empty();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
@@ -60,8 +60,7 @@ public class EmptyDimension extends Dimension {
     return new IntIntImmutablePair(0, 0);
   }
 
-  @Override
-  public String toString() {
+  @Override public String getName() {
     return "[empty dimension]";
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
@@ -41,23 +41,23 @@ public class EmptyDimension extends Dimension {
   }
 
   @Override
-  public Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax) {
+  public Region getRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
     return EmptyRegion.instance;
   }
 
   @Override
-  public boolean regionExists(RegionPosition pos) {
+  public boolean hasRegion(RegionPosition pos) {
     return false;
   }
 
   @Override
-  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
+  public boolean hasRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
     return false;
   }
 
   @Override
-  public IntIntPair heightRange() {
-    return new IntIntImmutablePair(0, 0);
+  public HeightRange heightRange() {
+    return new HeightRange(0, 0);
   }
 
   @Override public String getName() {

--- a/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyDimension.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public class EmptyDimension extends Dimension {
   EmptyDimension() {
-    super(Dimension.Identifier.OVERWORLD, null, Collections.emptySet());
+    super(Dimension.Identifier.OVERWORLD, null, Collections.emptySet(), null);
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -23,6 +23,7 @@ import se.llbit.chunky.map.MapTile;
 import se.llbit.chunky.ui.ChunkMap;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.util.Mutable;
+import se.llbit.util.annotation.NotNull;
 
 /**
  * Empty or non-existent chunk in a region that <b>does not</b> exist.
@@ -48,7 +49,7 @@ public class EmptyRegionChunk extends Chunk {
     surface = IconLayer.CORRUPT;
   }
 
-  @Override public synchronized void getChunkData(Mutable<ChunkData> reuseChunkData, BlockPalette palette, BiomePalette biomePalette, int yMin, int yMax) { }
+  @Override public synchronized void getChunkData(@NotNull Mutable<ChunkData> reuseChunkData, BlockPalette palette, BiomePalette biomePalette, int yMin, int yMax) { }
 
   @Override public void renderSurface(MapTile tile) {
     renderEmpty(tile);
@@ -80,7 +81,7 @@ public class EmptyRegionChunk extends Chunk {
     // do nothing
   }
 
-  @Override public synchronized boolean loadChunk(Mutable<ChunkData> chunkData, int yMin, int yMax) {
+  @Override public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax) {
     return false;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyRegionChunk.java
@@ -27,7 +27,7 @@ import se.llbit.util.annotation.NotNull;
 
 /**
  * Empty or non-existent chunk in a region that <b>does not</b> exist.
- * In the {@link ChunkMap map view} an {@link EmptyChunk} is represented as gray.
+ * In the {@link ChunkMap map view} an {@link EmptyRegionChunk} is represented as gray.
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */

--- a/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
@@ -36,12 +36,12 @@ public class EmptyWorld extends World {
   }
 
   @Override
-  public Set<Dimension.Identifier> availableDimensions() {
+  public Set<Dimension.Identifier> getAvailableDimensions() {
     return Collections.emptySet();
   }
 
   @Override
-  public Optional<Dimension.Identifier> defaultDimension() {
+  public Optional<Dimension.Identifier> getDefaultDimension() {
     return Optional.empty();
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
@@ -16,6 +16,9 @@
  */
 package se.llbit.chunky.world;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Represents an empty or non-existent world.
  *
@@ -32,8 +35,13 @@ public class EmptyWorld extends World {
   }
 
   @Override
-  public void loadDimension(Dimension.Identifier dimensionId) {
-    // no-op
+  public Set<Dimension.Identifier> listDimensions() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Dimension loadDimension(Dimension.Identifier dimensionId) {
+    return this.currentDimension;
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
@@ -31,7 +31,7 @@ public class EmptyWorld extends World {
   public static final EmptyWorld INSTANCE = new EmptyWorld();
 
   private EmptyWorld() {
-    super("[empty world]", null, 0, -1);
+    super("[empty world]", null, 0);
     this.currentDimension = new EmptyDimension();
   }
 
@@ -47,6 +47,7 @@ public class EmptyWorld extends World {
 
   @Override
   public Dimension loadDimension(Dimension.Identifier dimensionId) {
+    // no-op
     return this.currentDimension;
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
@@ -16,6 +16,10 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.util.annotation.NotNull;
+
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
@@ -31,8 +35,42 @@ public class EmptyWorld extends World {
   public static final EmptyWorld INSTANCE = new EmptyWorld();
 
   private EmptyWorld() {
-    super("[empty world]", null, 0);
-    this.currentDimension = new EmptyDimension();
+    super(new World.Info("[empty world]", Path.of(""), 0, 0, "Survival",
+        new WorldFormat() {
+          @Override
+          public boolean isValid(@NotNull Path path) {
+            return false;
+          }
+
+          @NotNull
+          @Override
+          public Optional<Info> getWorldInfo(@NotNull Path path) {
+            return Optional.empty();
+          }
+
+          @NotNull
+          @Override
+          public World loadWorld(@NotNull Info info) {
+            return EmptyWorld.INSTANCE;
+          }
+
+          @Override
+          public String getName() {
+            return "Empty World Format";
+          }
+
+          @Override
+          public String getDescription() {
+            return "";
+          }
+
+          @Override
+          public String getId() {
+            return "";
+          }
+        }),
+      new EmptyDimension()
+    );
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/EmptyWorld.java
@@ -17,6 +17,7 @@
 package se.llbit.chunky.world;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -35,8 +36,13 @@ public class EmptyWorld extends World {
   }
 
   @Override
-  public Set<Dimension.Identifier> listDimensions() {
+  public Set<Dimension.Identifier> availableDimensions() {
     return Collections.emptySet();
+  }
+
+  @Override
+  public Optional<Dimension.Identifier> defaultDimension() {
+    return Optional.empty();
   }
 
   @Override
@@ -48,5 +54,4 @@ public class EmptyWorld extends World {
   public String toString() {
     return "[empty world]";
   }
-
 }

--- a/chunky/src/java/se/llbit/chunky/world/HeightRange.java
+++ b/chunky/src/java/se/llbit/chunky/world/HeightRange.java
@@ -1,0 +1,7 @@
+package se.llbit.chunky.world;
+
+/**
+ * @param min Lower (INCLUSIVE) bound of the range
+ * @param max Upper (EXCLUSIVE) bound of the range
+ */
+public record HeightRange(int min, int max) { }

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -9,6 +9,7 @@ import se.llbit.chunky.map.SurfaceLayer;
 import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.BiomePalette;
 import se.llbit.chunky.world.biome.Biomes;
+import se.llbit.chunky.world.java.JavaChunk;
 import se.llbit.chunky.world.region.ImposterCubicRegion;
 import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.ListTag;
@@ -26,7 +27,7 @@ import java.util.Set;
  *
  * Represents an infinitely tall column of 16x16x16 Cubes
  */
-public class ImposterCubicChunk extends Chunk {
+public class ImposterCubicChunk extends JavaChunk {
   private final CubicDimension dimension;
 
   public ImposterCubicChunk(ChunkPosition pos, Dimension dimension) {

--- a/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/ImposterCubicChunk.java
@@ -53,7 +53,7 @@ public class ImposterCubicChunk extends JavaChunk {
    */
   @Override
   public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> mutableChunkData, int yMin, int yMax) {
-    if (!shouldReloadChunk()) {
+    if (!shouldReload()) {
       return false;
     }
 

--- a/chunky/src/java/se/llbit/chunky/world/PlayerEntityData.java
+++ b/chunky/src/java/se/llbit/chunky/world/PlayerEntityData.java
@@ -93,7 +93,7 @@ public class PlayerEntityData {
     }
   }
 
-  static UUID getUuid(Tag playerTag) {
+  public static UUID getUuid(Tag playerTag) {
     final UUID uuid;
     long uuidHi;
     long uuidLo;

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -16,20 +16,8 @@
  */
 package se.llbit.chunky.world;
 
-import se.llbit.chunky.world.java.JavaWorld;
-import se.llbit.log.Log;
-import se.llbit.math.Vector3i;
-import se.llbit.nbt.NamedTag;
-import se.llbit.nbt.Tag;
-import se.llbit.util.MinecraftText;
-import se.llbit.util.UuidUtil;
-import se.llbit.util.annotation.NotNull;
-
 import java.io.*;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
 
 /**
  * The World class contains information about the currently viewed world.
@@ -72,7 +60,7 @@ public abstract class World implements Comparable<World> {
   }
 
   /**
-   * The dimensions returned here are later provided to {@link #loadDimension(String)} when requesting a dimension be
+   * The dimensions returned here are later provided to {@link #loadDimension(Dimension.Identifier)} when requesting a dimension be
    * loaded.
    *
    * @return List the viewable dimensions within the world.
@@ -86,7 +74,7 @@ public abstract class World implements Comparable<World> {
   public abstract Optional<Dimension.Identifier> defaultDimension();
 
   /**
-   * @param dimension The dimension to load, guaranteed to be one of the dimensions previously returned by {@link #availableDimensions()}
+   * @param dimensionId The dimension to load, guaranteed to be one of the dimensions previously returned by {@link #availableDimensions()}
    * @return The loaded dimension
    */
   public abstract Dimension loadDimension(Dimension.Identifier dimensionId);

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -16,6 +16,7 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.log.Log;
 import se.llbit.math.Vector3i;
 import se.llbit.nbt.NamedTag;
@@ -37,32 +38,20 @@ import java.util.zip.GZIPInputStream;
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class World implements Comparable<World> {
-
-  /** The currently supported NBT version of level.dat files. */
-  public static final int NBT_VERSION = 19133;
-
+public abstract class World implements Comparable<World> {
   /** Default sea water level. */
   public static final int SEA_LEVEL = 63;
 
-  /** Minimum level.dat data version of tall worlds (21w06a). */
-  public static final int VERSION_21W06A = 2694;
-  public static final int VERSION_1_12_2 = 1343;
-
-  private final File worldDirectory;
+  protected final File worldDirectory;
 
   protected Dimension currentDimension;
 
-  private final String levelName;
-  private int gameMode = 0;
-  private final long seed;
-
-  private int versionId;
+  protected final String levelName;
+  protected int gameMode = 0;
+  protected final long seed;
 
   /** Timestamp for level.dat when player data was last loaded. */
-  private long timestamp;
-
-  private UUID singleplayerPlayerUuid;
+  protected long timestamp;
 
   /**
    * @param levelName name of the world (not the world directory).
@@ -82,11 +71,6 @@ public class World implements Comparable<World> {
     SILENT
   }
 
-  public void loadDimension(Dimension.Identifier dimensionId) {
-    currentDimension = loadDimension(this, this.worldDirectory, dimensionId, Collections.emptySet());
-    currentDimension.reloadPlayerData();
-  }
-
   /**
    * Parse player location and level name.
    *
@@ -96,175 +80,17 @@ public class World implements Comparable<World> {
     if (worldDirectory == null) {
       return EmptyWorld.INSTANCE;
     }
-    String levelName = worldDirectory.getName(); // Default level name.
-    File worldFile = new File(worldDirectory, "level.dat");
-    long modtime = worldFile.lastModified();
-    try (FileInputStream fin = new FileInputStream(worldFile);
-        InputStream gzin = new GZIPInputStream(fin);
-        DataInputStream in = new DataInputStream(gzin)) {
-      Set<String> request = new HashSet<>();
-      request.add(".Data.version");
-      request.add(".Data.Version.Id");
-      request.add(".Data.RandomSeed");
-      request.add(".Data.Player");
-      request.add(".Data.singleplayer_uuid");
-      request.add(".Data.LevelName");
-      request.add(".Data.GameType");
-      request.add(".Data.isCubicWorld");
-      Map<String, Tag> result = NamedTag.quickParse(in, request);
-
-      Tag version = result.get(".Data.version");
-      if (warnings == LoggedWarnings.NORMAL && version.intValue() != NBT_VERSION) {
-        Log.warnf("The world format for the world %s is not supported by Chunky.\n" + "Will attempt to load the world anyway.",
-            levelName);
-      }
-      Tag versionId = result.get(".Data.Version.Id");
-      Tag player = result.get(".Data.Player");
-      Tag spawnX = player.get("SpawnX");
-      Tag spawnY = player.get("SpawnY");
-      Tag spawnZ = player.get("SpawnZ");
-      Tag singleplayerUuid = result.get(".Data.singleplayer_uuid");
-      Tag gameType = result.get(".Data.GameType");
-      Tag randomSeed = result.get(".Data.RandomSeed");
-      levelName = MinecraftText.removeFormatChars(result.get(".Data.LevelName").stringValue(levelName));
-
-      long seed = randomSeed.longValue(0);
-
-      Set<PlayerEntityData> playerEntities = getPlayerEntityData(worldDirectory, dimensionId, player);
-
-      World world = new World(levelName, worldDirectory, seed, modtime);
-      world.gameMode = gameType.intValue(0);
-      world.versionId = versionId.intValue();
-      if (singleplayerUuid.isIntArray(4)) {
-        world.singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
-      } else if (!player.isError()) {
-        world.singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
-      }
-
-      Dimension dimension = loadDimension(world, worldDirectory, dimensionId, playerEntities);
-
-      boolean haveSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
-      if (haveSpawnPos) {
-        dimension.setSpawnPos(new Vector3i(spawnX.intValue(0), spawnY.intValue(0), spawnZ.intValue(0)));
-      }
-
-      world.currentDimension = dimension;
-
-      return world;
-    } catch (FileNotFoundException e) {
-      if (warnings == LoggedWarnings.NORMAL) {
-        Log.infof("Could not find level.dat file for world %s!", levelName);
-      }
-    } catch (IOException e) {
-      if (warnings == LoggedWarnings.NORMAL) {
-        Log.infof("Could not read the level.dat file for world %s!", levelName);
-      }
-    }
-    return EmptyWorld.INSTANCE;
+    return JavaWorld.loadWorld(worldDirectory, dimensionId, warnings);
   }
 
-  @NotNull
-  private static Dimension loadDimension(World world, File worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities) {
-    File dimensionDirectory = Path.of(worldDirectory.getPath(), "dimensions", dimensionId.namespace(), dimensionId.name()).toFile();
-    if (dimensionDirectory.exists()) {
-      // 26.1-snapshot-6 or later
-      return new Dimension(world, dimensionId, dimensionDirectory, playerEntities);
-    }
+  public abstract void loadDimension(Dimension.Identifier dimensionId);
 
-    dimensionDirectory = switch (dimensionId.getNamespacedName()) { // TODO in Java 21+ we can use `switch (dimensionId)` here
-      case "minecraft:the_nether" -> new File(worldDirectory, "DIM-1");
-      case "minecraft:the_end" -> new File(worldDirectory, "DIM1");
-      default -> worldDirectory;
-    };
-    if (new File(dimensionDirectory, "region3d").exists()) {
-      return new CubicDimension(world, dimensionId, dimensionDirectory, playerEntities);
-    } else {
-      return new Dimension(world, dimensionId, dimensionDirectory, playerEntities);
-    }
-  }
-
-  @NotNull
-  private static Set<PlayerEntityData> getPlayerEntityData(File worldDirectory, Dimension.Identifier dimensionId, Tag player) {
-    Set<PlayerEntityData> playerEntities = new HashSet<>();
-    if (!player.isError()) {
-      playerEntities.add(new PlayerEntityData(player));
-    }
-    loadAdditionalPlayers(worldDirectory, playerEntities);
-    // Filter for the players only within the requested dimension
-    playerEntities = playerEntities.stream().filter(playerData -> playerData.dimension.equals(dimensionId)).collect(Collectors.toSet());
-    return playerEntities;
-  }
-
-  /**
-   * Reload player data for the current dimension. This method is not in Dimension because players are per-world, not per-dimension
-   * @return {@code true} if player data was reloaded.
-   */
-  synchronized boolean reloadPlayerData() {
-    if (worldDirectory == null) {
-      return false;
-    }
-    File worldFile = new File(worldDirectory, "level.dat");
-    long lastModified = worldFile.lastModified();
-    if (lastModified == timestamp) {
-      return false;
-    }
-    Log.infof("world %s: timestamp updated: reading player data", levelName);
-    timestamp = lastModified;
-
-    try (FileInputStream fin = new FileInputStream(worldFile);
-         InputStream gzin = new GZIPInputStream(fin);
-         DataInputStream in = new DataInputStream(gzin)) {
-      Set<String> request = new HashSet<>();
-      request.add(".Data.Player");
-      request.add(".Data.singleplayer_uuid");
-      Map<String, Tag> result = NamedTag.quickParse(in, request);
-      Tag player = result.get(".Data.Player");
-      Tag singleplayerUuid = result.get(".Data.singleplayer_uuid");
-      if (singleplayerUuid.isIntArray(4)) {
-        singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
-      } else if (!player.isError()) {
-        singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
-      }
-
-      currentDimension.setPlayerEntities(getPlayerEntityData(worldDirectory, currentDimension.getDimensionId(), player));
-    } catch (IOException e) {
-      Log.infof("Could not read the level.dat file for world %s while trying to reload player data!", levelName);
-      return false;
-    }
-    return true;
-  }
-
-  private static void loadAdditionalPlayers(File worldDirectory, Set<PlayerEntityData> playerEntities) {
-    loadPlayerData(new File(worldDirectory, "players"), playerEntities);
-    loadPlayerData(new File(worldDirectory, "playerdata"), playerEntities);
-    loadPlayerData(new File(new File(worldDirectory, "players"), "data"), playerEntities); // 26.1-snapshot-6 or later
-  }
-
-  private static void loadPlayerData(File playerdata, Set<PlayerEntityData> playerEntities) {
-    if (playerdata.isDirectory()) {
-      File[] players = playerdata.listFiles();
-      if (players != null) {
-        for (File player : players) {
-          try (DataInputStream in = new DataInputStream(
-              new GZIPInputStream(new FileInputStream(player)))) {
-            playerEntities.add(new PlayerEntityData(NamedTag.read(in).unpack()));
-          } catch (IOException e) {
-            Log.infof("Could not read player data file '%s'", player.getAbsolutePath());
-          }
-        }
-      }
-    }
-  }
 
   /**
    * @return The current dimension
    */
   public synchronized Dimension currentDimension() {
     return this.currentDimension;
-  }
-
-  public Optional<UUID> getSingleplayerPlayerUuid() {
-    return Optional.ofNullable(singleplayerPlayerUuid);
   }
 
   /**
@@ -281,10 +107,6 @@ public class World implements Comparable<World> {
   /** The name of this world (not the world directory name). */
   public String levelName() {
     return levelName;
-  }
-
-  public int getVersionId() {
-    return versionId;
   }
 
   /**
@@ -310,7 +132,6 @@ public class World implements Comparable<World> {
       default -> "Unknown";
     };
   }
-
   @Override public int compareTo(World o) {
     // Compares world names and directories.
     return toString().compareToIgnoreCase(o.toString());

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -76,6 +76,7 @@ public abstract class World implements Comparable<World> {
    *
    * @return {@code true} if the world data was loaded
    */
+  @Deprecated
   public static World loadWorld(File worldDirectory, Dimension.Identifier dimensionId, LoggedWarnings warnings) {
     if (worldDirectory == null) {
       return EmptyWorld.INSTANCE;
@@ -83,8 +84,15 @@ public abstract class World implements Comparable<World> {
     return JavaWorld.loadWorld(worldDirectory, dimensionId, warnings);
   }
 
-  public abstract void loadDimension(Dimension.Identifier dimensionId);
+  /**
+   * The dimensions returned here are later provided to {@link #loadDimension(Dimension.Identifier)} when requesting a dimension be
+   * loaded.
+   *
+   * @return List the viewable dimensions within the world.
+   */
+  public abstract Set<Dimension.Identifier> listDimensions();
 
+  public abstract Dimension loadDimension(Dimension.Identifier dimensionId);
 
   /**
    * @return The current dimension
@@ -107,18 +115,6 @@ public abstract class World implements Comparable<World> {
   /** The name of this world (not the world directory name). */
   public String levelName() {
     return levelName;
-  }
-
-  /**
-   * @return <code>true</code> if the given directory exists and
-   * contains a level.dat file
-   */
-  public static boolean isWorldDir(File worldDir) {
-    if (worldDir != null && worldDir.isDirectory()) {
-      File levelDat = new File(worldDir, "level.dat");
-      return levelDat.exists() && levelDat.isFile();
-    }
-    return false;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -38,20 +38,15 @@ public abstract class World implements Comparable<World> {
   protected int gameMode = 0;
   protected final long seed;
 
-  /** Timestamp for level.dat when player data was last loaded. */
-  protected long timestamp;
-
   /**
    * @param levelName name of the world (not the world directory).
    * @param worldDirectory Minecraft world directory.
    * @param seed
-   * @param timestamp
    */
-  protected World(String levelName, File worldDirectory, long seed, long timestamp) {
+  protected World(String levelName, File worldDirectory, long seed) {
     this.levelName = levelName;
     this.worldDirectory = worldDirectory;
     this.seed = seed;
-    this.timestamp = timestamp;
   }
 
   public enum LoggedWarnings {

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -72,26 +72,23 @@ public abstract class World implements Comparable<World> {
   }
 
   /**
-   * Parse player location and level name.
-   *
-   * @return {@code true} if the world data was loaded
-   */
-  @Deprecated
-  public static World loadWorld(File worldDirectory, Dimension.Identifier dimensionId, LoggedWarnings warnings) {
-    if (worldDirectory == null) {
-      return EmptyWorld.INSTANCE;
-    }
-    return JavaWorld.loadWorld(worldDirectory, dimensionId, warnings);
-  }
-
-  /**
-   * The dimensions returned here are later provided to {@link #loadDimension(Dimension.Identifier)} when requesting a dimension be
+   * The dimensions returned here are later provided to {@link #loadDimension(String)} when requesting a dimension be
    * loaded.
    *
    * @return List the viewable dimensions within the world.
    */
-  public abstract Set<Dimension.Identifier> listDimensions();
+  public abstract Set<Dimension.Identifier> availableDimensions();
 
+  /**
+   * <b>MUST</b> be one of {@link #availableDimensions()}
+   * @return The preferred default dimension of this world (typically the overworld)
+   */
+  public abstract Optional<Dimension.Identifier> defaultDimension();
+
+  /**
+   * @param dimension The dimension to load, guaranteed to be one of the dimensions previously returned by {@link #availableDimensions()}
+   * @return The loaded dimension
+   */
   public abstract Dimension loadDimension(Dimension.Identifier dimensionId);
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -65,16 +65,16 @@ public abstract class World implements Comparable<World> {
    *
    * @return List the viewable dimensions within the world.
    */
-  public abstract Set<Dimension.Identifier> availableDimensions();
+  public abstract Set<Dimension.Identifier> getAvailableDimensions();
 
   /**
-   * <b>MUST</b> be one of {@link #availableDimensions()}
+   * <b>MUST</b> be one of {@link #getAvailableDimensions()}
    * @return The preferred default dimension of this world (typically the overworld)
    */
-  public abstract Optional<Dimension.Identifier> defaultDimension();
+  public abstract Optional<Dimension.Identifier> getDefaultDimension();
 
   /**
-   * @param dimensionId The dimension to load, guaranteed to be one of the dimensions previously returned by {@link #availableDimensions()}
+   * @param dimensionId The dimension to load, guaranteed to be one of the dimensions previously returned by {@link #getAvailableDimensions()}
    * @return The loaded dimension
    */
   public abstract Dimension loadDimension(Dimension.Identifier dimensionId);

--- a/chunky/src/java/se/llbit/chunky/world/World.java
+++ b/chunky/src/java/se/llbit/chunky/world/World.java
@@ -16,37 +16,50 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.util.annotation.NotNull;
+
 import java.io.*;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
- * The World class contains information about the currently viewed world.
- * It has a map of all chunks in the world and is responsible for parsing
- * chunks when needed. All rendering is done through the WorldRenderer class.
+ * The World class contains {@link Info metadata} about itself, and methods for querying and loading its dimensions.
+ * It also contains the {@link #currentDimension() currently loaded dimension} if there is one.
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public abstract class World implements Comparable<World> {
+public abstract class World {
+  /**
+   * Metadata about a world.
+   */
+  public record Info(String name, Path path, long lastModified, long seed, String gameMode, WorldFormat worldFormat) {
+    /**
+     * Chunky sees each valid {@link Info#path()} and {@link Info#worldFormat()} combination as a distinct world which
+     * can be selected by the user.
+     */
+    public boolean isSameWorld(Info other) {
+      return this.worldFormat == other.worldFormat && this.path.equals(other.path);
+    }
+  }
+
   /** Default sea water level. */
   public static final int SEA_LEVEL = 63;
 
-  protected final File worldDirectory;
+  private final Info info;
 
+  @NotNull
   protected Dimension currentDimension;
 
-  protected final String levelName;
-  protected int gameMode = 0;
-  protected final long seed;
+  protected World(Info info) {
+    this.info = info;
+    this.currentDimension = EmptyWorld.INSTANCE.currentDimension();
+  }
 
-  /**
-   * @param levelName name of the world (not the world directory).
-   * @param worldDirectory Minecraft world directory.
-   * @param seed
-   */
-  protected World(String levelName, File worldDirectory, long seed) {
-    this.levelName = levelName;
-    this.worldDirectory = worldDirectory;
-    this.seed = seed;
+  /** Only for use by {@link EmptyWorld} */
+  protected World(Info info, @NotNull EmptyDimension dimension) {
+    this.info = info;
+    this.currentDimension = dimension;
   }
 
   public enum LoggedWarnings {
@@ -55,8 +68,8 @@ public abstract class World implements Comparable<World> {
   }
 
   /**
-   * The dimensions returned here are later provided to {@link #loadDimension(Dimension.Identifier)} when requesting a dimension be
-   * loaded.
+   * The dimensions returned here are later provided to {@link #loadDimension(Dimension.Identifier)} when requesting a
+   * dimension be loaded.
    *
    * @return List the viewable dimensions within the world.
    */
@@ -75,50 +88,19 @@ public abstract class World implements Comparable<World> {
   public abstract Dimension loadDimension(Dimension.Identifier dimensionId);
 
   /**
-   * @return The current dimension
+   * @return The current dimension or {@link EmptyDimension#INSTANCE} if there isn't one.
    */
+  @NotNull
   public synchronized Dimension currentDimension() {
     return this.currentDimension;
   }
 
-  /**
-   * @return The world directory
-   */
-  public File getWorldDirectory() {
-    return worldDirectory;
+  public Info getInfo() {
+    return this.info;
   }
 
   @Override public String toString() {
-    return levelName + " (" + worldDirectory.getName() + ")";
-  }
-
-  /** The name of this world (not the world directory name). */
-  public String levelName() {
-    return levelName;
-  }
-
-  /**
-   * @return String describing the game-mode of this world
-   */
-  public String gameMode() {
-    return switch (gameMode) {
-      case 0 -> "Survival";
-      case 1 -> "Creative";
-      case 2 -> "Adventure";
-      default -> "Unknown";
-    };
-  }
-  @Override public int compareTo(World o) {
-    // Compares world names and directories.
-    return toString().compareToIgnoreCase(o.toString());
-  }
-
-  public long getSeed() {
-    return seed;
-  }
-
-  public Date getLastModified() {
-    return new Date(this.worldDirectory.lastModified());
+    return info.name + " (" + info.path.getFileName() + ")";
   }
 
   /**
@@ -127,7 +109,7 @@ public abstract class World implements Comparable<World> {
    * @return Resource pack file/directory or empty optional if this world has no bundled resource pack
    */
   public Optional<File> getResourcePack() {
-    for (File resourcepacksDirectory : new File[]{getWorldDirectory(), new File(getWorldDirectory(), "resourcepacks")}) {
+    for (File resourcepacksDirectory : new File[]{ info.path.toFile(), new File(info.path.toFile(), "resourcepacks")}) {
       if (resourcepacksDirectory.isDirectory()) {
         File resourcePack = new File(resourcepacksDirectory, "resources.zip");
     if (resourcePack.isFile()) {

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
@@ -13,7 +13,7 @@ import se.llbit.chunky.map.SurfaceLayer;
 import se.llbit.chunky.world.*;
 import se.llbit.chunky.world.biome.ArrayBiomePalette;
 import se.llbit.chunky.world.biome.BiomePalette;
-import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.java.region.JavaRegion;
 import se.llbit.chunky.world.region.Region;
 import se.llbit.log.Log;
 import se.llbit.math.QuickMath;
@@ -42,7 +42,7 @@ public class JavaChunk extends Chunk {
    * @return loaded data, or null if something went wrong
    */
   private Map<String, Tag> getChunkTags(Set<String> request) throws ChunkLoadingException {
-    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
+    JavaRegion region = (JavaRegion) dimension.getRegion(position.getRegionPosition());
     Mutable<Integer> timestamp = new Mutable<>(dataTimestamp);
     Map<String, Tag> chunkTags = region.getChunkTags(this.position, request, timestamp);
     this.dataTimestamp = timestamp.get();
@@ -54,7 +54,7 @@ public class JavaChunk extends Chunk {
    * @return loaded data, or null if something went wrong
    */
   private Map<String, Tag> getEntityTags(Set<String> request) throws ChunkLoadingException {
-    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
+    JavaRegion region = (JavaRegion) dimension.getRegion(position.getRegionPosition());
     return region.getEntityTags(this.position, request);
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
@@ -1,6 +1,5 @@
 package se.llbit.chunky.world.java;
 
-import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
 import se.llbit.chunky.block.legacy.LegacyBlocks;
 import se.llbit.chunky.chunk.BlockPalette;
 import se.llbit.chunky.chunk.ChunkData;
@@ -87,8 +86,8 @@ public class JavaChunk extends Chunk {
 
     surfaceTimestamp = dataTimestamp;
     version = chunkVersion(data);
-    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
-    chunkData.set(this.dimension.createChunkData(chunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
+    HeightRange chunkBounds = inclusiveChunkBounds(data);
+    chunkData.set(this.dimension.createChunkData(chunkData.get(), chunkBounds.min(), chunkBounds.max()));
     loadSurface(data, chunkData.get(), yMin, yMax);
     biomesTimestamp = dataTimestamp;
 
@@ -289,10 +288,10 @@ public class JavaChunk extends Chunk {
 
     int dataVersion = data.get(DATAVERSION).intValue();
 
-    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
+    HeightRange chunkBounds = inclusiveChunkBounds(data);
 
     if(reuseChunkData.get() == null || reuseChunkData.get() instanceof EmptyChunkData) {
-      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
+      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), chunkBounds.min(), chunkBounds.max()));
     } else {
       reuseChunkData.get().clear();
     }
@@ -343,7 +342,7 @@ public class JavaChunk extends Chunk {
   /**
    * @return The min and max blockY for a given section array
    */
-  private IntIntImmutablePair inclusiveChunkBounds(Tag chunkData) {
+  private HeightRange inclusiveChunkBounds(Tag chunkData) {
     Tag sections = getTagFromNames(chunkData, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     int minSectionY = Integer.MAX_VALUE;
     int maxSectionY = Integer.MIN_VALUE;
@@ -359,7 +358,7 @@ public class JavaChunk extends Chunk {
       }
     }
 
-    return new IntIntImmutablePair(minSectionY << 4, (maxSectionY << 4) + 15);
+    return new HeightRange(minSectionY << 4, (maxSectionY << 4) + 15);
   }
 
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
@@ -1,0 +1,365 @@
+package se.llbit.chunky.world.java;
+
+import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
+import se.llbit.chunky.block.legacy.LegacyBlocks;
+import se.llbit.chunky.chunk.BlockPalette;
+import se.llbit.chunky.chunk.ChunkData;
+import se.llbit.chunky.chunk.ChunkLoadingException;
+import se.llbit.chunky.chunk.EmptyChunkData;
+import se.llbit.chunky.chunk.biome.BiomeDataFactory;
+import se.llbit.chunky.map.BiomeLayer;
+import se.llbit.chunky.map.IconLayer;
+import se.llbit.chunky.map.SurfaceLayer;
+import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.biome.ArrayBiomePalette;
+import se.llbit.chunky.world.biome.BiomePalette;
+import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.region.Region;
+import se.llbit.log.Log;
+import se.llbit.math.QuickMath;
+import se.llbit.nbt.CompoundTag;
+import se.llbit.nbt.ListTag;
+import se.llbit.nbt.SpecificTag;
+import se.llbit.nbt.Tag;
+import se.llbit.util.BitBuffer;
+import se.llbit.util.Mutable;
+import se.llbit.util.annotation.NotNull;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static se.llbit.util.NbtUtil.getTagFromNames;
+import static se.llbit.util.NbtUtil.tagFromMap;
+
+public class JavaChunk extends Chunk {
+  public JavaChunk(ChunkPosition pos, Dimension dimension) {
+    super(pos, dimension);
+  }
+
+  /**
+   * @param request fresh request set
+   * @return loaded data, or null if something went wrong
+   */
+  private Map<String, Tag> getChunkTags(Set<String> request) throws ChunkLoadingException {
+    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
+    Mutable<Integer> timestamp = new Mutable<>(dataTimestamp);
+    Map<String, Tag> chunkTags = region.getChunkTags(this.position, request, timestamp);
+    this.dataTimestamp = timestamp.get();
+    return chunkTags;
+  }
+
+  /**
+   * @param request fresh request set
+   * @return loaded data, or null if something went wrong
+   */
+  private Map<String, Tag> getEntityTags(Set<String> request) throws ChunkLoadingException {
+    MCRegion region = (MCRegion) dimension.getRegion(position.getRegionPosition());
+    return region.getEntityTags(this.position, request);
+  }
+
+  @Override
+  public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax) {
+    if (!shouldReloadChunk()) {
+      return false;
+    }
+
+    Set<String> request = new HashSet<>();
+    request.add(Chunk.DATAVERSION);
+    request.add(Chunk.LEVEL_SECTIONS);
+    request.add(Chunk.SECTIONS_POST_21W39A);
+    request.add(Chunk.LEVEL_BIOMES);
+    request.add(Chunk.BIOMES_POST_21W39A);
+    request.add(Chunk.LEVEL_HEIGHTMAP);
+
+    Map<String, Tag> dataMap;
+    try {
+      dataMap = getChunkTags(request);
+    } catch (ChunkLoadingException e) { // we don't want to crash the map view if a chunk fails to load, so we warn the user
+      Log.warn(String.format("Failed to load chunk %s", position), e);
+      return false;
+    }
+    // TODO: improve error handling here.
+    if (dataMap == null) {
+      return false;
+    }
+    Tag data = tagFromMap(dataMap);
+
+    surfaceTimestamp = dataTimestamp;
+    version = chunkVersion(data);
+    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
+    chunkData.set(this.dimension.createChunkData(chunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
+    loadSurface(data, chunkData.get(), yMin, yMax);
+    biomesTimestamp = dataTimestamp;
+
+    dimension.chunkUpdated(position);
+    return true;
+  }
+
+  private void loadSurface(@NotNull Tag data, ChunkData chunkData, int yMin, int yMax) {
+    if (data == null) {
+      surface = IconLayer.CORRUPT;
+      return;
+    }
+
+    Heightmap heightmap = dimension.getHeightmap();
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    if (sections.isList()) {
+      if (version == ChunkVersion.PRE_FLATTENING || version == ChunkVersion.POST_FLATTENING) {
+        BiomePalette biomePalette = new ArrayBiomePalette();
+        BiomeDataFactory.loadBiomeData(chunkData, data, biomePalette, yMin, yMax);
+        biomes = new BiomeLayer(chunkData, biomePalette);
+
+        BlockPalette palette = new BlockPalette();
+        palette.unsynchronize(); //only this RegionParser will use this palette
+        loadBlockData(data, chunkData, palette, yMin, yMax);
+
+        int[] heightmapData = extractHeightmapData(data, chunkData);
+        updateHeightmap(heightmap, position, chunkData, heightmapData, palette, yMax);
+
+        surface = new SurfaceLayer(dimension.getDimensionId(), chunkData, palette, biomePalette, yMin, yMax, heightmapData);
+        queueTopography();
+      }
+    } else {
+      surface = IconLayer.CORRUPT;
+    }
+  }
+
+  private int[] extractHeightmapData(@NotNull Tag data, ChunkData chunkData) {
+    Tag heightmapTag = data.get(LEVEL_HEIGHTMAP);
+    if (heightmapTag.isIntArray(X_MAX * Z_MAX)) {
+      return heightmapTag.intArray();
+    } else {
+      int[] fallback = new int[X_MAX * Z_MAX];
+      for (int i = 0; i < fallback.length; ++i) {
+        fallback[i] = chunkData.maxY();
+      }
+      return fallback;
+    }
+  }
+
+  protected boolean shouldReloadChunk() {
+    int timestamp = Integer.MAX_VALUE;
+    timestamp = Math.min(timestamp, surfaceTimestamp);
+    timestamp = Math.min(timestamp, biomesTimestamp);
+    if (timestamp == 0) {
+      return true;
+    }
+    Region region = dimension.getRegion(position.getRegionPosition());
+    return region.chunkChangedSince(position, timestamp);
+  }
+
+  /** Detect Minecraft version that generated the chunk. */
+  private static ChunkVersion chunkVersion(@NotNull Tag data) {
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    if (sections.isList()) {
+      for (SpecificTag section : sections.asList()) {
+        if (!section.get("Palette").isList()) {
+          if (section.get("Blocks").isByteArray(SECTION_BYTES)) {
+            return ChunkVersion.PRE_FLATTENING;
+          }
+        }
+      }
+      return ChunkVersion.POST_FLATTENING;
+    }
+    return ChunkVersion.UNKNOWN;
+  }
+
+  private static void loadBlockData(@NotNull Tag data, @NotNull ChunkData chunkData,
+                                    BlockPalette blockPalette, int minY, int maxY) {
+
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    if (sections.isList()) {
+      for (SpecificTag section : sections.asList()) {
+        Tag yTag = section.get("Y");
+        int sectionY = yTag.byteValue();
+        int sectionMinBlockY = sectionY << 4;
+
+        if(sectionY < minY >> 4 || sectionY-1 > (maxY >> 4)+1)
+          continue; //skip parsing sections that are outside requested bounds
+
+        Tag blockPaletteTag = getTagFromNames(section, "Palette", "block_states\\palette");
+        if (blockPaletteTag.isList()) {
+          ListTag localBlockPalette = blockPaletteTag.asList();
+          // Bits per block:
+          int bpb = 4;
+          if (localBlockPalette.size() > 16) {
+            bpb = QuickMath.log2(QuickMath.nextPow2(localBlockPalette.size()));
+          }
+
+          int dataSize = (4096 * bpb) / 64;
+          Tag blockStates = getTagFromNames(section, "BlockStates", "block_states\\data");
+
+          if (blockStates.isLongArray(dataSize)) {
+            // since 20w17a, block states are aligned to 64-bit boundaries, so there are 64 % bpb
+            // unused bits per block state; if so, the array is longer than the expected data size
+            boolean isAligned = data.get(DATAVERSION).intValue() >= DATAVERSION_20W17A;
+            if (isAligned) {
+              // entries are 64-bit-padded, re-calculate the bits per block
+              // this is the dataSize calculation from above reverted, we know the actual data size
+              bpb = blockStates.longArray().length / 64;
+            }
+
+            int[] subpalette = new int[localBlockPalette.size()];
+            int paletteIndex = 0;
+            for (Tag item : localBlockPalette.asList()) {
+              subpalette[paletteIndex] = blockPalette.put(item);
+              paletteIndex += 1;
+            }
+            BitBuffer buffer = new BitBuffer(blockStates.longArray(), bpb, isAligned);
+            for (int y = 0; y < SECTION_Y_MAX; y++) {
+              int blockY = sectionMinBlockY + y;
+              for (int z = 0; z < Z_MAX; z++) {
+                for(int x = 0; x < X_MAX; x++) {
+                  int b0 = buffer.read();
+                  if (b0 < subpalette.length) {
+                    chunkData.setBlockAt(x, blockY, z, subpalette[b0]);
+                  }
+                }
+              }
+            }
+          } else {
+            // Single block palette
+            if (localBlockPalette.size() == 1) {
+              // Check it is not air block
+              int block = blockPalette.put(localBlockPalette.get(0));
+              if (block != blockPalette.airId) {
+                // Set the entire section
+                for (int y = 0; y < SECTION_Y_MAX; y++) {
+                  int blockY = sectionMinBlockY + y;
+                  for (int z = 0; z < Z_MAX; z++) {
+                    for(int x = 0; x < X_MAX; x++) {
+                      chunkData.setBlockAt(x, blockY, z, block);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        } else {
+          int yOffset = sectionY & 0xFF;
+
+          Tag dataTag = section.get("Data");
+          byte[] blockDataBytes = new byte[(Chunk.X_MAX * Chunk.Y_MAX * Chunk.Z_MAX) / 2];
+          if (dataTag.isByteArray(SECTION_HALF_NIBBLES)) {
+            System.arraycopy(dataTag.byteArray(), 0, blockDataBytes, SECTION_HALF_NIBBLES * yOffset,
+              SECTION_HALF_NIBBLES);
+          }
+
+          Tag blocksTag = section.get("Blocks");
+          if (blocksTag.isByteArray(SECTION_BYTES)) {
+            byte[] blocksBytes = new byte[Chunk.X_MAX * Chunk.Y_MAX * Chunk.Z_MAX];
+            System.arraycopy(blocksTag.byteArray(), 0, blocksBytes, SECTION_BYTES * yOffset,
+              SECTION_BYTES);
+
+            int offset = SECTION_BYTES * yOffset;
+            for (int y = 0; y < SECTION_Y_MAX; y++) {
+              int blockY = sectionMinBlockY + y;
+              for (int z = 0; z < Z_MAX; z++) {
+                for (int x = 0; x < X_MAX; x++) {
+                  chunkData.setBlockAt(x, blockY, z, blockPalette.put(
+                    LegacyBlocks.getTag(offset, blocksBytes, blockDataBytes)));
+                  offset += 1;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public synchronized void getChunkData(@NotNull Mutable<ChunkData> reuseChunkData, BlockPalette palette, BiomePalette biomePalette, int minY, int maxY) throws ChunkLoadingException {
+    Set<String> request = new HashSet<>();
+    request.add(DATAVERSION);
+    request.add(LEVEL_SECTIONS);
+    request.add(SECTIONS_POST_21W39A);
+    request.add(LEVEL_BIOMES);
+    request.add(BIOMES_POST_21W39A);
+    request.add(LEVEL_ENTITIES);
+    request.add(LEVEL_TILEENTITIES);
+    request.add(BLOCK_ENTITIES_POST_21W43A);
+    Map<String, Tag> dataMap = getChunkTags(request);
+    // TODO: improve error handling here.
+    if (dataMap == null) {
+      throw new ChunkLoadingException(String.format("Got null data for chunk %s", this.position));
+    }
+    Tag data = tagFromMap(dataMap);
+
+    int dataVersion = data.get(DATAVERSION).intValue();
+
+    IntIntImmutablePair chunkBounds = inclusiveChunkBounds(data);
+
+    if(reuseChunkData.get() == null || reuseChunkData.get() instanceof EmptyChunkData) {
+      reuseChunkData.set(dimension.createChunkData(reuseChunkData.get(), chunkBounds.leftInt(), chunkBounds.rightInt()));
+    } else {
+      reuseChunkData.get().clear();
+    }
+    ChunkData chunkData = reuseChunkData.get(); //unwrap mutable, for ease of use
+
+    version = chunkVersion(data);
+    Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    Tag entitiesTag = data.get(LEVEL_ENTITIES);
+    Tag tileEntitiesTag = getTagFromNames(data, LEVEL_TILEENTITIES, BLOCK_ENTITIES_POST_21W43A);
+
+    BiomeDataFactory.loadBiomeData(chunkData, data, biomePalette, minY, maxY);
+    if (sections.isList()) {
+      loadBlockData(data, chunkData, palette, minY, maxY);
+
+      if (entitiesTag.isList()) {
+        for (SpecificTag tag : (ListTag) entitiesTag) {
+          if (tag.isCompoundTag())
+            chunkData.addEntity((CompoundTag) tag);
+        }
+      }
+
+      if (tileEntitiesTag.isList()) {
+        for (SpecificTag tag : (ListTag) tileEntitiesTag) {
+          if (tag.isCompoundTag())
+            chunkData.addTileEntity((CompoundTag) tag);
+        }
+      }
+    }
+
+    // post 20w45A entities
+    if (dataVersion >= DATAVERSION_20W45A) {
+      Set<String> entitiesRequest = new HashSet<>();
+      entitiesRequest.add(ENTITIES_POST_20W45A);
+
+      Map<String, Tag> entitiesMap = getEntityTags(entitiesRequest);
+      if (entitiesMap != null) {
+        entitiesTag = entitiesMap.get(".Entities");
+        if (entitiesTag.isList()) {
+          for (SpecificTag tag : (ListTag) entitiesTag) {
+            if (tag.isCompoundTag())
+              chunkData.addEntity((CompoundTag) tag);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @return The min and max blockY for a given section array
+   */
+  private IntIntImmutablePair inclusiveChunkBounds(Tag chunkData) {
+    Tag sections = getTagFromNames(chunkData, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
+    int minSectionY = Integer.MAX_VALUE;
+    int maxSectionY = Integer.MIN_VALUE;
+    if (sections.isList()) {
+      for (SpecificTag section : sections.asList()) {
+        byte sectionY = (byte) section.get("Y").byteValue();
+        if (sectionY < minSectionY) {
+          minSectionY = sectionY;
+        }
+        if (sectionY > maxSectionY) {
+          maxSectionY = sectionY;
+        }
+      }
+    }
+
+    return new IntIntImmutablePair(minSectionY << 4, (maxSectionY << 4) + 15);
+  }
+
+}

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaChunk.java
@@ -59,7 +59,7 @@ public class JavaChunk extends Chunk {
 
   @Override
   public synchronized boolean loadChunk(@NotNull Mutable<ChunkData> chunkData, int yMin, int yMax) {
-    if (!shouldReloadChunk()) {
+    if (!shouldReload()) {
       return false;
     }
 
@@ -85,7 +85,7 @@ public class JavaChunk extends Chunk {
     Tag data = tagFromMap(dataMap);
 
     surfaceTimestamp = dataTimestamp;
-    version = chunkVersion(data);
+    version = getChunkVersion(data);
     HeightRange chunkBounds = inclusiveChunkBounds(data);
     chunkData.set(this.dimension.createChunkData(chunkData.get(), chunkBounds.min(), chunkBounds.max()));
     loadSurface(data, chunkData.get(), yMin, yMax);
@@ -137,7 +137,7 @@ public class JavaChunk extends Chunk {
     }
   }
 
-  protected boolean shouldReloadChunk() {
+  protected boolean shouldReload() {
     int timestamp = Integer.MAX_VALUE;
     timestamp = Math.min(timestamp, surfaceTimestamp);
     timestamp = Math.min(timestamp, biomesTimestamp);
@@ -149,7 +149,7 @@ public class JavaChunk extends Chunk {
   }
 
   /** Detect Minecraft version that generated the chunk. */
-  private static ChunkVersion chunkVersion(@NotNull Tag data) {
+  private static ChunkVersion getChunkVersion(@NotNull Tag data) {
     Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     if (sections.isList()) {
       for (SpecificTag section : sections.asList()) {
@@ -297,7 +297,7 @@ public class JavaChunk extends Chunk {
     }
     ChunkData chunkData = reuseChunkData.get(); //unwrap mutable, for ease of use
 
-    version = chunkVersion(data);
+    version = getChunkVersion(data);
     Tag sections = getTagFromNames(data, LEVEL_SECTIONS, SECTIONS_POST_21W39A);
     Tag entitiesTag = data.get(LEVEL_ENTITIES);
     Tag tileEntitiesTag = getTagFromNames(data, LEVEL_TILEENTITIES, BLOCK_ENTITIES_POST_21W43A);

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -1,0 +1,138 @@
+package se.llbit.chunky.world.java;
+
+import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import se.llbit.chunky.map.MapView;
+import se.llbit.chunky.map.WorldMapLoader;
+import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.region.*;
+import se.llbit.math.Vector3;
+import se.llbit.math.Vector3i;
+import se.llbit.util.annotation.Nullable;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.Set;
+
+public class JavaDimension extends Dimension {
+  protected final JavaWorld world;
+  protected final Long2ObjectMap<Region> regionMap = new Long2ObjectOpenHashMap<>();
+
+  /**
+   * @param world
+   * @param dimensionId
+   * @param dimensionDirectory Minecraft world directory.
+   * @param playerEntities
+   */
+  protected JavaDimension(JavaWorld world, Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
+    super(dimensionId, dimensionDirectory, playerEntities);
+    this.world = world;
+  }
+
+  @Override
+  public RegionChangeWatcher createRegionChangeWatcher(WorldMapLoader worldMapLoader, MapView mapView) {
+    return new MCRegionChangeWatcher(worldMapLoader, mapView);
+  }
+
+  @Override
+  public Region createRegion(RegionPosition pos) {
+    return new MCRegion(pos, this);
+  }
+
+  /**
+   * Set the region for the given position.
+   */
+  public synchronized void setRegion(RegionPosition pos, Region region) {
+    regionMap.put(pos.getLong(), region);
+  }
+
+  @Override
+  public synchronized Region getRegion(RegionPosition pos) {
+    return regionMap.computeIfAbsent(pos.getLong(), p -> {
+      // check if the region is present in the world directory
+      Region region = EmptyRegion.instance;
+      if (regionExists(pos)) {
+        region = createRegion(pos);
+      }
+      return region;
+    });
+  }
+
+  @Override
+  public Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax) {
+    return getRegion(pos);
+  }
+
+  @Override
+  public boolean regionExists(RegionPosition pos) {
+    File regionFile = new File(getRegionDirectory(), pos.getMcaName());
+    return regionFile.exists();
+  }
+
+  @Override
+  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
+    return this.regionExists(pos);
+  }
+
+  @Override
+  public IntIntPair heightRange() {
+    return this.world.versionId >= JavaWorld.VERSION_21W06A ?
+      new IntIntImmutablePair(-64, 320) :
+      new IntIntImmutablePair(0, 256);
+  }
+
+
+  @Override
+  public synchronized Chunk getChunk(ChunkPosition pos) {
+    return getRegion(pos.getRegionPosition()).getChunk(pos);
+  }
+
+  @Override
+  public synchronized boolean reloadPlayerData() {
+    return this.world.reloadPlayerData();
+  }
+
+  @Override
+  public synchronized Optional<Vector3> getPlayerPos() {
+    if (!playerEntities.isEmpty()) {
+      return world.getSingleplayerPlayerUuid()
+        .flatMap(uuid -> playerEntities.stream()
+          .filter(player -> player.uuid.equals(uuid))
+          .map(pos -> new Vector3(pos.x, pos.y, pos.z))
+          .findFirst());
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  public void setSpawnPos(@Nullable Vector3i spawnPos) {
+    this.spawnPos = spawnPos;
+  }
+
+  /**
+   * Called when a new region has been discovered by the region parser.
+   */
+  public void regionDiscovered(RegionPosition pos) {
+    synchronized (this) {
+      regionMap.computeIfAbsent(pos.getLong(), p -> createRegion(pos));
+    }
+  }
+
+  /**
+   * Get the data directory for the given dimension.
+   *
+   * @return File object pointing to the data directory
+   */
+  protected synchronized File getDimensionDirectory() {
+    return dimensionDirectory;
+  }
+
+  /**
+   * @return File object pointing to the region file directory
+   */
+  public synchronized File getRegionDirectory() {
+    return new File(getDimensionDirectory(), "region");
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -1,7 +1,5 @@
 package se.llbit.chunky.world.java;
 
-import it.unimi.dsi.fastutil.ints.IntIntImmutablePair;
-import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import se.llbit.chunky.map.MapView;
@@ -64,26 +62,26 @@ public class JavaDimension extends Dimension {
   }
 
   @Override
-  public Region getRegionWithinRange(RegionPosition pos, int yMin, int yMax) {
+  public Region getRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
     return getRegion(pos);
   }
 
   @Override
-  public boolean regionExists(RegionPosition pos) {
+  public boolean hasRegion(RegionPosition pos) {
     File regionFile = new File(getRegionDirectory(), pos.getMcaName());
     return regionFile.exists();
   }
 
   @Override
-  public boolean regionExistsWithinRange(RegionPosition pos, int minY, int maxY) {
-    return this.regionExists(pos);
+  public boolean hasRegionWithinRange(RegionPosition pos, HeightRange heightRange) {
+    return this.hasRegion(pos);
   }
 
   @Override
-  public IntIntPair heightRange() {
+  public HeightRange heightRange() {
     return this.world.versionId >= JavaWorld.VERSION_21W06A ?
-      new IntIntImmutablePair(-64, 320) :
-      new IntIntImmutablePair(0, 256);
+      new HeightRange(-64, 320) :
+      new HeightRange(0, 256);
   }
 
 

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -7,6 +7,8 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.java.region.JavaRegion;
+import se.llbit.chunky.world.java.region.JavaRegionChangeWatcher;
 import se.llbit.chunky.world.region.*;
 import se.llbit.math.Vector3;
 import se.llbit.math.Vector3i;
@@ -34,12 +36,12 @@ public class JavaDimension extends Dimension {
 
   @Override
   public RegionChangeWatcher createRegionChangeWatcher(WorldMapLoader worldMapLoader, MapView mapView) {
-    return new MCRegionChangeWatcher(worldMapLoader, mapView);
+    return new JavaRegionChangeWatcher(worldMapLoader, mapView);
   }
 
   @Override
   public Region createRegion(RegionPosition pos) {
-    return new MCRegion(pos, this);
+    return new JavaRegion(pos, this);
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -130,4 +130,9 @@ public class JavaDimension extends Dimension {
   public synchronized File getRegionDirectory() {
     return new File(getDimensionDirectory(), "region");
   }
+
+  @Override
+  public String getName() {
+    return dimensionDirectory.getName() ;
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -13,6 +13,7 @@ import se.llbit.math.Vector3i;
 import se.llbit.util.annotation.Nullable;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,7 +28,7 @@ public class JavaDimension extends Dimension {
    * @param dimensionDirectory Minecraft world directory.
    * @param playerEntities
    */
-  protected JavaDimension(JavaWorld world, Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+  protected JavaDimension(JavaWorld world, Identifier dimensionId, Path dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
     super(dimensionId, dimensionDirectory, playerEntities, spawnPos);
     this.world = world;
   }
@@ -128,11 +129,11 @@ public class JavaDimension extends Dimension {
    * @return File object pointing to the region file directory
    */
   public synchronized File getRegionDirectory() {
-    return new File(getDimensionDirectory(), "region");
+    return dimensionDirectory.resolve("region").toFile();
   }
 
   @Override
   public String getName() {
-    return dimensionDirectory.getName() ;
+    return dimensionDirectory.getFileName().toString();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -15,6 +15,7 @@ import se.llbit.util.annotation.Nullable;
 import java.io.File;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class JavaDimension extends Dimension {
   protected final JavaWorld world;
@@ -26,8 +27,8 @@ public class JavaDimension extends Dimension {
    * @param dimensionDirectory Minecraft world directory.
    * @param playerEntities
    */
-  protected JavaDimension(JavaWorld world, Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities) {
-    super(dimensionId, dimensionDirectory, playerEntities);
+  protected JavaDimension(JavaWorld world, Identifier dimensionId, File dimensionDirectory, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+    super(dimensionId, dimensionDirectory, playerEntities, spawnPos);
     this.world = world;
   }
 
@@ -91,24 +92,27 @@ public class JavaDimension extends Dimension {
 
   @Override
   public synchronized boolean reloadPlayerData() {
-    return this.world.reloadPlayerData();
+    boolean changed = this.world.reloadPlayerData();
+    if (changed) {
+      this.playerEntities.clear();
+      this.playerEntities.addAll(this.world.playerEntities.stream()
+        .filter(player -> player.dimension.equals(this.dimensionId))
+        .collect(Collectors.toSet()));
+    }
+    return changed;
   }
 
   @Override
   public synchronized Optional<Vector3> getPlayerPos() {
-    if (!playerEntities.isEmpty()) {
+    if (!this.playerEntities.isEmpty()) {
       return world.getSingleplayerPlayerUuid()
-        .flatMap(uuid -> playerEntities.stream()
+        .flatMap(uuid -> this.playerEntities.stream()
           .filter(player -> player.uuid.equals(uuid))
           .map(pos -> new Vector3(pos.x, pos.y, pos.z))
           .findFirst());
     } else {
       return Optional.empty();
     }
-  }
-
-  public void setSpawnPos(@Nullable Vector3i spawnPos) {
-    this.spawnPos = spawnPos;
   }
 
   /**
@@ -118,15 +122,6 @@ public class JavaDimension extends Dimension {
     synchronized (this) {
       regionMap.computeIfAbsent(pos.getLong(), p -> createRegion(pos));
     }
-  }
-
-  /**
-   * Get the data directory for the given dimension.
-   *
-   * @return File object pointing to the data directory
-   */
-  protected synchronized File getDimensionDirectory() {
-    return dimensionDirectory;
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaDimension.java
@@ -54,7 +54,7 @@ public class JavaDimension extends Dimension {
     return regionMap.computeIfAbsent(pos.getLong(), p -> {
       // check if the region is present in the world directory
       Region region = EmptyRegion.instance;
-      if (regionExists(pos)) {
+      if (hasRegion(pos)) {
         region = createRegion(pos);
       }
       return region;

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -1,0 +1,217 @@
+package se.llbit.chunky.world.java;
+
+import se.llbit.chunky.world.*;
+import se.llbit.log.Log;
+import se.llbit.math.Vector3i;
+import se.llbit.nbt.NamedTag;
+import se.llbit.nbt.Tag;
+import se.llbit.util.MinecraftText;
+import se.llbit.util.UuidUtil;
+import se.llbit.util.annotation.NotNull;
+
+import java.io.*;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+public class JavaWorld extends World {
+  /** The currently supported NBT version of level.dat files. */
+  public static final int NBT_VERSION = 19133;
+
+  /** Minimum level.dat data version of tall worlds (21w06a). */
+  public static final int VERSION_21W06A = 2694;
+  public static final int VERSION_1_12_2 = 1343;
+
+  protected final int versionId;
+  protected UUID singleplayerPlayerUuid;
+
+  public Optional<UUID> getSingleplayerPlayerUuid() {
+    return Optional.ofNullable(singleplayerPlayerUuid);
+  }
+
+  /**
+   * @param levelName      name of the world (not the world directory).
+   * @param worldDirectory Minecraft world directory.
+   * @param seed
+   * @param timestamp
+   */
+  protected JavaWorld(String levelName, File worldDirectory, long seed, long timestamp, int versionId) {
+    super(levelName, worldDirectory, seed, timestamp);
+    this.versionId = versionId;
+  }
+
+  /**
+   * Parse player location and level name.
+   *
+   * @return {@code true} if the world data was loaded
+   */
+  public static World loadWorld(File worldDirectory, Dimension.Identifier dimensionId, LoggedWarnings warnings) {
+    if (worldDirectory == null) {
+      return EmptyWorld.INSTANCE;
+    }
+    String levelName = worldDirectory.getName(); // Default level name.
+    File worldFile = new File(worldDirectory, "level.dat");
+    long modtime = worldFile.lastModified();
+    try (FileInputStream fin = new FileInputStream(worldFile);
+         InputStream gzin = new GZIPInputStream(fin);
+         DataInputStream in = new DataInputStream(gzin)) {
+      Set<String> request = new HashSet<>();
+      request.add(".Data.version");
+      request.add(".Data.Version.Id");
+      request.add(".Data.RandomSeed");
+      request.add(".Data.Player");
+      request.add(".Data.singleplayer_uuid");
+      request.add(".Data.LevelName");
+      request.add(".Data.GameType");
+      request.add(".Data.isCubicWorld");
+      Map<String, Tag> result = NamedTag.quickParse(in, request);
+
+      Tag version = result.get(".Data.version");
+      if (warnings == LoggedWarnings.NORMAL && version.intValue() != NBT_VERSION) {
+        Log.warnf("The world format for the world %s is not supported by Chunky.\n" + "Will attempt to load the world anyway.",
+          levelName);
+      }
+      Tag versionId = result.get(".Data.Version.Id");
+      Tag player = result.get(".Data.Player");
+      Tag spawnX = player.get("SpawnX");
+      Tag spawnY = player.get("SpawnY");
+      Tag spawnZ = player.get("SpawnZ");
+      Tag singleplayerUuid = result.get(".Data.singleplayer_uuid");
+      Tag gameType = result.get(".Data.GameType");
+      Tag randomSeed = result.get(".Data.RandomSeed");
+      levelName = MinecraftText.removeFormatChars(result.get(".Data.LevelName").stringValue(levelName));
+
+      long seed = randomSeed.longValue(0);
+
+      Set<PlayerEntityData> playerEntities = getPlayerEntityData(worldDirectory, dimensionId, player);
+
+      JavaWorld world = new JavaWorld(levelName, worldDirectory, seed, modtime, versionId.intValue());
+      world.gameMode = gameType.intValue(0);
+      if (singleplayerUuid.isIntArray(4)) {
+        world.singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
+      } else if (!player.isError()) {
+        world.singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
+      }
+
+      JavaDimension dimension = (JavaDimension) loadDimension(world, worldDirectory, dimensionId, playerEntities);
+
+      boolean haveSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
+      if (haveSpawnPos) {
+        dimension.setSpawnPos(new Vector3i(spawnX.intValue(0), spawnY.intValue(0), spawnZ.intValue(0)));
+      }
+
+      world.currentDimension = dimension;
+
+      return world;
+    } catch (FileNotFoundException e) {
+      if (warnings == LoggedWarnings.NORMAL) {
+        Log.infof("Could not find level.dat file for world %s!", levelName);
+      }
+    } catch (IOException e) {
+      if (warnings == LoggedWarnings.NORMAL) {
+        Log.infof("Could not read the level.dat file for world %s!", levelName);
+      }
+    }
+    return EmptyWorld.INSTANCE;
+  }
+
+  @Override
+  public void loadDimension(Dimension.Identifier dimensionId) {
+    currentDimension = loadDimension(this, this.worldDirectory, dimensionId, Collections.emptySet());
+    currentDimension.reloadPlayerData();
+  }
+
+  @NotNull
+  private static Dimension loadDimension(JavaWorld world, File worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities) {
+    File dimensionDirectory = Path.of(worldDirectory.getPath(), "dimensions", dimensionId.namespace(), dimensionId.name()).toFile();
+    if (dimensionDirectory.exists()) {
+      // 26.1-snapshot-6 or later
+      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities);
+    }
+
+    dimensionDirectory = switch (dimensionId.getNamespacedName()) { // TODO in Java 21+ we can use `switch (dimensionId)` here
+      case "minecraft:the_nether" -> new File(worldDirectory, "DIM-1");
+      case "minecraft:the_end" -> new File(worldDirectory, "DIM1");
+      default -> worldDirectory;
+    };
+    if (new File(dimensionDirectory, "region3d").exists()) {
+      return new CubicDimension(world, dimensionId, dimensionDirectory, playerEntities);
+    } else {
+      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities);
+    }
+  }
+
+  @NotNull
+  private static Set<PlayerEntityData> getPlayerEntityData(File worldDirectory, Dimension.Identifier dimensionId, Tag player) {
+    Set<PlayerEntityData> playerEntities = new HashSet<>();
+    if (!player.isError()) {
+      playerEntities.add(new PlayerEntityData(player));
+    }
+    loadAdditionalPlayers(worldDirectory, playerEntities);
+    // Filter for the players only within the requested dimension
+    playerEntities = playerEntities.stream().filter(playerData -> playerData.dimension.equals(dimensionId)).collect(Collectors.toSet());
+    return playerEntities;
+  }
+
+  private static void loadAdditionalPlayers(File worldDirectory, Set<PlayerEntityData> playerEntities) {
+    loadPlayerData(new File(worldDirectory, "players"), playerEntities);
+    loadPlayerData(new File(worldDirectory, "playerdata"), playerEntities);
+    loadPlayerData(new File(new File(worldDirectory, "players"), "data"), playerEntities); // 26.1-snapshot-6 or later
+  }
+
+  private static void loadPlayerData(File playerdata, Set<PlayerEntityData> playerEntities) {
+    if (playerdata.isDirectory()) {
+      File[] players = playerdata.listFiles();
+      if (players != null) {
+        for (File player : players) {
+          try (DataInputStream in = new DataInputStream(
+            new GZIPInputStream(new FileInputStream(player)))) {
+            playerEntities.add(new PlayerEntityData(NamedTag.read(in).unpack()));
+          } catch (IOException e) {
+            Log.infof("Could not read player data file '%s'", player.getAbsolutePath());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Reload player data for the current dimension. This method is not in Dimension because players are per-world, not per-dimension
+   * @return {@code true} if player data was reloaded.
+   */
+  synchronized boolean reloadPlayerData() {
+    if (worldDirectory == null) {
+      return false;
+    }
+    File worldFile = new File(worldDirectory, "level.dat");
+    long lastModified = worldFile.lastModified();
+    if (lastModified == timestamp) {
+      return false;
+    }
+    Log.infof("world %s: timestamp updated: reading player data", levelName);
+    timestamp = lastModified;
+
+    try (FileInputStream fin = new FileInputStream(worldFile);
+         InputStream gzin = new GZIPInputStream(fin);
+         DataInputStream in = new DataInputStream(gzin)) {
+      Set<String> request = new HashSet<>();
+      request.add(".Data.Player");
+      request.add(".Data.singleplayer_uuid");
+      Map<String, Tag> result = NamedTag.quickParse(in, request);
+      Tag player = result.get(".Data.Player");
+      Tag singleplayerUuid = result.get(".Data.singleplayer_uuid");
+      if (singleplayerUuid.isIntArray(4)) {
+        singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
+      } else if (!player.isError()) {
+        singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
+      }
+
+      currentDimension.setPlayerEntities(getPlayerEntityData(worldDirectory, currentDimension.getDimensionId(), player));
+    } catch (IOException e) {
+      Log.infof("Could not read the level.dat file for world %s while trying to reload player data!", levelName);
+      return false;
+    }
+    return true;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -24,7 +24,7 @@ public class JavaWorld extends World {
   public static final int VERSION_21W06A = 2694;
   public static final int VERSION_1_12_2 = 1343;
 
-  protected int versionId;
+  protected final int versionId;
 
   /**
    * In a java world spawn position is per-world and not per-dimension, so we store it here.
@@ -37,10 +37,6 @@ public class JavaWorld extends World {
   protected final Collection<PlayerEntityData> playerEntities;
 
   protected UUID singleplayerPlayerUuid;
-
-  public Optional<UUID> getSingleplayerPlayerUuid() {
-    return Optional.ofNullable(singleplayerPlayerUuid);
-  }
 
   /** Timestamp of when player data was last loaded. */
   protected long playerDataTimestamp;
@@ -176,6 +172,10 @@ public class JavaWorld extends World {
     } else {
       return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     }
+  }
+
+  public Optional<UUID> getSingleplayerPlayerUuid() {
+    return Optional.ofNullable(singleplayerPlayerUuid);
   }
 
   @NotNull

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -129,7 +129,7 @@ public class JavaWorld extends World {
   }
 
   @Override
-  public Set<Dimension.Identifier> availableDimensions() {
+  public Set<Dimension.Identifier> getAvailableDimensions() {
     return Set.of(Dimension.Identifier.OVERWORLD,
       Dimension.Identifier.THE_NETHER,
       Dimension.Identifier.THE_END
@@ -137,7 +137,7 @@ public class JavaWorld extends World {
   }
 
   @Override
-  public Optional<Dimension.Identifier> defaultDimension() {
+  public Optional<Dimension.Identifier> getDefaultDimension() {
     return Optional.empty();
   }
 
@@ -246,7 +246,7 @@ public class JavaWorld extends World {
     return true;
   }
 
-  public static boolean isWorldDir(File worldDir) {
+  public static boolean isWorldDirectory(File worldDir) {
     if (worldDir != null && worldDir.isDirectory()) {
       File levelDat = new File(worldDir, "level.dat");
       return levelDat.exists() && levelDat.isFile();

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -249,12 +249,4 @@ public class JavaWorld extends World {
     }
     return true;
   }
-
-  public static boolean isWorldDirectory(File worldDir) {
-    if (worldDir != null && worldDir.isDirectory()) {
-      File levelDat = new File(worldDir, "level.dat");
-      return levelDat.exists() && levelDat.isFile();
-    }
-    return false;
-  }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -8,6 +8,7 @@ import se.llbit.nbt.Tag;
 import se.llbit.util.MinecraftText;
 import se.llbit.util.UuidUtil;
 import se.llbit.util.annotation.NotNull;
+import se.llbit.util.annotation.Nullable;
 
 import java.io.*;
 import java.nio.file.Path;
@@ -23,7 +24,18 @@ public class JavaWorld extends World {
   public static final int VERSION_21W06A = 2694;
   public static final int VERSION_1_12_2 = 1343;
 
-  protected final int versionId;
+  protected int versionId;
+
+  /**
+   * In a java world spawn position is per-world and not per-dimension, so we store it here.
+   */
+  protected final Vector3i spawnPos;
+
+  /**
+   * In a java world player data is per-world and not per-dimension, so we store it here.
+   */
+  protected final Collection<PlayerEntityData> playerEntities;
+
   protected UUID singleplayerPlayerUuid;
 
   public Optional<UUID> getSingleplayerPlayerUuid() {
@@ -36,9 +48,11 @@ public class JavaWorld extends World {
    * @param seed
    * @param timestamp
    */
-  protected JavaWorld(String levelName, File worldDirectory, long seed, long timestamp, int versionId) {
+  protected JavaWorld(String levelName, File worldDirectory, long seed, long timestamp, int versionId, Set<PlayerEntityData> playerEntities, Vector3i spawnPos) {
     super(levelName, worldDirectory, seed, timestamp);
     this.versionId = versionId;
+    this.playerEntities = playerEntities;
+    this.spawnPos = spawnPos;
   }
 
   /**
@@ -84,9 +98,15 @@ public class JavaWorld extends World {
 
       long seed = randomSeed.longValue(0);
 
-      Set<PlayerEntityData> playerEntities = getPlayerEntityData(worldDirectory, dimensionId, player);
+      Set<PlayerEntityData> playerEntities = getPlayerEntityData(worldDirectory, player);
 
-      JavaWorld world = new JavaWorld(levelName, worldDirectory, seed, modtime, versionId.intValue());
+      boolean haveSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
+      Vector3i spawnPos = new Vector3i();
+      if (haveSpawnPos) {
+        spawnPos = new Vector3i(spawnX.intValue(0), spawnY.intValue(0), spawnZ.intValue(0));
+      }
+
+      JavaWorld world = new JavaWorld(levelName, worldDirectory, seed, modtime, versionId.intValue(), playerEntities, spawnPos);
       world.gameMode = gameType.intValue(0);
       if (singleplayerUuid.isIntArray(4)) {
         world.singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
@@ -94,14 +114,7 @@ public class JavaWorld extends World {
         world.singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
       }
 
-      JavaDimension dimension = (JavaDimension) loadDimension(world, worldDirectory, dimensionId, playerEntities);
-
-      boolean haveSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
-      if (haveSpawnPos) {
-        dimension.setSpawnPos(new Vector3i(spawnX.intValue(0), spawnY.intValue(0), spawnZ.intValue(0)));
-      }
-
-      world.currentDimension = dimension;
+      world.currentDimension = loadDimension(world, worldDirectory, dimensionId, playerEntities, spawnPos);
 
       return world;
     } catch (FileNotFoundException e) {
@@ -117,17 +130,32 @@ public class JavaWorld extends World {
   }
 
   @Override
-  public void loadDimension(Dimension.Identifier dimensionId) {
-    currentDimension = loadDimension(this, this.worldDirectory, dimensionId, Collections.emptySet());
+  public Set<Dimension.Identifier> listDimensions() {
+    return Set.of(Dimension.Identifier.OVERWORLD,
+      Dimension.Identifier.THE_NETHER,
+      Dimension.Identifier.THE_END
+    );
+  }
+
+  @Override
+  public Dimension loadDimension(Dimension.Identifier dimensionId) {
+    currentDimension = loadDimension(
+      this,
+      this.worldDirectory,
+      dimensionId,
+      this.playerEntities.stream().filter(player -> player.dimension.equals(dimensionId)).collect(Collectors.toSet()),
+      this.spawnPos
+    );
     currentDimension.reloadPlayerData();
+    return currentDimension;
   }
 
   @NotNull
-  private static Dimension loadDimension(JavaWorld world, File worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities) {
+  private static Dimension loadDimension(JavaWorld world, File worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
     File dimensionDirectory = Path.of(worldDirectory.getPath(), "dimensions", dimensionId.namespace(), dimensionId.name()).toFile();
     if (dimensionDirectory.exists()) {
       // 26.1-snapshot-6 or later
-      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities);
+      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     }
 
     dimensionDirectory = switch (dimensionId.getNamespacedName()) { // TODO in Java 21+ we can use `switch (dimensionId)` here
@@ -136,21 +164,19 @@ public class JavaWorld extends World {
       default -> worldDirectory;
     };
     if (new File(dimensionDirectory, "region3d").exists()) {
-      return new CubicDimension(world, dimensionId, dimensionDirectory, playerEntities);
+      return new CubicDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     } else {
-      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities);
+      return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     }
   }
 
   @NotNull
-  private static Set<PlayerEntityData> getPlayerEntityData(File worldDirectory, Dimension.Identifier dimensionId, Tag player) {
+  private static Set<PlayerEntityData> getPlayerEntityData(File worldDirectory, Tag player) {
     Set<PlayerEntityData> playerEntities = new HashSet<>();
     if (!player.isError()) {
       playerEntities.add(new PlayerEntityData(player));
     }
     loadAdditionalPlayers(worldDirectory, playerEntities);
-    // Filter for the players only within the requested dimension
-    playerEntities = playerEntities.stream().filter(playerData -> playerData.dimension.equals(dimensionId)).collect(Collectors.toSet());
     return playerEntities;
   }
 
@@ -207,11 +233,20 @@ public class JavaWorld extends World {
         singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
       }
 
-      currentDimension.setPlayerEntities(getPlayerEntityData(worldDirectory, currentDimension.getDimensionId(), player));
+      this.playerEntities.clear();
+      this.playerEntities.addAll(getPlayerEntityData(worldDirectory, player));
     } catch (IOException e) {
       Log.infof("Could not read the level.dat file for world %s while trying to reload player data!", levelName);
       return false;
     }
     return true;
+  }
+
+  public static boolean isWorldDir(File worldDir) {
+    if (worldDir != null && worldDir.isDirectory()) {
+      File levelDat = new File(worldDir, "level.dat");
+      return levelDat.exists() && levelDat.isFile();
+    }
+    return false;
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -60,7 +60,7 @@ public class JavaWorld extends World {
    *
    * @return {@code true} if the world data was loaded
    */
-  public static World loadWorld(File worldDirectory, Dimension.Identifier dimensionId, LoggedWarnings warnings) {
+  public static World loadWorld(File worldDirectory, LoggedWarnings warnings) {
     if (worldDirectory == null) {
       return EmptyWorld.INSTANCE;
     }
@@ -108,13 +108,12 @@ public class JavaWorld extends World {
 
       JavaWorld world = new JavaWorld(levelName, worldDirectory, seed, modtime, versionId.intValue(), playerEntities, spawnPos);
       world.gameMode = gameType.intValue(0);
+
       if (singleplayerUuid.isIntArray(4)) {
         world.singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
       } else if (!player.isError()) {
         world.singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
       }
-
-      world.currentDimension = loadDimension(world, worldDirectory, dimensionId, playerEntities, spawnPos);
 
       return world;
     } catch (FileNotFoundException e) {
@@ -130,11 +129,16 @@ public class JavaWorld extends World {
   }
 
   @Override
-  public Set<Dimension.Identifier> listDimensions() {
+  public Set<Dimension.Identifier> availableDimensions() {
     return Set.of(Dimension.Identifier.OVERWORLD,
       Dimension.Identifier.THE_NETHER,
       Dimension.Identifier.THE_END
     );
+  }
+
+  @Override
+  public Optional<Dimension.Identifier> defaultDimension() {
+    return Optional.empty();
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -42,6 +42,9 @@ public class JavaWorld extends World {
     return Optional.ofNullable(singleplayerPlayerUuid);
   }
 
+  /** Timestamp of when player data was last loaded. */
+  protected long playerDataTimestamp;
+
   /**
    * @param levelName      name of the world (not the world directory).
    * @param worldDirectory Minecraft world directory.
@@ -49,10 +52,11 @@ public class JavaWorld extends World {
    * @param timestamp
    */
   protected JavaWorld(String levelName, File worldDirectory, long seed, long timestamp, int versionId, Set<PlayerEntityData> playerEntities, Vector3i spawnPos) {
-    super(levelName, worldDirectory, seed, timestamp);
+    super(levelName, worldDirectory, seed);
     this.versionId = versionId;
     this.playerEntities = playerEntities;
     this.spawnPos = spawnPos;
+    this.playerDataTimestamp = timestamp;
   }
 
   /**
@@ -216,11 +220,11 @@ public class JavaWorld extends World {
     }
     File worldFile = new File(worldDirectory, "level.dat");
     long lastModified = worldFile.lastModified();
-    if (lastModified == timestamp) {
+    if (lastModified == playerDataTimestamp) {
       return false;
     }
     Log.infof("world %s: timestamp updated: reading player data", levelName);
-    timestamp = lastModified;
+    playerDataTimestamp = lastModified;
 
     try (FileInputStream fin = new FileInputStream(worldFile);
          InputStream gzin = new GZIPInputStream(fin);

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorld.java
@@ -11,8 +11,11 @@ import se.llbit.util.annotation.NotNull;
 import se.llbit.util.annotation.Nullable;
 
 import java.io.*;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
@@ -41,96 +44,65 @@ public class JavaWorld extends World {
   /** Timestamp of when player data was last loaded. */
   protected long playerDataTimestamp;
 
-  /**
-   * @param levelName      name of the world (not the world directory).
-   * @param worldDirectory Minecraft world directory.
-   * @param seed
-   * @param timestamp
-   */
-  protected JavaWorld(String levelName, File worldDirectory, long seed, long timestamp, int versionId, Set<PlayerEntityData> playerEntities, Vector3i spawnPos) {
-    super(levelName, worldDirectory, seed);
+  protected JavaWorld(Info info, long timestamp, int versionId, Set<PlayerEntityData> playerEntities, Vector3i spawnPos) {
+    super(info);
     this.versionId = versionId;
     this.playerEntities = playerEntities;
     this.spawnPos = spawnPos;
     this.playerDataTimestamp = timestamp;
   }
 
-  /**
-   * Parse player location and level name.
-   *
-   * @return {@code true} if the world data was loaded
-   */
-  public static World loadWorld(File worldDirectory, LoggedWarnings warnings) {
-    if (worldDirectory == null) {
-      return EmptyWorld.INSTANCE;
-    }
-    String levelName = worldDirectory.getName(); // Default level name.
-    File worldFile = new File(worldDirectory, "level.dat");
-    long modtime = worldFile.lastModified();
-    try (FileInputStream fin = new FileInputStream(worldFile);
-         InputStream gzin = new GZIPInputStream(fin);
-         DataInputStream in = new DataInputStream(gzin)) {
-      Set<String> request = new HashSet<>();
-      request.add(".Data.version");
-      request.add(".Data.Version.Id");
-      request.add(".Data.RandomSeed");
-      request.add(".Data.Player");
-      request.add(".Data.singleplayer_uuid");
-      request.add(".Data.LevelName");
-      request.add(".Data.GameType");
-      request.add(".Data.isCubicWorld");
-      Map<String, Tag> result = NamedTag.quickParse(in, request);
+  public static Optional<World.Info> loadWorldInfo(@NotNull Path worldDirectory, LoggedWarnings warnings, JavaWorldFormat format) {
+    return readWorldData(worldDirectory, warnings, data -> {
+      Tag gameType = data.tags.get(".Data.GameType");
+      String gameMode = switch (gameType.intValue(0)) {
+        case 0 -> "Survival";
+        case 1 -> "Creative";
+        case 2 -> "Adventure";
+        default -> "Unknown";
+      };
+      Tag randomSeed = data.tags.get(".Data.RandomSeed");
 
-      Tag version = result.get(".Data.version");
-      if (warnings == LoggedWarnings.NORMAL && version.intValue() != NBT_VERSION) {
-        Log.warnf("The world format for the world %s is not supported by Chunky.\n" + "Will attempt to load the world anyway.",
-          levelName);
-      }
-      Tag versionId = result.get(".Data.Version.Id");
-      Tag player = result.get(".Data.Player");
-      Tag spawnX = player.get("SpawnX");
-      Tag spawnY = player.get("SpawnY");
-      Tag spawnZ = player.get("SpawnZ");
-      Tag singleplayerUuid = result.get(".Data.singleplayer_uuid");
-      Tag gameType = result.get(".Data.GameType");
-      Tag randomSeed = result.get(".Data.RandomSeed");
-      levelName = MinecraftText.removeFormatChars(result.get(".Data.LevelName").stringValue(levelName));
+      String levelName = MinecraftText.removeFormatChars(data.tags.get(".Data.LevelName").stringValue(data.levelName));
 
       long seed = randomSeed.longValue(0);
 
-      Set<PlayerEntityData> playerEntities = getPlayerEntityData(worldDirectory, player);
+      return new Info(levelName, worldDirectory, data.modTime, seed, gameMode, format);
+    });
+  }
 
-      boolean haveSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
+  public static World loadWorld(Info info, LoggedWarnings warnings) {
+    return readWorldData(info.path(), warnings, data -> {
+      Tag versionId = data.tags.get(".Data.Version.Id");
+
+      Tag player = data.tags.get(".Data.Player");
+      Set<PlayerEntityData> playerEntities = getPlayerEntityData(info.path(), player);
+
+      Tag spawnX = player.get("SpawnX");
+      Tag spawnY = player.get("SpawnY");
+      Tag spawnZ = player.get("SpawnZ");
+      boolean hasSpawnPos = !(spawnX.isError() || spawnY.isError() || spawnZ.isError());
       Vector3i spawnPos = new Vector3i();
-      if (haveSpawnPos) {
+      if (hasSpawnPos) {
         spawnPos = new Vector3i(spawnX.intValue(0), spawnY.intValue(0), spawnZ.intValue(0));
       }
 
-      JavaWorld world = new JavaWorld(levelName, worldDirectory, seed, modtime, versionId.intValue(), playerEntities, spawnPos);
-      world.gameMode = gameType.intValue(0);
+      JavaWorld world = new JavaWorld(info, data.modTime, versionId.intValue(), playerEntities, spawnPos);
 
+      Tag singleplayerUuid = data.tags.get(".Data.singleplayer_uuid");
       if (singleplayerUuid.isIntArray(4)) {
         world.singleplayerPlayerUuid = UuidUtil.intsToUuid(singleplayerUuid.intArray());
       } else if (!player.isError()) {
         world.singleplayerPlayerUuid = PlayerEntityData.getUuid(player);
       }
 
-      return world;
-    } catch (FileNotFoundException e) {
-      if (warnings == LoggedWarnings.NORMAL) {
-        Log.infof("Could not find level.dat file for world %s!", levelName);
-      }
-    } catch (IOException e) {
-      if (warnings == LoggedWarnings.NORMAL) {
-        Log.infof("Could not read the level.dat file for world %s!", levelName);
-      }
-    }
-    return EmptyWorld.INSTANCE;
+      return (World) world;
+    }).orElse(EmptyWorld.INSTANCE);
   }
 
   @Override
   public Set<Dimension.Identifier> getAvailableDimensions() {
-    return Set.of(Dimension.Identifier.OVERWORLD,
+    return Set.of(Dimension.Identifier.OVERWORLD, // TODO: return the actual set of dimensions on disk.
       Dimension.Identifier.THE_NETHER,
       Dimension.Identifier.THE_END
     );
@@ -145,7 +117,7 @@ public class JavaWorld extends World {
   public Dimension loadDimension(Dimension.Identifier dimensionId) {
     currentDimension = loadDimension(
       this,
-      this.worldDirectory,
+      getInfo().path(),
       dimensionId,
       this.playerEntities.stream().filter(player -> player.dimension.equals(dimensionId)).collect(Collectors.toSet()),
       this.spawnPos
@@ -155,19 +127,19 @@ public class JavaWorld extends World {
   }
 
   @NotNull
-  private static Dimension loadDimension(JavaWorld world, File worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
-    File dimensionDirectory = Path.of(worldDirectory.getPath(), "dimensions", dimensionId.namespace(), dimensionId.name()).toFile();
-    if (dimensionDirectory.exists()) {
+  private static Dimension loadDimension(JavaWorld world, Path worldDirectory, Dimension.Identifier dimensionId, Set<PlayerEntityData> playerEntities, @Nullable Vector3i spawnPos) {
+    Path dimensionDirectory = worldDirectory.resolve("dimensions").resolve(dimensionId.namespace()).resolve(dimensionId.name());
+    if (Files.exists(dimensionDirectory)) {
       // 26.1-snapshot-6 or later
       return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     }
 
     dimensionDirectory = switch (dimensionId.getNamespacedName()) { // TODO in Java 21+ we can use `switch (dimensionId)` here
-      case "minecraft:the_nether" -> new File(worldDirectory, "DIM-1");
-      case "minecraft:the_end" -> new File(worldDirectory, "DIM1");
+      case "minecraft:the_nether" -> worldDirectory.resolve("DIM-1");
+      case "minecraft:the_end" -> worldDirectory.resolve("DIM1");
       default -> worldDirectory;
     };
-    if (new File(dimensionDirectory, "region3d").exists()) {
+    if (Files.isDirectory(dimensionDirectory.resolve("region3d"))) {
       return new CubicDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
     } else {
       return new JavaDimension(world, dimensionId, dimensionDirectory, playerEntities, spawnPos);
@@ -179,7 +151,7 @@ public class JavaWorld extends World {
   }
 
   @NotNull
-  private static Set<PlayerEntityData> getPlayerEntityData(File worldDirectory, Tag player) {
+  private static Set<PlayerEntityData> getPlayerEntityData(Path worldDirectory, Tag player) {
     Set<PlayerEntityData> playerEntities = new HashSet<>();
     if (!player.isError()) {
       playerEntities.add(new PlayerEntityData(player));
@@ -188,24 +160,25 @@ public class JavaWorld extends World {
     return playerEntities;
   }
 
-  private static void loadAdditionalPlayers(File worldDirectory, Set<PlayerEntityData> playerEntities) {
-    loadPlayerData(new File(worldDirectory, "players"), playerEntities);
-    loadPlayerData(new File(worldDirectory, "playerdata"), playerEntities);
-    loadPlayerData(new File(new File(worldDirectory, "players"), "data"), playerEntities); // 26.1-snapshot-6 or later
+  private static void loadAdditionalPlayers(Path worldDirectory, Set<PlayerEntityData> playerEntities) {
+    loadPlayerData(worldDirectory.resolve("players"), playerEntities);
+    loadPlayerData(worldDirectory.resolve("playerdata"), playerEntities);
+    loadPlayerData(worldDirectory.resolve("players").resolve("data"), playerEntities); // 26.1-snapshot-6 or later
   }
 
-  private static void loadPlayerData(File playerdata, Set<PlayerEntityData> playerEntities) {
-    if (playerdata.isDirectory()) {
-      File[] players = playerdata.listFiles();
-      if (players != null) {
-        for (File player : players) {
+  private static void loadPlayerData(Path playerDataDirectory, Set<PlayerEntityData> playerEntities) {
+    if (Files.isDirectory(playerDataDirectory)) {
+      try (DirectoryStream<Path> paths = Files.newDirectoryStream(playerDataDirectory)) {
+        for (Path player : paths) {
           try (DataInputStream in = new DataInputStream(
-            new GZIPInputStream(new FileInputStream(player)))) {
+            new GZIPInputStream(new FileInputStream(player.toFile())))) {
             playerEntities.add(new PlayerEntityData(NamedTag.read(in).unpack()));
           } catch (IOException e) {
-            Log.infof("Could not read player data file '%s'", player.getAbsolutePath());
+            Log.infof("Could not read player data file '%s'", player.toAbsolutePath());
           }
         }
+      } catch (IOException e) {
+        Log.infof("Could not list player data directory '%s'", playerDataDirectory.toAbsolutePath());
       }
     }
   }
@@ -215,18 +188,20 @@ public class JavaWorld extends World {
    * @return {@code true} if player data was reloaded.
    */
   synchronized boolean reloadPlayerData() {
-    if (worldDirectory == null) {
+    Path worldFile = getInfo().path().resolve("level.dat");
+    long lastModified;
+    try {
+      lastModified = Files.getLastModifiedTime(worldFile).toMillis();
+    } catch (IOException e) {
       return false;
     }
-    File worldFile = new File(worldDirectory, "level.dat");
-    long lastModified = worldFile.lastModified();
     if (lastModified == playerDataTimestamp) {
       return false;
     }
-    Log.infof("world %s: timestamp updated: reading player data", levelName);
+    Log.infof("world %s: timestamp updated: reading player data", getInfo().name());
     playerDataTimestamp = lastModified;
 
-    try (FileInputStream fin = new FileInputStream(worldFile);
+    try (FileInputStream fin = new FileInputStream(worldFile.toFile());
          InputStream gzin = new GZIPInputStream(fin);
          DataInputStream in = new DataInputStream(gzin)) {
       Set<String> request = new HashSet<>();
@@ -242,11 +217,49 @@ public class JavaWorld extends World {
       }
 
       this.playerEntities.clear();
-      this.playerEntities.addAll(getPlayerEntityData(worldDirectory, player));
+      this.playerEntities.addAll(getPlayerEntityData(getInfo().path(), player));
     } catch (IOException e) {
-      Log.infof("Could not read the level.dat file for world %s while trying to reload player data!", levelName);
+      Log.infof("Could not read the level.dat file for world %s while trying to reload player data!", getInfo().name());
       return false;
     }
     return true;
+  }
+
+  private record WorldData(String levelName, long modTime, Map<String, Tag> tags) {}
+  private static <T> Optional<T> readWorldData(@NotNull Path worldDirectory, LoggedWarnings warnings, Function<WorldData, T> consumer) {
+    String levelName = worldDirectory.getFileName().toString();
+    Path levelDat = worldDirectory.resolve("level.dat");
+    try (FileInputStream fin = new FileInputStream(levelDat.toFile());
+         InputStream gzin = new GZIPInputStream(fin);
+         DataInputStream in = new DataInputStream(gzin)) {
+      long modtime = Files.getLastModifiedTime(levelDat).toMillis();
+      Set<String> request = new HashSet<>();
+      request.add(".Data.version");
+      request.add(".Data.Version.Id");
+      request.add(".Data.RandomSeed");
+      request.add(".Data.Player");
+      request.add(".Data.singleplayer_uuid");
+      request.add(".Data.LevelName");
+      request.add(".Data.GameType");
+
+      Map<String, Tag> result = NamedTag.quickParse(in, request);
+
+      Tag version = result.get(".Data.version");
+      if (warnings == LoggedWarnings.NORMAL && version.intValue() != NBT_VERSION) {
+        Log.warnf("The world format for the world %s is not supported by Chunky.\n" + "Will attempt to load the world anyway.",
+          levelName);
+      }
+
+      return Optional.of(consumer.apply(new WorldData(levelName, modtime, result)));
+    } catch (FileNotFoundException e) {
+      if (warnings == LoggedWarnings.NORMAL) {
+        Log.infof("Could not find level.dat file for world %s!", levelName);
+      }
+    } catch (IOException e) {
+      if (warnings == LoggedWarnings.NORMAL) {
+        Log.infof("Could not read the level.dat file for world %s!", levelName);
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
@@ -24,7 +24,7 @@ public class JavaWorldFormat implements WorldFormat {
 
   @Override
   public boolean isValid(Path path) {
-    return JavaWorld.isWorldDir(path.toFile());
+    return JavaWorld.isWorldDirectory(path.toFile());
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
@@ -4,6 +4,7 @@ import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.worldformat.WorldFormat;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class JavaWorldFormat implements WorldFormat {
@@ -24,7 +25,11 @@ public class JavaWorldFormat implements WorldFormat {
 
   @Override
   public boolean isValid(Path path) {
-    return JavaWorld.isWorldDirectory(path.toFile());
+    if (Files.isDirectory(path)) {
+      Path levelDat = path.resolve("level.dat");
+      return Files.exists(levelDat) && Files.isRegularFile(levelDat);
+    }
+    return false;
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
@@ -4,14 +4,17 @@ import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.worldformat.WorldFormat;
 import se.llbit.util.annotation.NotNull;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 public class JavaWorldFormat implements WorldFormat {
+  public static final String NAME = "Java (Anvil)";
+  public static final String ID = "JAVA_ANVIL";
+
   @Override
   public String getName() {
-    return "Java (Anvil)";
+    return NAME;
   }
 
   @Override
@@ -21,7 +24,7 @@ public class JavaWorldFormat implements WorldFormat {
 
   @Override
   public String getId() {
-    return "JAVA_ANVIL";
+    return ID;
   }
 
   @Override
@@ -33,8 +36,23 @@ public class JavaWorldFormat implements WorldFormat {
     return false;
   }
 
+  @NotNull
   @Override
-  public World loadWorld(@NotNull Path path) throws IOException {
-    return JavaWorld.loadWorld(path.toFile(), World.LoggedWarnings.SILENT);
+  public Optional<World.Info> getWorldInfo(@NotNull Path path) {
+    if (!Files.isDirectory(path)) {
+      return Optional.empty();
+    }
+    Path levelDat = path.resolve("level.dat");
+    if (!Files.exists(levelDat) || !Files.isRegularFile(levelDat)) {
+      return Optional.empty();
+    }
+
+    return JavaWorld.loadWorldInfo(path, World.LoggedWarnings.SILENT, this);
+  }
+
+  @NotNull
+  @Override
+  public World loadWorld(@NotNull World.Info info) {
+    return JavaWorld.loadWorld(info, World.LoggedWarnings.NORMAL);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
@@ -2,6 +2,7 @@ package se.llbit.chunky.world.java;
 
 import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.worldformat.WorldFormat;
+import se.llbit.util.annotation.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,7 +25,7 @@ public class JavaWorldFormat implements WorldFormat {
   }
 
   @Override
-  public boolean isValid(Path path) {
+  public boolean isValid(@NotNull Path path) {
     if (Files.isDirectory(path)) {
       Path levelDat = path.resolve("level.dat");
       return Files.exists(levelDat) && Files.isRegularFile(levelDat);
@@ -33,7 +34,7 @@ public class JavaWorldFormat implements WorldFormat {
   }
 
   @Override
-  public World loadWorld(Path path) throws IOException {
+  public World loadWorld(@NotNull Path path) throws IOException {
     return JavaWorld.loadWorld(path.toFile(), World.LoggedWarnings.SILENT);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/JavaWorldFormat.java
@@ -1,16 +1,25 @@
-package se.llbit.chunky.world.worldformat;
+package se.llbit.chunky.world.java;
 
-import se.llbit.chunky.world.Dimension;
-import se.llbit.chunky.world.java.JavaWorld;
 import se.llbit.chunky.world.World;
+import se.llbit.chunky.world.worldformat.WorldFormat;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 public class JavaWorldFormat implements WorldFormat {
   @Override
-  public String name() {
+  public String getName() {
     return "Java (Anvil)";
+  }
+
+  @Override
+  public String getDescription() {
+    return "The Minecraft world format for Java worlds since 1.2.1 (12w07a)";
+  }
+
+  @Override
+  public String getId() {
+    return "JAVA_ANVIL";
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegion.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
  */
-package se.llbit.chunky.world.region;
+package se.llbit.chunky.world.java.region;
 
 import java.io.*;
 import java.util.Iterator;
@@ -26,6 +26,8 @@ import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.world.*;
 import se.llbit.chunky.world.java.JavaChunk;
 import se.llbit.chunky.world.java.JavaDimension;
+import se.llbit.chunky.world.region.ChunkReadException;
+import se.llbit.chunky.world.region.Region;
 import se.llbit.log.Log;
 import se.llbit.nbt.ErrorTag;
 import se.llbit.nbt.NamedTag;
@@ -44,19 +46,8 @@ import se.llbit.util.annotation.Nullable;
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class MCRegion implements Region {
-
-  /**
-   * Region X chunk width
-   */
-  public static final int CHUNKS_X = 32;
-
-  /**
-   * Region Z chunk width
-   */
-  public static final int CHUNKS_Z = 32;
-
-  private static final int NUM_CHUNKS = CHUNKS_X * CHUNKS_Z;
+public class JavaRegion implements Region {
+  private static final int NUM_CHUNKS = Region.CHUNKS_X * Region.CHUNKS_Z;
 
   /**
    * Sector size in bytes.
@@ -82,12 +73,12 @@ public class MCRegion implements Region {
    *
    * @param pos the region position
    */
-  public MCRegion(RegionPosition pos, JavaDimension dimension) {
+  public JavaRegion(RegionPosition pos, JavaDimension dimension) {
     this.dimension = dimension;
     fileName = pos.getMcaName();
     position = pos;
-    for (int z = 0; z < CHUNKS_Z; ++z) {
-      for (int x = 0; x < CHUNKS_X; ++x) {
+    for (int z = 0; z < Region.CHUNKS_Z; ++z) {
+      for (int x = 0; x < Region.CHUNKS_X; ++x) {
         chunks[getMCAChunkIndex(x, z)] = EmptyChunk.INSTANCE;
       }
     }

--- a/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
@@ -21,6 +21,7 @@ import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.world.ChunkView;
+import se.llbit.chunky.world.HeightRange;
 import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.java.JavaDimension;
 import se.llbit.chunky.world.region.Region;
@@ -51,9 +52,10 @@ public class JavaRegionChangeWatcher extends RegionChangeWatcher {
         for (int rx = theView.prx0; rx <= theView.prx1; ++rx) {
           for (int rz = theView.prz0; rz <= theView.prz1; ++rz) {
             RegionPosition pos = new RegionPosition(rx, rz);
-            Region region = dimension.getRegionWithinRange(pos, theView.yMin, theView.yMax);
+            HeightRange heightRange = new HeightRange(theView.yMin, theView.yMax);
+            Region region = dimension.getRegionWithinRange(pos, heightRange);
             if (region.isEmpty()) {
-              if (dimension.regionExistsWithinRange(pos, theView.yMin, theView.yMax)) {
+              if (dimension.hasRegionWithinRange(pos, heightRange)) {
                 region = dimension.createRegion(pos);
               }
               dimension.setRegion(pos, region);

--- a/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
@@ -41,7 +41,7 @@ public class JavaRegionChangeWatcher extends RegionChangeWatcher {
     try {
       while (!isInterrupted()) {
         sleep(3000);
-        // MCRegionChangeWatcher is only created by JavaDimension, so this cast is always safe.
+        // RegionChangeWatcher is only created by JavaDimension, so this cast is always safe.
         JavaDimension dimension = (JavaDimension) mapLoader.getWorld().currentDimension();
         if (dimension.reloadPlayerData()) {
           if (PersistentSettings.getFollowPlayer()) {

--- a/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/java/region/JavaRegionChangeWatcher.java
@@ -14,25 +14,25 @@
  * You should have received a copy of the GNU General Public License
  * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
  */
-package se.llbit.chunky.world.region;
+package se.llbit.chunky.world.java.region;
 
 import javafx.application.Platform;
 import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
-import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.ChunkView;
-import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.java.JavaDimension;
+import se.llbit.chunky.world.region.Region;
+import se.llbit.chunky.world.region.RegionChangeWatcher;
 
 /**
  * Monitors filesystem for changes to region files.
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class MCRegionChangeWatcher extends RegionChangeWatcher {
-  public MCRegionChangeWatcher(WorldMapLoader loader, MapView mapView) {
+public class JavaRegionChangeWatcher extends RegionChangeWatcher {
+  public JavaRegionChangeWatcher(WorldMapLoader loader, MapView mapView) {
     super(loader, mapView, "Region Refresher");
   }
 

--- a/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
+++ b/chunky/src/java/se/llbit/chunky/world/listeners/ChunkUpdateListener.java
@@ -18,7 +18,7 @@ package se.llbit.chunky.world.listeners;
 
 import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.RegionPosition;
-import se.llbit.chunky.world.region.MCRegion;
+import se.llbit.chunky.world.region.Region;
 
 import java.util.Collection;
 
@@ -33,8 +33,8 @@ public interface ChunkUpdateListener {
   default void regionChunksUpdated(RegionPosition region) {
     int minChunkX = region.x << 5;
     int minChunkZ = region.z << 5;
-    for (int chunkX = minChunkX; chunkX < minChunkX + MCRegion.CHUNKS_X; chunkX++) {
-      for (int chunkZ = minChunkZ; chunkZ < minChunkZ + MCRegion.CHUNKS_Z; chunkZ++) {
+    for (int chunkX = minChunkX; chunkX < minChunkX + Region.CHUNKS_X; chunkX++) {
+      for (int chunkZ = minChunkZ; chunkZ < minChunkZ + Region.CHUNKS_Z; chunkZ++) {
         this.chunkUpdated(new ChunkPosition(chunkX, chunkZ));
       }
     }

--- a/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/MCRegion.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import se.llbit.chunky.chunk.ChunkLoadingException;
 import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.world.*;
+import se.llbit.chunky.world.java.JavaChunk;
+import se.llbit.chunky.world.java.JavaDimension;
 import se.llbit.log.Log;
 import se.llbit.nbt.ErrorTag;
 import se.llbit.nbt.NamedTag;
@@ -63,7 +65,7 @@ public class MCRegion implements Region {
 
   private final Chunk[] chunks = new Chunk[NUM_CHUNKS];
   private final RegionPosition position;
-  private final Dimension dimension;
+  private final JavaDimension dimension;
   private final String fileName;
   private long regionFileTime = 0;
   private final int[] chunkTimestamps = new int[NUM_CHUNKS];
@@ -80,7 +82,7 @@ public class MCRegion implements Region {
    *
    * @param pos the region position
    */
-  public MCRegion(RegionPosition pos, Dimension dimension) {
+  public MCRegion(RegionPosition pos, JavaDimension dimension) {
     this.dimension = dimension;
     fileName = pos.getMcaName();
     position = pos;
@@ -156,7 +158,7 @@ public class MCRegion implements Region {
           int loc = file.readInt();
           if (loc != 0) {
             if (chunk.isEmpty()) {
-              chunk = new Chunk(pos, dimension);
+              chunk = new JavaChunk(pos, dimension);
               setChunk(pos, chunk);
             }
           } else {

--- a/chunky/src/java/se/llbit/chunky/world/region/MCRegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/MCRegionChangeWatcher.java
@@ -24,6 +24,7 @@ import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.ChunkView;
 import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.RegionPosition;
+import se.llbit.chunky.world.java.JavaDimension;
 
 /**
  * Monitors filesystem for changes to region files.
@@ -39,7 +40,8 @@ public class MCRegionChangeWatcher extends RegionChangeWatcher {
     try {
       while (!isInterrupted()) {
         sleep(3000);
-        Dimension dimension = mapLoader.getWorld().currentDimension();
+        // MCRegionChangeWatcher is only created by JavaDimension, so this cast is always safe.
+        JavaDimension dimension = (JavaDimension) mapLoader.getWorld().currentDimension();
         if (dimension.reloadPlayerData()) {
           if (PersistentSettings.getFollowPlayer()) {
             Platform.runLater(() -> dimension.getPlayerPos().ifPresent(mapView::panTo));

--- a/chunky/src/java/se/llbit/chunky/world/region/Region.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/Region.java
@@ -7,6 +7,15 @@ import se.llbit.chunky.world.RegionPosition;
 
 public interface Region extends Iterable<Chunk> {
   /**
+   * Region X chunk width
+   */
+  int CHUNKS_X = 32;
+  /**
+   * Region Z chunk width
+   */
+  int CHUNKS_Z = 32;
+
+  /**
    * @return Chunk at (x, z)
    */
   @PluginApi

--- a/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
@@ -61,7 +61,7 @@ public class RegionParser extends Thread {
         ChunkView map = mapView.getMapView();
         if (map.isRegionVisible(position)) {
           Dimension dimension = mapLoader.getWorld().currentDimension();
-          Region region = dimension.getRegionWithinRange(position, mapView.getYMin(), mapView.getYMax());
+          Region region = dimension.getRegionWithinRange(position, new HeightRange(mapView.getYMin(), mapView.getYMax()));
           region.parse(mapView.getYMin(), mapView.getYMax());
           Mutable<ChunkData> chunkData = new Mutable<>(null);
           for (Chunk chunk : region) {

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/JavaWorldFormat.java
@@ -9,12 +9,17 @@ import java.nio.file.Path;
 
 public class JavaWorldFormat implements WorldFormat {
   @Override
+  public String name() {
+    return "Java (Anvil)";
+  }
+
+  @Override
   public boolean isValid(Path path) {
     return JavaWorld.isWorldDir(path.toFile());
   }
 
   @Override
-  public World loadWorld(Path path, Dimension.Identifier dimension) throws IOException {
-    return JavaWorld.loadWorld(path.toFile(), dimension, World.LoggedWarnings.SILENT);
+  public World loadWorld(Path path) throws IOException {
+    return JavaWorld.loadWorld(path.toFile(), World.LoggedWarnings.SILENT);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/JavaWorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/JavaWorldFormat.java
@@ -1,0 +1,20 @@
+package se.llbit.chunky.world.worldformat;
+
+import se.llbit.chunky.world.Dimension;
+import se.llbit.chunky.world.java.JavaWorld;
+import se.llbit.chunky.world.World;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class JavaWorldFormat implements WorldFormat {
+  @Override
+  public boolean isValid(Path path) {
+    return JavaWorld.isWorldDir(path.toFile());
+  }
+
+  @Override
+  public World loadWorld(Path path, Dimension.Identifier dimension) throws IOException {
+    return JavaWorld.loadWorld(path.toFile(), dimension, World.LoggedWarnings.SILENT);
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -6,6 +6,7 @@ import se.llbit.util.annotation.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * A {@link WorldFormat} determines whether paths on disk are valid for its world type, and can then load that
@@ -29,14 +30,22 @@ public interface WorldFormat extends Registerable {
   boolean isValid(@NotNull Path path);
 
   /**
-   * Load the world at the given path.
+   * Load metadata about a world
    *
    * <p>Calls to this method do not indicate that any blocks will be loaded from the world. As such implementations
    * should do <b><u>minimal</u></b> work to load the metadata for a world.</p>
    *
-   * @param path The path to the world.
-   * @return The loaded world
-   * @throws IOException When something goes wrong when loading the world.
+   * @param path The path to the world
+   * @return The {@link World.Info}, if it was created successfully.
    */
-  World loadWorld(@NotNull Path path) throws IOException;
+  @NotNull Optional<World.Info> getWorldInfo(@NotNull Path path);
+
+  /**
+   * Load the world represented by the given world info.
+   *
+   * @param info The world info.
+   * @return The loaded world, or an empty world if the world was not loadable.
+   * @throws IOException When something goes wrong when loading the world. Will be reported to the user.
+   */
+  @NotNull World loadWorld(@NotNull World.Info info) throws IOException;
 }

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -8,15 +8,13 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 /**
- * A {@link WorldFormat} represents a path on disk that can be loaded into chunky as a {@link World}
+ * A {@link WorldFormat} determines whether paths on disk are valid for its world type, and can then load that
+ * {@link World} into chunky.
  *
  * <p>Implementations should be <b><u>stateless</u></b>, and never cache world validity.</p>
  *
  * <p>Implementations will be queried for many different paths via {@link #isValid(Path)}.
  * The same {@link Path} is likely to be checked more than once over the lifetime of the {@link WorldFormat}</p>
- *
- * <p>Impls. are guaranteed that paths given to {@link #loadWorld(Path)} will already be validated
- * through their {@link #isValid(Path)}</p>
  */
 public interface WorldFormat extends Registerable {
   /**

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -1,19 +1,63 @@
 package se.llbit.chunky.world.worldformat;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.World;
+import se.llbit.log.Log;
 import se.llbit.chunky.world.java.JavaWorld;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public interface WorldFormat {
   // TODO: Registerable
   Collection<WorldFormat> worldFormats = List.of(new JavaWorldFormat());
 
+  /**
+   * @return The user-recognisable name of the world format. Shown to the user if this format has issues or throws.
+   */
+  String name();
+
+  /**
+   * This method will be called on every possible world directory (typically this is every directory in `.minecraft/saves`).
+   *
+   * @param path The path to the world.
+   * @return Whether this is a valid world under this world format.
+   */
   boolean isValid(Path path);
 
-  World loadWorld(Path path, Dimension.Identifier dimension) throws IOException;
+  /**
+   * Load the world at the given path
+   * @param path The path to the world.
+   * @return The loaded world
+   * @throws IOException When something goes wrong when loading the world.
+   */
+  World loadWorld(Path path) throws IOException;
+
+  // Should this go somewhere else?
+  static Optional<World> loadWorld(File dir) {
+    Map<String, World> worldsByFormat = new Object2ObjectOpenHashMap<>();
+
+    for (WorldFormat worldFormat : WorldFormat.worldFormats) {
+      if (worldFormat.isValid(dir.toPath())) {
+        try {
+          World world = worldFormat.loadWorld(dir.toPath());
+          if (world != EmptyWorld.INSTANCE) {
+            worldsByFormat.put(worldFormat.name(), world);
+          }
+        } catch (IOException e) {
+          Log.error(String.format("An error occurred when trying to load a world using format `%s` from %s", worldFormat.name(), dir.getAbsolutePath()), e);
+        }
+      }
+    }
+    if (worldsByFormat.size() > 1) {
+      // Maybe allow the user to select which?
+      // This method is called from a variety of different popup/menu situations, is this ^ possible?
+      Log.warn(String.format("The directory %s has multiple valid world formats: %s", dir.getAbsolutePath(), String.join(", ", worldsByFormat.keySet())));
+    }
+    return worldsByFormat.values().stream().findFirst();
+  }
 }

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -6,10 +6,23 @@ import se.llbit.util.Registerable;
 import java.io.IOException;
 import java.nio.file.Path;
 
-/** For worlds that have multiple dimensions, and fully support the map view */
+/**
+ * A {@link WorldFormat} represents a path on disk that can be loaded into chunky as a {@link World}
+ *
+ * <p>Implementations should be <b><u>stateless</u></b>, and never cache world validity.</p>
+ *
+ * <p>Implementations will be queried for many different paths via {@link #isValid(Path)}.
+ * The same {@link Path} is likely to be checked more than once over the lifetime of the {@link WorldFormat}</p>
+ *
+ * <p>Impls. are guaranteed that paths given to {@link #loadWorld(Path)} will already be validated
+ * through their {@link #isValid(Path)}</p>
+ */
 public interface WorldFormat extends Registerable {
   /**
-   * This method will be called on every possible world directory (typically this is every directory in `.minecraft/saves`).
+   * Determine whether a {@link Path} is valid for this {@link WorldFormat}
+   *
+   * <p>This method will be called on every possible world directory
+   * (typically this is every directory in `.minecraft/saves`).</p>
    *
    * @param path The path to the world.
    * @return Whether this is a valid world under this world format.
@@ -17,7 +30,11 @@ public interface WorldFormat extends Registerable {
   boolean isValid(Path path);
 
   /**
-   * Load the world at the given path
+   * Load the world at the given path.
+   *
+   * <p>Calls to this method do not indicate that any blocks will be loaded from the world. As such implementations
+   * should do <b><u>minimal</u></b> work to load the metadata for a world.</p>
+   *
    * @param path The path to the world.
    * @return The loaded world
    * @throws IOException When something goes wrong when loading the world.

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -2,6 +2,7 @@ package se.llbit.chunky.world.worldformat;
 
 import se.llbit.chunky.world.World;
 import se.llbit.util.Registerable;
+import se.llbit.util.annotation.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -27,7 +28,7 @@ public interface WorldFormat extends Registerable {
    * @param path The path to the world.
    * @return Whether this is a valid world under this world format.
    */
-  boolean isValid(Path path);
+  boolean isValid(@NotNull Path path);
 
   /**
    * Load the world at the given path.
@@ -39,5 +40,5 @@ public interface WorldFormat extends Registerable {
    * @return The loaded world
    * @throws IOException When something goes wrong when loading the world.
    */
-  World loadWorld(Path path) throws IOException;
+  World loadWorld(@NotNull Path path) throws IOException;
 }

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -1,0 +1,19 @@
+package se.llbit.chunky.world.worldformat;
+
+import se.llbit.chunky.world.Dimension;
+import se.llbit.chunky.world.World;
+import se.llbit.chunky.world.java.JavaWorld;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+public interface WorldFormat {
+  // TODO: Registerable
+  Collection<WorldFormat> worldFormats = List.of(new JavaWorldFormat());
+
+  boolean isValid(Path path);
+
+  World loadWorld(Path path, Dimension.Identifier dimension) throws IOException;
+}

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormat.java
@@ -1,26 +1,13 @@
 package se.llbit.chunky.world.worldformat;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import se.llbit.chunky.world.EmptyWorld;
-import se.llbit.chunky.world.Dimension;
 import se.llbit.chunky.world.World;
-import se.llbit.log.Log;
-import se.llbit.chunky.world.java.JavaWorld;
+import se.llbit.util.Registerable;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
 
-public interface WorldFormat {
-  // TODO: Registerable
-  Collection<WorldFormat> worldFormats = List.of(new JavaWorldFormat());
-
-  /**
-   * @return The user-recognisable name of the world format. Shown to the user if this format has issues or throws.
-   */
-  String name();
-
+/** For worlds that have multiple dimensions, and fully support the map view */
+public interface WorldFormat extends Registerable {
   /**
    * This method will be called on every possible world directory (typically this is every directory in `.minecraft/saves`).
    *
@@ -36,28 +23,4 @@ public interface WorldFormat {
    * @throws IOException When something goes wrong when loading the world.
    */
   World loadWorld(Path path) throws IOException;
-
-  // Should this go somewhere else?
-  static Optional<World> loadWorld(File dir) {
-    Map<String, World> worldsByFormat = new Object2ObjectOpenHashMap<>();
-
-    for (WorldFormat worldFormat : WorldFormat.worldFormats) {
-      if (worldFormat.isValid(dir.toPath())) {
-        try {
-          World world = worldFormat.loadWorld(dir.toPath());
-          if (world != EmptyWorld.INSTANCE) {
-            worldsByFormat.put(worldFormat.name(), world);
-          }
-        } catch (IOException e) {
-          Log.error(String.format("An error occurred when trying to load a world using format `%s` from %s", worldFormat.name(), dir.getAbsolutePath()), e);
-        }
-      }
-    }
-    if (worldsByFormat.size() > 1) {
-      // Maybe allow the user to select which?
-      // This method is called from a variety of different popup/menu situations, is this ^ possible?
-      Log.warn(String.format("The directory %s has multiple valid world formats: %s", dir.getAbsolutePath(), String.join(", ", worldsByFormat.keySet())));
-    }
-    return worldsByFormat.values().stream().findFirst();
-  }
 }

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormats.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormats.java
@@ -1,0 +1,55 @@
+package se.llbit.chunky.world.worldformat;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import se.llbit.chunky.world.EmptyWorld;
+import se.llbit.chunky.world.World;
+import se.llbit.chunky.world.java.JavaWorldFormat;
+import se.llbit.log.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class WorldFormats {
+  private static final Map<String, WorldFormat> worldFormatsById = new Object2ObjectOpenHashMap<>();
+
+  public static void addWorldFormat(WorldFormat worldFormat) {
+    worldFormatsById.put(worldFormat.getId(), worldFormat);
+  }
+
+  public static Map<String, WorldFormat> getWorldFormats() {
+    return Collections.unmodifiableMap(worldFormatsById);
+  }
+
+  public static WorldFormat getWorldFormat(String id) {
+    return worldFormatsById.get(id);
+  }
+
+  static {
+    addWorldFormat(new JavaWorldFormat());
+  }
+
+  public static Optional<World> createWorld(File dir) {
+    Map<String, World> providedWorlds = new Object2ObjectOpenHashMap<>();
+
+    getWorldFormats().forEach((id, format) -> {
+      if (format.isValid(dir.toPath())) {
+        try {
+          World world = format.loadWorld(dir.toPath());
+          if (world != EmptyWorld.INSTANCE) {
+            providedWorlds.put(format.getId(), world);
+          }
+        } catch (IOException e) {
+          Log.error(String.format("An error occurred when trying to load a world using format `%s` from %s", format.getName(), dir.getAbsolutePath()), e);
+        }
+      }
+    });
+
+    if (providedWorlds.size() > 1) {
+      // Maybe allow the user to select which?
+      // This method is called from a variety of different popup/menu situations, is this ^ possible?
+      Log.warn(String.format("The directory %s has multiple valid world formats: %s", dir.getAbsolutePath(), String.join(", ", providedWorlds.keySet())));
+    }
+    return providedWorlds.values().stream().findFirst();
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormats.java
+++ b/chunky/src/java/se/llbit/chunky/world/worldformat/WorldFormats.java
@@ -1,17 +1,21 @@
 package se.llbit.chunky.world.worldformat;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.World;
 import se.llbit.chunky.world.java.JavaWorldFormat;
 import se.llbit.log.Log;
+import se.llbit.util.annotation.NotNull;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class WorldFormats {
-  private static final Map<String, WorldFormat> worldFormatsById = new Object2ObjectOpenHashMap<>();
+  /**
+   * Uses an ordered hashmap to guarantee a consistent encounter order (and that {@link JavaWorldFormat} is checked first)
+   */
+  private static final LinkedHashMap<String, WorldFormat> worldFormatsById = new LinkedHashMap<>();
 
   public static void addWorldFormat(WorldFormat worldFormat) {
     worldFormatsById.put(worldFormat.getId(), worldFormat);
@@ -21,35 +25,32 @@ public class WorldFormats {
     return Collections.unmodifiableMap(worldFormatsById);
   }
 
-  public static WorldFormat getWorldFormat(String id) {
-    return worldFormatsById.get(id);
+  public static Optional<WorldFormat> getWorldFormat(String id) {
+    return Optional.ofNullable(worldFormatsById.get(id));
   }
 
   static {
     addWorldFormat(new JavaWorldFormat());
   }
 
-  public static Optional<World> createWorld(File dir) {
-    Map<String, World> providedWorlds = new Object2ObjectOpenHashMap<>();
+  @NotNull
+  public static Collection<World.Info> getInfos(Path path) {
+    return getWorldFormats().values().stream()
+      .filter(format -> format.isValid(path))
+      .map(format -> format.getWorldInfo(path))
+      .flatMap(Optional::stream)
+      .collect(Collectors.toList());
+  }
 
-    getWorldFormats().forEach((id, format) -> {
-      if (format.isValid(dir.toPath())) {
-        try {
-          World world = format.loadWorld(dir.toPath());
-          if (world != EmptyWorld.INSTANCE) {
-            providedWorlds.put(format.getId(), world);
-          }
-        } catch (IOException e) {
-          Log.error(String.format("An error occurred when trying to load a world using format `%s` from %s", format.getName(), dir.getAbsolutePath()), e);
-        }
-      }
-    });
-
-    if (providedWorlds.size() > 1) {
-      // Maybe allow the user to select which?
-      // This method is called from a variety of different popup/menu situations, is this ^ possible?
-      Log.warn(String.format("The directory %s has multiple valid world formats: %s", dir.getAbsolutePath(), String.join(", ", providedWorlds.keySet())));
+  @NotNull
+  public static World createWorld(@NotNull World.Info info) {
+    try {
+      return info.worldFormat().loadWorld(info);
+    } catch (IOException e) {
+      Log.error(String.format("An error occurred when trying to load a world using format `%s` from %s",
+        info.worldFormat().getName(), info.path().toAbsolutePath()), e
+      );
     }
-    return providedWorlds.values().stream().findFirst();
+    return EmptyWorld.INSTANCE;
   }
 }

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -190,6 +190,16 @@ public final class PersistentSettings {
     return lastWorld.isEmpty() ? null : new File(lastWorld);
   }
 
+  public static void setLastWorldFormat(String worldFormat) {
+    settings.setString("lastWorldFormat", worldFormat);
+    save();
+  }
+
+  /** @return the world format of the previously loaded world. */
+  public static String getLastWorldFormat() {
+    return settings.getString("lastWorldFormat", "");
+  }
+
   public static void setSkinDirectory(File directory) {
     settings.setString("skinDirectory", directory.getAbsolutePath());
     save();


### PR DESCRIPTION
I mainly want comments on general structure, everything else is bikesheddable. I'll go over everything again and polish it up before review.

Lots of changes here, so far I've only looked at loading worlds from the gui, haven't looked at reloading from the previous 
session

`Chunk`, `World`, `Dimension` are now abstract classes, the previous implementation is now `JavaChunk` etc.
there is also a skeleton of registerable `WorldFormat`s. Each is asked if a directory is valid for it, if the user selects it, the format is asked to load the world.

The ultimate goal would probably be to have `Chunk` be an implementation detail of java world, but that's a much larger task as it would require a rewrite of parts of the map view and scene chunk loading