### PR TITLE
Fix error when loading worlds with custom heads that have no uuid and no encoded texture.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
+++ b/chunky/src/java/se/llbit/chunky/block/minecraft/Head.java
@@ -125,6 +125,9 @@ public class Head extends MinecraftBlockTranslucent {
       }
     }
     int[] uuidInts = profileTag.get("id").intArray();
-    return MojangApi.fetchProfile(UuidUtil.intsToUuid(uuidInts).toString()).getSkin();
+    if (uuidInts.length == 4) {
+      return MojangApi.fetchProfile(UuidUtil.intsToUuid(uuidInts).toString()).getSkin();
+    }
+    return Optional.empty();
   }
 }


### PR DESCRIPTION
Probably related to #1828 (i.e. custom heads that we can't load yet), but at least we don't crash anymore.