### PR TITLE
Fix scene reset warning blocking input events for all other dialogs.

### DIFF
--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -1,17 +1,9 @@
 package se.llbit.fxutil;
 
 import javafx.scene.Scene;
-import javafx.scene.control.Alert;
+import javafx.scene.control.*;
 import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.Button;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.CheckBox;
-import javafx.scene.control.Dialog;
-import javafx.scene.control.DialogPane;
-import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
-import javafx.scene.layout.VBox;
-import javafx.scene.text.Text;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
@@ -31,27 +23,13 @@ public class Dialogs {
     return alert;
   }
 
-  public static Dialog<ButtonType> createSpecialApprovalConfirmation(
-    String title,
-    String header,
-    String content,
-    String confirmLabel
-  ) {
-    return new SpecialApprovalConfirmationDialog(
-      title,
-      header,
-      content,
-      confirmLabel
-    );
-  }
-
   /**
    * Init design of the dialog to the design of the main window.
    * This sets the icon and color scheme.
    */
   public static void setupDialogDesign(Dialog<?> dialog, Scene mainScene) {
     Window mainWindow = mainScene.getWindow();
-    if(mainWindow instanceof Stage) {
+    if (mainWindow instanceof Stage) {
       Stage mainWindowStage = (Stage) mainWindow;
       Stage dialogStage = (Stage) dialog.getDialogPane().getScene().getWindow();
 
@@ -73,6 +51,7 @@ public class Dialogs {
 
   /**
    * Makes the given dialog always stay on top of its parent window.
+   *
    * @param dialog A dialog
    */
   public static void stayOnTop(Alert dialog) {
@@ -80,35 +59,6 @@ public class Dialogs {
     if (window instanceof Stage) {
       ((Stage) window).setAlwaysOnTop(true);
       ((Stage) window).toFront();
-    }
-  }
-
-  /**
-   * makes extra sure that user wants to confirm things
-   */
-  static class SpecialApprovalConfirmationDialog extends Dialog<ButtonType> {
-    final CheckBox checkBox;
-
-    SpecialApprovalConfirmationDialog(
-      String title,
-      String header,
-      String content,
-      String checkBoxLabel
-    ) {
-      setResultConverter(param -> param);
-      checkBox = new CheckBox(checkBoxLabel);
-
-      final DialogPane dialogPane = getDialogPane();
-      dialogPane.getStyleClass().add("alert");
-      dialogPane.getStyleClass().add("warning");
-
-      setTitle(title);
-      dialogPane.setHeaderText(header);
-      dialogPane.setContent(new VBox(16, new Text(content), checkBox));
-      dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
-
-      dialogPane.lookupButton(ButtonType.OK)
-        .disableProperty().bind(checkBox.selectedProperty().not());
     }
   }
 }

--- a/chunky/src/java/se/llbit/fxutil/Dialogs.java
+++ b/chunky/src/java/se/llbit/fxutil/Dialogs.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
@@ -57,6 +58,7 @@ public class Dialogs {
       dialogStage.getIcons().addAll(mainWindowStage.getIcons());
     }
     dialog.initOwner(mainWindow);
+    dialog.initModality(Modality.WINDOW_MODAL);
   }
 
   /**


### PR DESCRIPTION
Fixes #1194

I reproduced this by adding the following code right before the reset confirmation is shown in `ChunkyFxController.java`:

```java
Log.warn("Provoke bug");
requestRenderReset();
```