### PR TITLE
Fix crash when loading some resource packs.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/ConditionalTextures.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/ConditionalTextures.java
@@ -5,8 +5,6 @@ import se.llbit.chunky.resources.LayeredResourcePacks;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * This texture loader will load different textures depending on a texture being available.
@@ -28,11 +26,6 @@ public class ConditionalTextures extends TextureLoader {
       return then.load(texturePack);
     }
     return otherwise.load(texturePack);
-  }
-
-  @Override
-  public boolean loadFromTerrain(BitmapImage[] terrain) {
-    throw new UnsupportedOperationException("ConditionalTextures doesn't support loadFromTerrain");
   }
 
   @Override

--- a/chunky/src/java/se/llbit/chunky/resources/texturepack/JsonFontTextureLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/texturepack/JsonFontTextureLoader.java
@@ -86,7 +86,8 @@ public class JsonFontTextureLoader extends TextureLoader {
       JsonObject definition = fontDefinition.asObject();
       if (definition.get("type").stringValue("").equals("bitmap")) {
         BitmapImage spritemap;
-        String texture = definition.get("file").stringValue("").split(":")[1];
+        String[] textureAndNamespace = definition.get("file").stringValue("").split(":");
+        String texture = textureAndNamespace.length > 1 ? textureAndNamespace[1] : textureAndNamespace[0];
         Optional<LayeredResourcePacks.Entry> texturePath = texturePack.getFirstEntry("assets/minecraft/textures/" + texture);
         if (texturePath.isPresent()) {
           try (InputStream imageStream = texturePath.get().getInputStream()) {
@@ -106,6 +107,10 @@ public class JsonFontTextureLoader extends TextureLoader {
 
         int width = spritemap.width / 16;
         int height = fontDefinition.asObject().get("height").asInt(8);
+        if (width <= 0 || height <= 0) {
+          // some resource packs somehow do this, ignore
+          continue;
+        }
         int ascent =
           fontDefinition
             .asObject()


### PR DESCRIPTION
Fixed #1724 (ie. [Conquest_](https://www.curseforge.com/minecraft/texture-packs/conquest_/files/5741192) now works fine).