### PR TITLE
Fix CLI not always printing the render completed message.

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -226,7 +226,7 @@ public class DefaultRenderManager extends Thread implements RenderManager {
         frameCompletionListener.accept(bufferedScene, bufferedScene.spp);
         updateRenderProgress();
 
-        if (bufferedScene.spp > bufferedScene.getTargetSpp()) {
+        if (bufferedScene.spp >= bufferedScene.getTargetSpp()) {
           renderCompletionListener.accept(bufferedScene.renderTime, samplesPerSecond());
           return true;
         }


### PR DESCRIPTION
I'd appreciate some feedback on this bug. :pray: 

The "Render job finished." message and render time didn't always show up in the CLI. This fixes it and the fix looks straight forward, but was the old comparison intentional? Am I breaking something?