### PR TITLE
Fix map color of spurce and birch leaves.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Leaves.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Leaves.java
@@ -24,21 +24,28 @@ import se.llbit.chunky.resources.Texture;
 import se.llbit.chunky.world.biome.Biome;
 
 public class Leaves extends AbstractModelBlock {
+  private final int tint;
 
   public Leaves(String name, Texture texture) {
     super(name, texture);
     solid = false;
     this.model = new LeafModel(texture);
+    this.tint = -1;
   }
 
   public Leaves(String name, Texture texture, int tint) {
     super(name, texture);
     solid = false;
     this.model = new LeafModel(texture, tint);
+    this.tint = tint;
   }
 
   @Override
   public int getMapColor(Biome biome) {
+    if (this.tint >= 0) {
+      // this leave type has a blending color that is independent from the biome (eg. spruce or birch leaves)
+      return this.tint | 0xFF000000;
+    }
     return biome.foliageColor | 0xFF000000;
   }
 }


### PR DESCRIPTION
Before:
<img width="391" height="350" alt="image" src="https://github.com/user-attachments/assets/9ec5f9b2-512e-4b20-a256-f78995082e64" />

After:
<img width="293" height="216" alt="image" src="https://github.com/user-attachments/assets/bf2a8fbc-9a69-4847-b5bd-cca8a783b39c" />
