### PR TITLE
Fix armorstand and beacon beam textures in new resource packs.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -321,6 +321,7 @@ public class Texture {
   public static final Texture potatoes2 = new Texture();
   public static final Texture potatoes3 = new Texture();
   public static final Texture beacon = new Texture();
+  @TexturePath(value = "assets/minecraft/textures/entity/beacon/beacon_beam", alternatives = {"assets/minecraft/textures/entity/beacon_beam"})
   public static final Texture beaconBeam = new Texture();
   public static final Texture anvilSide = new Texture();
   public static final Texture anvilTop = new Texture();

--- a/chunky/src/java/se/llbit/chunky/resources/Texture.java
+++ b/chunky/src/java/se/llbit/chunky/resources/Texture.java
@@ -1737,6 +1737,7 @@ public class Texture {
   /** Banner base texture. */
   public static final Texture bannerBase = new Texture();
 
+  @TexturePath(value = "assets/minecraft/textures/entity/armorstand/armorstand", alternatives = {"assets/minecraft/textures/entity/armorstand/wood"})
   public static final Texture armorStand = new Texture();
 
   protected static boolean useAverageColor = PersistentSettings.getSingleColorTextures();

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -3017,9 +3017,6 @@ public class TexturePackLoader {
     ALL_TEXTURES.put("banner_base",
         new SimpleTexture("assets/minecraft/textures/entity/banner_base", Texture.bannerBase));
 
-    ALL_TEXTURES.put("armor_stand",
-        new SimpleTexture("assets/minecraft/textures/entity/armorstand/wood", Texture.armorStand));
-
     // Minecraft 1.13
     ALL_TEXTURES.put("stripped_oak_log",
         new SimpleTexture("assets/minecraft/textures/block/stripped_oak_log",

--- a/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/TexturePackLoader.java
@@ -310,7 +310,6 @@ public class TexturePackLoader {
         new SimpleTexture("assets/minecraft/textures/blocks/beacon", Texture.beacon),
         new SimpleTexture("textures/blocks/beacon", Texture.beacon),
         new IndexedTexture(0x29, Texture.beacon)));
-    ALL_TEXTURES.put("beacon_beam", new SimpleTexture("assets/minecraft/textures/entity/beacon_beam", Texture.beaconBeam));
     ALL_TEXTURES.put("crafting_table_top", new AlternateTextures(
         new SimpleTexture("assets/minecraft/textures/block/crafting_table_top",
             Texture.workbenchTop),


### PR DESCRIPTION
The textures were moved in 26.1-snapshot-2