### PR TITLE
Add default materials for weighted pressure plates

### DIFF
--- a/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
+++ b/chunky/src/java/se/llbit/chunky/chunk/BlockPalette.java
@@ -291,6 +291,11 @@ public class BlockPalette {
       block.metalness = 1.0f;
       block.setPerceptualSmoothness(0.9);
     });
+    materialProperties.put("minecraft:light_weighted_pressure_plate", block -> {
+      block.specular = 0.04f;
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.9);
+    });
     materialProperties.put("minecraft:raw_gold_block", block -> {
       block.metalness = 0.8f;
       block.setPerceptualSmoothness(0.5);
@@ -299,6 +304,11 @@ public class BlockPalette {
       block.specular = 0.04f;
     });
     materialProperties.put("minecraft:iron_block", block -> {
+      block.specular = 0.04f;
+      block.metalness = 1.0f;
+      block.setPerceptualSmoothness(0.9);
+    });
+    materialProperties.put("minecraft:heavy_weighted_pressure_plate", block -> {
       block.specular = 0.04f;
       block.metalness = 1.0f;
       block.setPerceptualSmoothness(0.9);


### PR DESCRIPTION
Gives light and heavy weighted pressure plates the same default properties as gold and iron blocks respectively.

Before (strange, inconsistently lit banana):
<img width="800" height="800" alt="Banana-4000 denoised" src="https://github.com/user-attachments/assets/7ed2ef48-19e1-4c6b-b969-27cff3dc69ec" />

After (much nicer, consistently shiny banana):
<img width="800" height="800" alt="metallic-pressure-plates" src="https://github.com/user-attachments/assets/58d6bb55-dc7b-4a04-bc41-d4e7591fa623" />
