### PR TITLE
Fix negative distance resulting in infinite attenuation due to almost horizontal intersections with clouds.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/sky/Sky.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/sky/Sky.java
@@ -989,6 +989,10 @@ public class Sky implements JsonSerializable {
     int target = 1;
     double t_offset = 0;
     if (oy < offsetY || oy > cloudTop) {
+      if (Math.abs(ray.d.y) < Ray.EPSILON) {
+        // ignore almost horizontal intersections that result in huge t_offset and negative t (issue #1664)
+        return false;
+      }
       if (ray.d.y > 0) {
         t_offset = (offsetY - oy) / ray.d.y;
       } else {
@@ -1126,7 +1130,9 @@ public class Sky implements JsonSerializable {
         return false;
       }
       ray.setNormal(nx, ny, nz);
-      enterCloud(ray, t + t_offset);
+      t += t_offset;
+      assert t >= 0 : "t negative, t_offset=" + t_offset;
+      enterCloud(ray, t);
       return true;
     } else {
       if (t > tExit) {


### PR DESCRIPTION
Fixes #1664

Thanks to @ThatRedox, we have a way to reproduce the issue:
```diff
Subject: [PATCH] a
---
Index: chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java b/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java
--- a/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java	(revision eefc0f72af48875d165d9eb7c1b9a5fca3b4ec71)
+++ b/chunky/src/java/se/llbit/chunky/renderer/PathTracingRenderer.java	(date 1766905427687)
@@ -82,6 +82,15 @@
         double sb = 0;
 
         for (int k = 0; k < sppPerPass; k++) {
+//          long randSeed = state.random.nextLong();
+//          state.random.setSeed(randSeed);
+
+          long randSeed = -7977825583683611334L;
+          state.random.setSeed(randSeed);
+          if (x == 1185 && y == 1126) {
+            state.random.setSeed(randSeed);
+          }
+
           double ox = state.random.nextDouble();
           double oy = state.random.nextDouble();
 
@@ -93,6 +102,14 @@
           sr += state.ray.color.x * branchCount;
           sg += state.ray.color.y * branchCount;
           sb += state.ray.color.z * branchCount;
+
+          if (!Double.isFinite(state.ray.color.x) || !Double.isFinite(state.ray.color.y) || !Double.isFinite(state.ray.color.z)) {
+            throw new RuntimeException(String.format("Invalid ray color: (%f, %f, %f)\nSeed: %d\nPixel: (%d, %d)",
+              state.ray.color.x, state.ray.color.y, state.ray.color.z,
+              randSeed,
+              x, y
+            ));
+          }
         }
 
         int offset = 3 * (y*width + x);
```