### PR TITLE
Fix select/deselect all for Squids

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/GeneralTab.java
@@ -379,6 +379,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       loadChickens.setSelected(true);
       loadPigs.setSelected(true);
       loadMooshrooms.setSelected(true);
+      loadSquids.setSelected(true);
       loadOtherEntities.setSelected(true);
     });
     loadNoEntity.setOnAction(event -> {
@@ -392,6 +393,7 @@ public class GeneralTab extends ScrollPane implements RenderControlsTab, Initial
       loadChickens.setSelected(false);
       loadPigs.setSelected(false);
       loadMooshrooms.setSelected(false);
+      loadSquids.setSelected(false);
       loadOtherEntities.setSelected(false);
     });
 


### PR DESCRIPTION
Noticed I forgot Squids in the Select/Deselect All buttons for the Load Entities drop down in the Scene tab. This fixes those buttons not correctly changing the setting.