### PR TITLE
Prevent an invalid world from breaking the world chooser dialog

### DIFF
--- a/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/WorldChooserController.java
@@ -34,6 +34,7 @@ import se.llbit.chunky.resources.ResourcePackLoader;
 import se.llbit.chunky.resources.TexturePackLoader;
 import se.llbit.chunky.ui.TableSortConfigSerializer;
 import se.llbit.chunky.world.Dimension;
+import se.llbit.chunky.world.EmptyWorld;
 import se.llbit.chunky.world.World;
 import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonArray;
@@ -196,7 +197,10 @@ public class WorldChooserController implements Initializable {
           if (worldDirs != null) {
             for (File dir : worldDirs) {
               if (World.isWorldDir(dir)) {
-                worlds.add(World.loadWorld(dir, Dimension.Identifier.OVERWORLD, World.LoggedWarnings.SILENT));
+                World world = World.loadWorld(dir, Dimension.Identifier.OVERWORLD, World.LoggedWarnings.SILENT);
+                if (world != EmptyWorld.INSTANCE) {
+                  worlds.add(world);
+                }
               }
             }
           }


### PR DESCRIPTION
If `World#loadWorld` returns an empty world (caused by invalid level.dat or having a bedrock world in your downloads folder) the world chooser dialog breaks and no worlds are selectable.