### PR TITLE
Adds shutdown to Plugin

### DIFF
--- a/chunky/src/java/se/llbit/chunky/Plugin.java
+++ b/chunky/src/java/se/llbit/chunky/Plugin.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky;
 
 import se.llbit.chunky.main.Chunky;
+import se.llbit.util.concurrent.ChunkyThread;
 
 /**
  * The plugin interface for Chunky plugins.
@@ -33,4 +34,17 @@ public interface Plugin {
    * @param chunky Chunky instance which the plugin should attach to
    */
   void attach(Chunky chunky);
+
+  /**
+   * Called when chunky shuts down, allowing the plugin to close critical resources. Most plugins do not need to do
+   * anything here.
+   *
+   * <p>This function will be called after all {@link ChunkyThread}s have shut down. Chunky's UI thread may still
+   * be running.</p>
+   * <p>This method will not be called if any {@link ChunkyThread} does not shut down within its given time limit</p>
+   * <p>This method may not be called if chunky terminates in a non-normal way, such as through {@link Runtime#halt},
+   * the user killing the process (<code>SIGKILL</code> & <code>TerminateProcess</code>), or an error within a native
+   * function.</p>
+   */
+  default void shutdown(Chunky chunky) { }
 }

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -48,6 +48,7 @@ import se.llbit.log.Level;
 import se.llbit.log.Log;
 import se.llbit.log.Receiver;
 import se.llbit.util.TaskTracker;
+import se.llbit.util.concurrent.ChunkyThread;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -241,6 +242,12 @@ public class Chunky {
         exitCode = 2;
       }
     }
+
+    ChunkyThread.interruptAndJoinAll();
+    ForkJoinPool commonThreads = Chunky.getCommonThreads();
+    commonThreads.shutdownNow(); // ForkJoinPool doesn't return any tasks that were awaiting execution (all canceled).
+    // We don't use the ForkJoinPool commonPool in chunky, but if we did there is no shutdown available so nothing changes.
+
     if (exitCode != 0) {
       System.exit(exitCode);
     }

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -57,6 +57,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -243,7 +244,7 @@ public class Chunky {
       }
     }
 
-    ChunkyThread.interruptAndJoinAll();
+    ChunkyThread.interruptAndJoinAll(5, TimeUnit.SECONDS);
     ForkJoinPool commonThreads = Chunky.getCommonThreads();
     commonThreads.shutdownNow(); // ForkJoinPool doesn't return any tasks that were awaiting execution (all canceled).
     // We don't use the ForkJoinPool commonPool in chunky, but if we did there is no shutdown available so nothing changes.

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -245,9 +245,6 @@ public class Chunky {
     }
 
     ChunkyThread.interruptAndJoinAll(5, TimeUnit.SECONDS);
-    ForkJoinPool commonThreads = Chunky.getCommonThreads();
-    commonThreads.shutdownNow(); // ForkJoinPool doesn't return any tasks that were awaiting execution (all canceled).
-    // We don't use the ForkJoinPool commonPool in chunky, but if we did there is no shutdown available so nothing changes.
 
     if (exitCode != 0) {
       System.exit(exitCode);
@@ -350,7 +347,7 @@ public class Chunky {
   public static ForkJoinPool getCommonThreads() {
     if (commonThreads == null) {
       // use at least two threads to prevent deadlocks in some java versions (see #1631)
-      commonThreads = new ForkJoinPool(Math.max(PersistentSettings.getNumThreads(), 2));
+      commonThreads = ChunkyThread.addForkJoinPool(new ForkJoinPool(Math.max(PersistentSettings.getNumThreads(), 2)));
     }
     return commonThreads;
   }
@@ -361,7 +358,7 @@ public class Chunky {
    */
   public static void setCommonThreadsCount(int threads) {
     ForkJoinPool t = getCommonThreads();
-    commonThreads = new ForkJoinPool(threads);
+    commonThreads = ChunkyThread.addForkJoinPool(new ForkJoinPool(threads));
     t.shutdown();
   }
 

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -217,34 +217,38 @@ public class Chunky {
     if (cmdline.mode == CommandLineOptions.Mode.CLI_OPERATION) {
       exitCode = cmdline.exitCode;
     } else {
-      // Initialize the common thread pool.
-      getCommonThreads();
-
-      Chunky chunky = new Chunky(cmdline.options);
-      chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.CREATE_SNAPSHOT;
-      chunky.loadPlugins();
-
       try {
-        switch (cmdline.mode) {
-          case HEADLESS_RENDER:
-            exitCode = chunky.doHeadlessRender();
-            break;
-          case CREATE_SNAPSHOT:
-            exitCode = chunky.doSnapshot();
-            break;
-          case START_GUI:
-            ChunkyFx.startChunkyUI(chunky);
-            break;
+        // Initialize the common thread pool.
+        getCommonThreads();
+
+        Chunky chunky = new Chunky(cmdline.options);
+        chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.CREATE_SNAPSHOT;
+        chunky.loadPlugins();
+
+        try {
+          switch (cmdline.mode) {
+            case HEADLESS_RENDER:
+              exitCode = chunky.doHeadlessRender();
+              break;
+            case CREATE_SNAPSHOT:
+              exitCode = chunky.doSnapshot();
+              break;
+            case START_GUI:
+              ChunkyFx.startChunkyUI(chunky);
+              break;
+          }
+        } catch (Throwable t) {
+          // set receiver in case an exception was thrown before it was set in one of the start modes.
+          Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO, Level.WARNING, Level.ERROR);
+          Log.error("Unchecked exception caused Chunky to close.", t);
+          exitCode = 2;
         }
-      } catch (Throwable t) {
-        // set receiver in case an exception was thrown before it was set in one of the start modes.
-        Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO, Level.WARNING, Level.ERROR);
-        Log.error("Unchecked exception caused Chunky to close.", t);
-        exitCode = 2;
+      } finally {
+        if (!ChunkyThread.interruptAndJoinAll(5, TimeUnit.SECONDS)) {
+          Log.warn("Not all Chunky threads stopped before exiting.");
+        }
       }
     }
-
-    ChunkyThread.interruptAndJoinAll(5, TimeUnit.SECONDS);
 
     if (exitCode != 0) {
       System.exit(exitCode);

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.main;
 
 import se.llbit.chunky.PersistentSettings;
+import se.llbit.chunky.Plugin;
 import se.llbit.chunky.block.BlockProvider;
 import se.llbit.chunky.block.BlockSpec;
 import se.llbit.chunky.block.MinecraftBlockProvider;
@@ -87,6 +88,7 @@ public class Chunky {
   };
 
   public final ChunkyOptions options;
+  private final PluginManager pluginManager;
   private RenderController renderController;
   private SceneFactory sceneFactory = SceneFactory.DEFAULT;
   private RenderContextFactory renderContextFactory = RenderContext::new;
@@ -108,6 +110,7 @@ public class Chunky {
 
   public Chunky(ChunkyOptions options) {
     this.options = options;
+    this.pluginManager = new PluginManager(new JarPluginLoader());
     registerBlockProvider(new MinecraftBlockProvider());
     registerBlockProvider(new LegacyMinecraftBlockProvider());
   }
@@ -257,7 +260,9 @@ public class Chunky {
   }
 
   private void shutdown(int timeout, TimeUnit unit) {
-    if (!ChunkyThread.interruptAndJoinAll(timeout, unit)) {
+    if (ChunkyThread.interruptAndJoinAll(timeout, unit)) {
+      pluginManager.shutdownPlugins(plugin -> plugin.shutdown(this));
+    } else {
       Log.error("Not all threads were joined before shutting down."); // FIXME: list all alive threads? ThreadGroups are annoying.
     }
   }
@@ -271,40 +276,10 @@ public class Chunky {
   }
 
   private void loadPlugins() {
-    File pluginsDirectory = SettingsDirectory.getPluginsDirectory();
-    if (!pluginsDirectory.isDirectory()) {
-      Log.infof("Plugins directory does not exist: %s", pluginsDirectory.getAbsolutePath());
-      return;
-    }
-    Path pluginsPath = pluginsDirectory.toPath();
-    JsonArray plugins = PersistentSettings.getPlugins();
-    // TODO: allow plugins to implement a custom plugin loader.
-    PluginManager pluginManager = new PluginManager(new JarPluginLoader());
-
-    // Parse plugin manifests
-    Set<PluginManifest> pluginManifests = plugins.elements.stream()
-      .map(value -> value.asString(""))
-      .filter(jarName -> !jarName.isEmpty())
-      .map(jarName -> pluginsPath.resolve(jarName).toAbsolutePath().toFile())
-      .map(PluginManager::parsePluginManifest)
-      .flatMap(Optional::stream)
-      .collect(Collectors.toSet());
-
-    // Load plugins
-    pluginManager.load(pluginManifests, (plugin, manifest) -> {
-      String jarName = manifest.pluginJar.getName();
-      Log.infof("Loading plugin: %s", jarName);
-      if (!isHeadless()) {
-        CreditsController.addPlugin(manifest.name, manifest.version.toString(), manifest.author, manifest.description);
-      }
-
-      try {
-        plugin.attach(this);
-      } catch (Throwable t) {
-        Log.error("Plugin " + jarName + " failed to load.", t);
-      }
-      Log.infof("Plugin loaded: %s %s", manifest.name, manifest.version);
-    });
+    this.pluginManager.loadPluginsFromDirectory(
+      SettingsDirectory.getPluginsDirectory(),
+      (plugin, manifest) -> plugin.attach(this)
+    );
   }
 
   /**

--- a/chunky/src/java/se/llbit/chunky/main/Chunky.java
+++ b/chunky/src/java/se/llbit/chunky/main/Chunky.java
@@ -213,45 +213,52 @@ public class Chunky {
       System.exit(1);
     }
 
-    int exitCode = 0;
     if (cmdline.mode == CommandLineOptions.Mode.CLI_OPERATION) {
-      exitCode = cmdline.exitCode;
+      System.exit(cmdline.exitCode);
     } else {
+      // Initialize the common thread pool.
+      getCommonThreads();
+
+      Chunky chunky = new Chunky(cmdline.options);
+      chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.CREATE_SNAPSHOT;
+      chunky.loadPlugins();
+
+      Runtime.getRuntime().addShutdownHook(
+        new Thread(() -> { // intentionally not a ChunkyThread
+          // Within a shutdown hook we need to close quickly, otherwise we  risk the user/OS escalating to KILL
+          chunky.shutdown(1, TimeUnit.SECONDS);
+        })
+      );
+
+      int exitCode = 0;
       try {
-        // Initialize the common thread pool.
-        getCommonThreads();
-
-        Chunky chunky = new Chunky(cmdline.options);
-        chunky.headless = cmdline.mode == Mode.HEADLESS_RENDER || cmdline.mode == Mode.CREATE_SNAPSHOT;
-        chunky.loadPlugins();
-
-        try {
-          switch (cmdline.mode) {
-            case HEADLESS_RENDER:
-              exitCode = chunky.doHeadlessRender();
-              break;
-            case CREATE_SNAPSHOT:
-              exitCode = chunky.doSnapshot();
-              break;
-            case START_GUI:
-              ChunkyFx.startChunkyUI(chunky);
-              break;
-          }
-        } catch (Throwable t) {
-          // set receiver in case an exception was thrown before it was set in one of the start modes.
-          Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO, Level.WARNING, Level.ERROR);
-          Log.error("Unchecked exception caused Chunky to close.", t);
-          exitCode = 2;
+        switch (cmdline.mode) {
+          case HEADLESS_RENDER:
+            exitCode = chunky.doHeadlessRender();
+            break;
+          case CREATE_SNAPSHOT:
+            exitCode = chunky.doSnapshot();
+            break;
+          case START_GUI:
+            ChunkyFx.startChunkyUI(chunky);
+            break;
         }
-      } finally {
-        if (!ChunkyThread.interruptAndJoinAll(5, TimeUnit.SECONDS)) {
-          Log.warn("Not all Chunky threads stopped before exiting.");
-        }
+      } catch (Throwable t) {
+        // set receiver in case an exception was thrown before it was set in one of the start modes.
+        Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO, Level.WARNING, Level.ERROR);
+        Log.error("Unchecked exception caused Chunky to close.", t);
+        exitCode = 2;
       }
-    }
-
-    if (exitCode != 0) {
+      chunky.shutdown(5, TimeUnit.SECONDS);
+      // Always exit, we've done all shutdown necessary and want to exit whether non-daemon threads exist or not.
+      // This should prevent hangs if threads aren't cooperating.
       System.exit(exitCode);
+    }
+  }
+
+  private void shutdown(int timeout, TimeUnit unit) {
+    if (!ChunkyThread.interruptAndJoinAll(timeout, unit)) {
+      Log.error("Not all threads were joined before shutting down."); // FIXME: list all alive threads? ThreadGroups are annoying.
     }
   }
 

--- a/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
@@ -72,18 +72,18 @@ public class PluginManager {
     while (!pluginsToLoad.isEmpty() && loadCycles < MAX_CYCLES) {
       Log.infof("Cycle %d", loadCycles);
       loadCycles++;
-      // new list to avoid CME due to removing inside iteration.
-      new ArrayList<>(pluginsToLoad).forEach(plugin -> {
+      for (Iterator<ResolvedPlugin> iterator = pluginsToLoad.iterator(); iterator.hasNext(); ) {
+        ResolvedPlugin plugin = iterator.next();
         if (plugin.allDependenciesLoaded(loadedPlugins)) {
           loadedPlugins.add(plugin);
-          pluginsToLoad.remove(plugin);
+          iterator.remove();
           Log.infof("  Loading plugin %s with deps { %s }, resolved { %s }%n", plugin,
             plugin.getManifest().getDependencies().stream().map(PluginDependency::toString).collect(Collectors.joining(", ")),
             plugin.getDependencies().stream().map(ResolvedPlugin::toString).collect(Collectors.joining(", "))
           );
           pluginLoader.load(onLoad, plugin.getManifest());
         }
-      });
+      }
     }
 
     // report if any unloaded plugins remain (their dependencies never got loaded)

--- a/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
@@ -16,9 +16,11 @@
  */
 package se.llbit.chunky.plugin.loader;
 
+import se.llbit.chunky.PersistentSettings;
 import se.llbit.chunky.Plugin;
 import se.llbit.chunky.plugin.manifest.PluginDependency;
 import se.llbit.chunky.plugin.manifest.PluginManifest;
+import se.llbit.json.JsonArray;
 import se.llbit.json.JsonParser;
 import se.llbit.log.Log;
 
@@ -31,17 +33,75 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class PluginManager {
   private final PluginLoader pluginLoader;
+  private final LinkedList<PluginEntry> plugins = new LinkedList<>();
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   public PluginManager(PluginLoader pluginLoader) {
     this.pluginLoader = pluginLoader;
   }
 
-  public void load(Set<PluginManifest> pluginManifests, BiConsumer<Plugin, PluginManifest> onLoad) {
+  public void loadPluginsFromDirectory(File pluginsDirectory, BiConsumer<Plugin, PluginManifest> onLoad) {
+    if (!pluginsDirectory.isDirectory()) {
+      Log.infof("Plugins directory does not exist: %s", pluginsDirectory.getAbsolutePath());
+      return;
+    }
+    Path pluginsPath = pluginsDirectory.toPath();
+    JsonArray plugins = PersistentSettings.getPlugins();
+    // TODO: allow plugins to implement a custom plugin loader?.
+
+    // Parse plugin manifests
+    Set<PluginManifest> pluginManifests = plugins.elements.stream()
+      .map(value -> value.asString(""))
+      .filter(jarName -> !jarName.isEmpty())
+      .map(jarName -> pluginsPath.resolve(jarName).toAbsolutePath().toFile())
+      .map(PluginManager::parsePluginManifest)
+      .flatMap(Optional::stream)
+      .collect(Collectors.toSet());
+
+    loadPlugins(pluginManifests, onLoad);
+  }
+
+  public void loadPlugins(Set<PluginManifest> pluginManifests, BiConsumer<Plugin, PluginManifest> onLoad) {
+    // Load plugins
+    this.load(pluginManifests, (plugin, manifest) -> {
+      String jarName = manifest.pluginJar.getName();
+      Log.infof("Loading plugin: %s", jarName);
+      try {
+        onLoad.accept(plugin, manifest);
+      } catch (Throwable t) {
+        Log.error("Plugin " + jarName + " failed to load.", t);
+      }
+      Log.infof("Plugin loaded: %s %s", manifest.name, manifest.version);
+    });
+  }
+
+  /**
+   * Calls shutdown on every plugin.
+   * <p>Has no effect if already shutdown.</p>
+   */
+  public void shutdownPlugins(Consumer<Plugin> onShutdown) {
+    if (this.isShutdown.getAndSet(true)) {
+      return;
+    }
+
+    // Iterates backwards to shut down plugins in the reverse of the order they were attached
+    this.plugins.descendingIterator().forEachRemaining(plugin -> {
+      try {
+        onShutdown.accept(plugin.plugin);
+      } catch (Throwable t) {
+        Log.error(String.format("The plugin %s threw when shutting down", plugin.manifest.name), t);
+      }
+    });
+  }
+
+  private void load(Set<PluginManifest> pluginManifests, BiConsumer<Plugin, PluginManifest> onLoad) {
     // create plugin objects
     Map<String, List<ResolvedPlugin>> pluginsByName = new HashMap<>();
     pluginManifests.forEach(manifest -> {
@@ -80,7 +140,10 @@ public class PluginManager {
             plugin.getManifest().getDependencies().stream().map(PluginDependency::toString).collect(Collectors.joining(", ")),
             plugin.getDependencies().stream().map(ResolvedPlugin::toString).collect(Collectors.joining(", "))
           );
-          pluginLoader.load(onLoad, plugin.getManifest());
+          pluginLoader.load((loadedPlugin, manifest) -> {
+            this.plugins.add(new PluginEntry(manifest, loadedPlugin));
+            onLoad.accept(loadedPlugin, manifest);
+          }, plugin.getManifest());
         }
       }
     }
@@ -118,4 +181,6 @@ public class PluginManager {
     }
     return Optional.empty();
   }
+
+  private record PluginEntry(PluginManifest manifest, Plugin plugin) {}
 }

--- a/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
+++ b/chunky/src/java/se/llbit/chunky/plugin/loader/PluginManager.java
@@ -35,8 +35,6 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 public class PluginManager {
-  private static final int MAX_CYCLES = Integer.parseInt(System.getProperty("chunky.plugins.maxLoadCycles", "100"));
-
   private final PluginLoader pluginLoader;
 
   public PluginManager(PluginLoader pluginLoader) {
@@ -64,12 +62,13 @@ public class PluginManager {
     Set<ResolvedPlugin> pluginsToLoad = pluginsByName.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
     pluginsToLoad.forEach(plugin -> plugin.resolveDependencies(pluginsByName));
 
-    // load plugins in dependency-first order, cyclic dependencies will never be loaded and will hit MAX_CYCLES cap.
-    // this was so trivial to implement using cycles that I decided against any kind of dependency tree structure,
-    // in the worst case this approach requires one cycle per plugin (if every plugin depended on the previous one in the list).
+    int maxCycles = pluginsToLoad.size();
+    // Load plugins in dependency-first order, cyclic dependencies will never be loaded and will hit the maxCycles cap.
+    // This was so trivial to implement using cycles that I decided against any kind of dependency tree structure.
+    // In the worst case this approach requires one cycle per plugin (if every plugin depended on the previous one in the list).
     Set<ResolvedPlugin> loadedPlugins = new HashSet<>();
     int loadCycles = 0;
-    while (!pluginsToLoad.isEmpty() && loadCycles < MAX_CYCLES) {
+    while (!pluginsToLoad.isEmpty() && loadCycles < maxCycles) {
       Log.infof("Cycle %d", loadCycles);
       loadCycles++;
       for (Iterator<ResolvedPlugin> iterator = pluginsToLoad.iterator(); iterator.hasNext(); ) {
@@ -89,8 +88,9 @@ public class PluginManager {
     // report if any unloaded plugins remain (their dependencies never got loaded)
     if (!pluginsToLoad.isEmpty()) {
       Log.errorf(
-        "Reached maximum cycles (%d) when loading plugins. Failed to load plugins: (%s)",
-        MAX_CYCLES,
+        "Reached maximum cycles %d when loading %d plugins. Failed to load plugins: (%s)",
+        maxCycles,
+        pluginManifests.size(),
         pluginsToLoad.stream().map(ResolvedPlugin::toString).collect(Collectors.joining(", "))
       );
     }

--- a/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/DefaultRenderManager.java
@@ -28,6 +28,7 @@ import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.resources.BitmapImage;
 import se.llbit.log.Log;
 import se.llbit.math.ColorUtil;
+import se.llbit.util.concurrent.ChunkyThread;
 import se.llbit.util.TaskTracker;
 
 import java.time.Duration;
@@ -52,7 +53,7 @@ import java.util.function.Consumer;
  * <p>All available final renderers are stored in {@code renderers} and preview renderers
  * are stored in {@code previewRenderers}.
  */
-public class DefaultRenderManager extends Thread implements RenderManager {
+public class DefaultRenderManager extends ChunkyThread implements RenderManager {
   /**
    * Map containing all the final render {@code Renderer}s. The renderer corresponding to
    * {@code getRendererName()} is used when a render is requested.

--- a/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/RenderWorkerPool.java
@@ -18,6 +18,7 @@
 package se.llbit.chunky.renderer;
 
 import se.llbit.log.Log;
+import se.llbit.util.concurrent.ChunkyThread;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -39,7 +40,7 @@ public class RenderWorkerPool {
     RenderWorkerPool create(int threads, long seed);
   }
 
-  public static class RenderWorker extends Thread {
+  public static class RenderWorker extends ChunkyThread {
     private final RenderWorkerPool pool;
 
     public final Random random;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/AsynchronousSceneManager.java
@@ -26,6 +26,7 @@ import se.llbit.chunky.world.ChunkPosition;
 import se.llbit.chunky.world.RegionPosition;
 import se.llbit.chunky.world.World;
 import se.llbit.log.Log;
+import se.llbit.util.concurrent.ChunkyThread;
 import se.llbit.util.TaskTracker;
 
 import java.io.File;
@@ -41,7 +42,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public class AsynchronousSceneManager extends Thread implements SceneManager {
+public class AsynchronousSceneManager extends ChunkyThread implements SceneManager {
 
   private final SynchronousSceneManager sceneManager;
   private final LinkedBlockingQueue<Runnable> taskQueue;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -62,6 +62,7 @@ import se.llbit.nbt.CompoundTag;
 import se.llbit.nbt.Tag;
 import se.llbit.util.*;
 import se.llbit.util.annotation.NotNull;
+import se.llbit.util.concurrent.ChunkyThread;
 import se.llbit.util.io.PositionalInputStream;
 import se.llbit.util.io.ZipExport;
 import se.llbit.util.mojangapi.MinecraftProfile;
@@ -858,7 +859,7 @@ public class Scene implements JsonSerializable {
       int[] cubeWorldBlocks = new int[16*16*16];
       int[] cubeWaterBlocks = new int[16*16*16];
 
-      ExecutorService executor = Executors.newSingleThreadExecutor();
+      ExecutorService executor = ChunkyThread.addExecutorService(Executors::newSingleThreadExecutor);
 
       ChunkData[] regionParsingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];
       ChunkData[] chunkLoadingDataArray = new ChunkData[MCRegion.CHUNKS_X * MCRegion.CHUNKS_Z];

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkMap.java
@@ -52,6 +52,7 @@ import se.llbit.chunky.world.listeners.ChunkUpdateListener;
 import se.llbit.chunky.world.region.MCRegion;
 import se.llbit.log.Log;
 import se.llbit.math.*;
+import se.llbit.util.concurrent.ChunkyThread;
 
 import java.awt.*;
 import java.io.File;
@@ -115,7 +116,7 @@ public class ChunkMap implements ChunkUpdateListener, ChunkViewListener, CameraV
   private volatile boolean scheduledUpdate = false;
   private volatile long lastRedraw = 0;
   private Runnable onViewDragged = () -> {};
-  private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+  private final ScheduledExecutorService executor = ChunkyThread.addExecutorService(Executors::newSingleThreadScheduledExecutor);
 
   private boolean shouldDrawPlayers = true;
 

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -82,7 +82,6 @@ public class ChunkyFx extends Application {
     if(mainStage != null) {
       PersistentSettings.setWindowPosition(new WindowPosition(mainStage));
     }
-    System.exit(0);
   }
 
   public static void startChunkyUI(Chunky chunkyInstance) {

--- a/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
+++ b/chunky/src/java/se/llbit/chunky/ui/ChunkyFx.java
@@ -29,6 +29,8 @@ import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.chunky.resources.SettingsDirectory;
 import se.llbit.chunky.ui.controller.ChunkyFxController;
 import se.llbit.fxutil.WindowPosition;
+import se.llbit.log.ConsoleReceiver;
+import se.llbit.log.Level;
 import se.llbit.log.Log;
 
 import java.io.File;
@@ -79,6 +81,8 @@ public class ChunkyFx extends Application {
 
   @Override
   public void stop() throws Exception {
+    // UI is closing so we need to replace the receivers
+    Log.setReceiver(ConsoleReceiver.INSTANCE, Level.INFO, Level.WARNING, Level.ERROR);
     if(mainStage != null) {
       PersistentSettings.setWindowPosition(new WindowPosition(mainStage));
     }

--- a/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/ResourcePackChooserController.java
@@ -49,6 +49,7 @@ import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.log.Log;
 import se.llbit.util.MinecraftText;
+import se.llbit.util.concurrent.ChunkyThread;
 
 import java.awt.*;
 import java.io.File;
@@ -451,7 +452,7 @@ public class ResourcePackChooserController implements Initializable {
 
   private static class PackListItem {
 
-    private final static Executor PACK_PARSER_EXECUTOR = Executors.newSingleThreadExecutor();
+    private final static Executor PACK_PARSER_EXECUTOR = ChunkyThread.addExecutorService(Executors::newSingleThreadExecutor);
 
     private static PackListItem DEFAULT = null;
 

--- a/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/SceneChooserController.java
@@ -36,6 +36,7 @@ import se.llbit.fxutil.Dialogs;
 import se.llbit.json.JsonObject;
 import se.llbit.json.JsonParser;
 import se.llbit.log.Log;
+import se.llbit.util.concurrent.ChunkyThread;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -63,6 +64,8 @@ public class SceneChooserController implements Initializable {
   @FXML private Button deleteBtn;
 
   private Stage stage;
+
+  private static final Executor loadExecutor = ChunkyThread.addExecutorService(Executors::newSingleThreadExecutor);
 
   private ChunkyFxController controller;
 
@@ -219,7 +222,6 @@ public class SceneChooserController implements Initializable {
 
   private void populateSceneTable(File sceneDir) {
     this.sceneTbl.setPlaceholder(new Label("Loading scenes…"));
-    Executor loadExecutor = Executors.newSingleThreadExecutor();
 
     loadExecutor.execute(() -> {
       List<SceneListItem> scenes = new ArrayList<>();

--- a/chunky/src/java/se/llbit/chunky/world/ChunkTopographyUpdater.java
+++ b/chunky/src/java/se/llbit/chunky/world/ChunkTopographyUpdater.java
@@ -16,6 +16,8 @@
  */
 package se.llbit.chunky.world;
 
+import se.llbit.util.concurrent.ChunkyThread;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -25,7 +27,7 @@ import java.util.Set;
  *
  * @author Jesper Öqvist (jesper@llbit.se)
  */
-public class ChunkTopographyUpdater extends Thread {
+public class ChunkTopographyUpdater extends ChunkyThread {
 
   private final Set<Chunk> queue = new HashSet<>();
 

--- a/chunky/src/java/se/llbit/chunky/world/SkymapTexture.java
+++ b/chunky/src/java/se/llbit/chunky/world/SkymapTexture.java
@@ -25,6 +25,7 @@ import se.llbit.math.ColorUtil;
 import se.llbit.math.QuickMath;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector4;
+import se.llbit.util.concurrent.ChunkyThread;
 import se.llbit.util.ImageTools;
 
 /**
@@ -35,7 +36,7 @@ import se.llbit.util.ImageTools;
  */
 public class SkymapTexture extends Texture {
 
-  class TexturePreprocessor extends Thread {
+  class TexturePreprocessor extends ChunkyThread {
     private final int x0;
     private final int x1;
     private final int y0;

--- a/chunky/src/java/se/llbit/chunky/world/region/RegionChangeWatcher.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/RegionChangeWatcher.java
@@ -20,13 +20,14 @@ import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.renderer.ChunkViewListener;
 import se.llbit.chunky.world.ChunkView;
+import se.llbit.util.concurrent.ChunkyThread;
 
 /**
  * Monitors filesystem for changes to region files.
  *
  * @author Jesper Öqvist <jesper@llbit.se>
  */
-public abstract class RegionChangeWatcher extends Thread implements ChunkViewListener {
+public abstract class RegionChangeWatcher extends ChunkyThread implements ChunkViewListener {
   protected final WorldMapLoader mapLoader;
   protected final MapView mapView;
   protected volatile ChunkView view = ChunkView.EMPTY;

--- a/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
+++ b/chunky/src/java/se/llbit/chunky/world/region/RegionParser.java
@@ -23,6 +23,7 @@ import se.llbit.chunky.map.MapView;
 import se.llbit.chunky.map.WorldMapLoader;
 import se.llbit.chunky.world.*;
 import se.llbit.log.Log;
+import se.llbit.util.concurrent.ChunkyThread;
 import se.llbit.util.Mutable;
 
 /**
@@ -34,7 +35,7 @@ import se.llbit.util.Mutable;
  *
  * @author Jesper Öqvist (jesper@llbit.se)
  */
-public class RegionParser extends Thread {
+public class RegionParser extends ChunkyThread {
 
   private final WorldMapLoader mapLoader;
   private final RegionQueue queue;

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -1,19 +1,16 @@
 package se.llbit.util.concurrent;
 
 import se.llbit.chunky.main.Chunky;
-import se.llbit.log.Log;
+import se.llbit.util.annotation.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.Function;
 
 /**
  * {@link Thread}/{@link ExecutorService} resource management.
- * <h4>The goal of this glass is to primarily:</h4>
+ * <h4>The goal of this class is to primarily:</h4>
  * <ul>
  *   <li>Ensure all chunky threads (even daemons) are interrupted and given a chance clean up before getting killed by
  *       the runtime on termination.</li>
@@ -27,11 +24,6 @@ import java.util.function.Function;
  *
  */
 public class ChunkyThread extends Thread {
-  /*
-   * All operations lock.
-   * When interruptAndJoinAll is called, additional threads/executors can't be added preventing later joins from
-   * waiting on threads that have not been interrupted.
-   */
   private static final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private static final Collection<Thread> threads = new ArrayList<>();
   private static final Collection<ExecutorService> executorServices = new ArrayList<>();
@@ -39,7 +31,7 @@ public class ChunkyThread extends Thread {
   /**
    * Add a {@link Thread} to be interrupted and joined by chunky on shutdown
    *
-   * @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
+   * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
    */
   public synchronized static <T extends Thread> T addThread(T thread) {
     if (shutdownLatch.getCount() == 0) {
@@ -52,7 +44,7 @@ public class ChunkyThread extends Thread {
   /**
    * Add an {@link ExecutorService} to be interrupted and joined by chunky on shutdown
    *
-    @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
+   * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
    */
   public synchronized static <E extends ExecutorService> E addExecutorService(Function<ThreadFactory, E> executorServiceSupplier) {
     if (shutdownLatch.getCount() == 0) {
@@ -64,13 +56,18 @@ public class ChunkyThread extends Thread {
   }
 
   /**
-   * Await the joining of all threads managed by chunky
+   * Await the joining of all threads managed by chunky. This method will <b><u>wait indefinitely</u></b> until a
+   * shutdown happens to begin its timeout.
    *
    * <p>This method is always safe to call.</p>
    *
    * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
+   *
+   * @param timeout The maximum time to wait <b><u>AFTER</u></b> a shutdown is initiated
+   * @param unit the time unit of the timeout argument
+   * @return Whether all threads were joined before returning
    */
-  public static void joinAll() {
+  public static boolean joinAll(long timeout, @NotNull TimeUnit unit) {
     /*
      * This method should not be synchronized because:
      *   1. Calls to this method that happen before interruptAndJoinAll will lock the latter interrupting thread, deadlocking.
@@ -90,54 +87,73 @@ public class ChunkyThread extends Thread {
       }
     }
 
-    for (Thread thread : threads) {
-      try {
-        thread.join();
-      } catch (InterruptedException e) {
-        interrupted = true;
-      }
-    }
-    for (ExecutorService executorService : executorServices) {
-      try {
-        executorService.awaitTermination(1, TimeUnit.MINUTES);
-      } catch (InterruptedException e) {
-        interrupted = true;
-      }
-    }
+    long startTime = System.nanoTime();
+    long endTime = startTime + unit.toNanos(timeout);
 
-    if (interrupted) {
-      Thread.currentThread().interrupt();
+    boolean anyAlive = false;
+
+    try {
+      for (ExecutorService executorService : executorServices) {
+        while (System.nanoTime() < endTime) {
+          try {
+            long waitTime = endTime - startTime;
+            if (waitTime > 0) {
+              executorService.awaitTermination(waitTime, TimeUnit.NANOSECONDS);
+            }
+            break;
+          } catch (InterruptedException e) {
+            interrupted = true;
+          }
+        }
+        anyAlive |= !executorService.isTerminated();
+      }
+      for (Thread thread : ChunkyThread.threads) {
+        while (System.nanoTime() < endTime) {
+          try {
+            long waitTimeMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
+            if (waitTimeMillis > 0) {
+              thread.join(waitTimeMillis);
+            }
+            break;
+          } catch (InterruptedException e) {
+            interrupted = true;
+          }
+        }
+        anyAlive |= thread.isAlive();
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
     }
+    return !anyAlive;
   }
 
   /**
    * Interrupt and then await joining of all threads managed by chunky.
    *
-   * <p>This method is always safe to call.</p>
-   *
    * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
    * <p>Only to be called by {@link Chunky}</p>
+   *
+   * @param timeout The maximum time to wait
+   * @param unit the time unit of the timeout argument
+   * @return Whether all threads were joined before the time limit was reached
    */
-  public synchronized static void interruptAndJoinAll() {
-    assert Thread.currentThread().getName().equals("main");
-    shutdownLatch.countDown();
+  public static boolean interruptAndJoinAll(long timeout, @NotNull TimeUnit unit) {
+    synchronized (ChunkyThread.class) {
+      shutdownLatch.countDown();
 
-    // shut down executorServices BEFORE threads because they recreate their threads when they are interrupted and stop
-    // causing an infinite hang.
-    for (ExecutorService executorService : executorServices) {
-      executorService.shutdownNow();
-    }
-
-    for (Thread thread : ChunkyThread.threads) {
-      thread.interrupt();
-    }
-    for (Thread thread : ChunkyThread.threads) {
-      try {
-        thread.join();
-      } catch (InterruptedException e) {
-        // ignored
+      // shut down executorServices BEFORE threads because they recreate their threads when they are interrupted and stop
+      // causing an infinite hang.
+      for (ExecutorService executorService : executorServices) {
+        executorService.shutdownNow();
+      }
+      for (Thread thread : ChunkyThread.threads) {
+        thread.interrupt();
       }
     }
+
+    return joinAll(timeout, unit);
   }
 
   private void setDefaults() {

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -1,0 +1,169 @@
+package se.llbit.util.concurrent;
+
+import se.llbit.chunky.main.Chunky;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+/**
+ * {@link Thread}/{@link ExecutorService} resource management.
+ * <h4>The goal of this glass is to primarily:</h4>
+ * <ul>
+ *   <li>Ensure all chunky threads (even daemons) are interrupted and given a chance clean up before getting killed by
+ *       the runtime on termination.</li>
+ *   <li>Within the non-termination {@link Runtime} shutdown sequence give guarantees to shut down hooks about the state
+ *       of chunky.</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <p>{@link Thread Threads} in chunky should extend this class, and {@link ExecutorService executor services} should
+ * be created with {@link #addExecutorService(Function)} to allow chunky to interrupt and join them before chunky closes.</p>
+ *
+ */
+public class ChunkyThread extends Thread {
+  /*
+   * All operations lock.
+   * When interruptAndJoinAll is called, additional threads/executors can't be added preventing later joins from
+   * waiting on threads that have not been interrupted.
+   */
+  private static final AtomicBoolean isShutdown = new AtomicBoolean(false);
+  private static final Collection<Thread> threads = new ArrayList<>();
+  private static final Collection<ExecutorService> executorServices = new ArrayList<>();
+
+  /**
+   * Add a {@link Thread} to be interrupted and joined by chunky on shutdown
+   *
+   * @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
+   */
+  public synchronized static <T extends Thread> T addThread(T thread) {
+    if (isShutdown.get()) {
+      throw new IllegalStateException("Creating a thread as chunky is stopping.");
+    }
+    threads.add(thread);
+    return thread;
+  }
+
+  /**
+   * Add an {@link ExecutorService} to be interrupted and joined by chunky on shutdown
+   *
+    @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
+   */
+  public synchronized static <E extends ExecutorService> E addExecutorService(Function<ThreadFactory, E> executorServiceSupplier) {
+    if (isShutdown.get()) {
+      throw new IllegalStateException("Creating an executor service as chunky is stopping.");
+    }
+    E e = executorServiceSupplier.apply(ChunkyThread::new);
+    executorServices.add(e);
+    return e;
+  }
+
+  /**
+   * Await the joining of all threads managed by chunky
+   *
+   * <p>This method is always safe to call.</p>
+   *
+   * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
+   */
+  public synchronized static void joinAll() {
+    for (Thread thread : threads) {
+      try {
+        thread.join();
+      } catch (InterruptedException e) {
+        // ignored
+      }
+    }
+    for (ExecutorService executorService : executorServices) {
+      try {
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /**
+   * Interrupt and then await joining of all threads managed by chunky.
+   *
+   * <p>This method is always safe to call.</p>
+   *
+   * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
+   * <p>Only to be called by {@link Chunky}</p>
+   */
+  public synchronized static void interruptAndJoinAll() {
+    assert Thread.currentThread().getName().equals("main");
+    isShutdown.set(true);
+
+    // shut down executorServices BEFORE threads because they recreate their threads when they are interrupted and stop
+    // causing an infinite hang.
+    for (ExecutorService executorService : executorServices) {
+      executorService.shutdownNow();
+    }
+
+    for (Thread thread : ChunkyThread.threads) {
+      thread.interrupt();
+    }
+    for (Thread thread : ChunkyThread.threads) {
+      try {
+        thread.join();
+      } catch (InterruptedException e) {
+        // ignored
+      }
+    }
+  }
+
+  private void setDefaults() {
+    this.setDaemon(true);
+    addThread(this);
+  }
+
+  /* Constructors from super */
+  public ChunkyThread() {
+    super();
+    setDefaults();
+  }
+
+  public ChunkyThread(Runnable task) {
+    super(task);
+    setDefaults();
+  }
+
+  public ChunkyThread(ThreadGroup group, Runnable task) {
+    super(group, task);
+    setDefaults();
+  }
+
+  public ChunkyThread(String name) {
+    super(name);
+    setDefaults();
+  }
+
+  public ChunkyThread(ThreadGroup group, String name) {
+    super(group, name);
+    setDefaults();
+  }
+
+  public ChunkyThread(Runnable task, String name) {
+    super(task, name);
+    setDefaults();
+  }
+
+  public ChunkyThread(ThreadGroup group, Runnable task, String name) {
+    super(group, task, name);
+    setDefaults();
+  }
+
+  public ChunkyThread(ThreadGroup group, Runnable task, String name, long stackSize) {
+    super(group, task, name, stackSize);
+    setDefaults();
+  }
+
+  public ChunkyThread(ThreadGroup group, Runnable task, String name, long stackSize, boolean inheritInheritableThreadLocals) {
+    super(group, task, name, stackSize, inheritInheritableThreadLocals);
+    setDefaults();
+  }
+}

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -70,7 +70,13 @@ public class ChunkyThread extends Thread {
    *
    * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
    */
-  public synchronized static void joinAll() {
+  public static void joinAll() {
+    /*
+     * This method should not be synchronized because:
+     *   1. Calls to this method that happen before interruptAndJoinAll will lock the latter interrupting thread, deadlocking.
+     *   2. shutdownLatch.await is at least acquire memory ordering, and modification is disabled after the latch is zero.
+     *      As such we are guaranteed that no threads can modify the state.
+     */
     boolean interrupted = false;
 
     while (true) {

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -53,7 +53,11 @@ public class ChunkyThread extends Thread {
     if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating an executor service as chunky is stopping.");
     }
-    E e = executorServiceSupplier.apply(ChunkyThread::new);
+    E e = executorServiceSupplier.apply(r -> { // executor shutdown interrupts its own threads, so they don't need to be ChunkyThreads
+      Thread t = new Thread(r);
+      t.setDaemon(true);
+      return t;
+    });
     executorServices.add(e);
     return e;
   }
@@ -159,8 +163,6 @@ public class ChunkyThread extends Thread {
     synchronized (ChunkyThread.class) {
       shutdownLatch.countDown();
 
-      // shut down executorServices BEFORE threads because they recreate their threads when they are interrupted and stop
-      // causing an infinite hang.
       for (ExecutorService executorService : executorServices) {
         executorService.shutdownNow();
       }

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -32,6 +32,13 @@ public class ChunkyThread extends Thread {
   private static final Collection<Thread> threads = new ArrayList<>();
   private static final Collection<ExecutorService> executorServices = new ArrayList<>();
 
+  static {
+    // If anyone calls System.exit() we still want to attempt to stop all threads
+    Runtime.getRuntime().addShutdownHook(
+      new Thread(() -> ChunkyThread.interruptAndJoinAll(0, TimeUnit.SECONDS)) // intentionally not ChunkyThread
+    );
+  }
+
   /**
    * Add a {@link Thread} to be interrupted and joined by chunky on shutdown
    *

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -19,8 +19,11 @@ import java.util.function.Function;
  * </ul>
  *
  * <h2>Usage</h2>
- * <p>{@link Thread Threads} in chunky should extend this class, and {@link ExecutorService executor services} should
- * be created with {@link #addExecutorService(Function)} to allow chunky to interrupt and join them before chunky closes.</p>
+ * <ul>
+ *   <li>{@link Thread Threads} in chunky should extend this class</li>
+ *   <li>{@link ExecutorService Executor Services} should be created with {@link #addExecutorService(Function)}</li>
+ *   <li>{@link ForkJoinPool Fork Join Pools} should be created with {@link #addForkJoinPool(ForkJoinPool)}</li>
+ * </ul>
  *
  */
 public class ChunkyThread extends Thread {
@@ -53,6 +56,19 @@ public class ChunkyThread extends Thread {
     E e = executorServiceSupplier.apply(ChunkyThread::new);
     executorServices.add(e);
     return e;
+  }
+
+  /**
+   * Add a {@link ForkJoinPool} to be interrupted and joined by chunky on shutdown
+   *
+   * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
+   */
+  public synchronized static ForkJoinPool addForkJoinPool(ForkJoinPool pool) {
+    if (shutdownLatch.getCount() == 0) {
+      throw new IllegalStateException("Creating a fork join pool as chunky is stopping.");
+    }
+    executorServices.add(pool);
+    return pool;
   }
 
   /**

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -1,6 +1,7 @@
 package se.llbit.util.concurrent;
 
 import se.llbit.chunky.main.Chunky;
+import se.llbit.chunky.plugin.PluginApi;
 import se.llbit.util.annotation.NotNull;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public class ChunkyThread extends Thread {
    *
    * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
    */
+  @PluginApi
   public synchronized static <T extends Thread> T addThread(T thread) {
     if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating a thread as chunky is stopping.");
@@ -49,6 +51,7 @@ public class ChunkyThread extends Thread {
    *
    * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
    */
+  @PluginApi
   public synchronized static <E extends ExecutorService> E addExecutorService(Function<ThreadFactory, E> executorServiceSupplier) {
     if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating an executor service as chunky is stopping.");
@@ -67,6 +70,7 @@ public class ChunkyThread extends Thread {
    *
    * @throws IllegalStateException When calling after {@link #interruptAndJoinAll(long, TimeUnit)} has been called.
    */
+  @PluginApi
   public synchronized static ForkJoinPool addForkJoinPool(ForkJoinPool pool) {
     if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating a fork join pool as chunky is stopping.");
@@ -87,6 +91,7 @@ public class ChunkyThread extends Thread {
    * @param unit the time unit of the timeout argument
    * @return Whether all threads were joined before returning
    */
+  @PluginApi
   public static boolean joinAll(long timeout, @NotNull TimeUnit unit) {
     /*
      * This method should not be synchronized because:

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -1,13 +1,14 @@
 package se.llbit.util.concurrent;
 
 import se.llbit.chunky.main.Chunky;
+import se.llbit.log.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 /**
@@ -31,7 +32,7 @@ public class ChunkyThread extends Thread {
    * When interruptAndJoinAll is called, additional threads/executors can't be added preventing later joins from
    * waiting on threads that have not been interrupted.
    */
-  private static final AtomicBoolean isShutdown = new AtomicBoolean(false);
+  private static final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private static final Collection<Thread> threads = new ArrayList<>();
   private static final Collection<ExecutorService> executorServices = new ArrayList<>();
 
@@ -41,7 +42,7 @@ public class ChunkyThread extends Thread {
    * @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
    */
   public synchronized static <T extends Thread> T addThread(T thread) {
-    if (isShutdown.get()) {
+    if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating a thread as chunky is stopping.");
     }
     threads.add(thread);
@@ -54,7 +55,7 @@ public class ChunkyThread extends Thread {
     @throws IllegalStateException When calling after {@link #interruptAndJoinAll()} has been called.
    */
   public synchronized static <E extends ExecutorService> E addExecutorService(Function<ThreadFactory, E> executorServiceSupplier) {
-    if (isShutdown.get()) {
+    if (shutdownLatch.getCount() == 0) {
       throw new IllegalStateException("Creating an executor service as chunky is stopping.");
     }
     E e = executorServiceSupplier.apply(ChunkyThread::new);
@@ -70,19 +71,36 @@ public class ChunkyThread extends Thread {
    * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
    */
   public synchronized static void joinAll() {
+    boolean interrupted = false;
+
+    while (true) {
+      try {
+        // must wait for the latch as hitting the for loop below first causes immediate evaluation of the
+        // for loop iterator, potentially missing new threads.
+        shutdownLatch.await();
+        break;
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+
     for (Thread thread : threads) {
       try {
         thread.join();
       } catch (InterruptedException e) {
-        // ignored
+        interrupted = true;
       }
     }
     for (ExecutorService executorService : executorServices) {
       try {
         executorService.awaitTermination(1, TimeUnit.MINUTES);
       } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
+        interrupted = true;
       }
+    }
+
+    if (interrupted) {
+      Thread.currentThread().interrupt();
     }
   }
 
@@ -96,7 +114,7 @@ public class ChunkyThread extends Thread {
    */
   public synchronized static void interruptAndJoinAll() {
     assert Thread.currentThread().getName().equals("main");
-    isShutdown.set(true);
+    shutdownLatch.countDown();
 
     // shut down executorServices BEFORE threads because they recreate their threads when they are interrupted and stop
     // causing an infinite hang.

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -91,7 +91,6 @@ public class ChunkyThread extends Thread {
    * @param unit the time unit of the timeout argument
    * @return Whether all threads were joined before returning
    */
-  @PluginApi
   public static boolean joinAll(long timeout, @NotNull TimeUnit unit) {
     /*
      * This method should not be synchronized because:

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -89,6 +89,7 @@ public class ChunkyThread extends Thread {
    *
    * @param timeout The maximum time to wait <b><u>AFTER</u></b> a shutdown is initiated
    * @param unit the time unit of the timeout argument
+   *
    * @return Whether all threads were joined before returning
    */
   public static boolean joinAll(long timeout, @NotNull TimeUnit unit) {
@@ -102,8 +103,9 @@ public class ChunkyThread extends Thread {
 
     while (true) {
       try {
-        // must wait for the latch as hitting the for loop below first causes immediate evaluation of the
-        // for loop iterator, potentially missing new threads.
+        // Must wait for the latch as hitting the for loop below first causes immediate evaluation of:
+        // - The for loop iterator, potentially missing new threads.
+        // - The end time, meaning waiting starts before shutdown begins.
         shutdownLatch.await();
         break;
       } catch (InterruptedException e) {
@@ -111,46 +113,25 @@ public class ChunkyThread extends Thread {
       }
     }
 
-    long startTime = System.nanoTime();
-    long endTime = startTime + unit.toNanos(timeout);
-
-    boolean anyAlive = false;
-
+    long endTime = System.nanoTime() + unit.toNanos(timeout);
     try {
-      for (ExecutorService executorService : executorServices) {
-        while (System.nanoTime() < endTime) {
-          try {
-            long waitTime = endTime - startTime;
-            if (waitTime > 0) {
-              executorService.awaitTermination(waitTime, TimeUnit.NANOSECONDS);
-            }
-            break;
-          } catch (InterruptedException e) {
-            interrupted = true;
+      while (System.nanoTime() < endTime) {
+        try {
+          if (joinAllInterruptable(endTime)) {
+            // All threads are joined, skip the rest of the wait time.
+            return true;
           }
+        } catch (InterruptedException e) {
+          interrupted = true;
         }
-        anyAlive |= !executorService.isTerminated();
       }
-      for (Thread thread : ChunkyThread.threads) {
-        while (System.nanoTime() < endTime) {
-          try {
-            long waitTimeMillis = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
-            if (waitTimeMillis > 0) {
-              thread.join(waitTimeMillis);
-            }
-            break;
-          } catch (InterruptedException e) {
-            interrupted = true;
-          }
-        }
-        anyAlive |= thread.isAlive();
-      }
+      // Got to the end of the wait time without joining everything, can give no guarantees
+      return false;
     } finally {
       if (interrupted) {
         Thread.currentThread().interrupt();
       }
     }
-    return !anyAlive;
   }
 
   /**
@@ -176,6 +157,43 @@ public class ChunkyThread extends Thread {
     }
 
     return joinAll(timeout, unit);
+  }
+
+  /**
+   * Await the joining of all threads managed by chunky.
+   *
+   * <p>This method is only safe to call if the {@link ChunkyThread#shutdownLatch} has been set.</p>
+   *
+   * <p><b><i>WARNING: calling this from any thread registered with {@link #addThread(Thread)} may <u>deadlock</u>.</i></b></p>
+   *
+   * @param endTimeNanos The time at which to stop waiting.
+   *
+   * @return Whether all threads were joined before returning
+   *
+   * @throws InterruptedException Propagates up when interrupted. The caller has no guarantee that shutdown has begun,
+   *                              or that any of the inner threads have been joined.
+   */
+  private static boolean joinAllInterruptable(long endTimeNanos) throws InterruptedException {
+    // The intention here whether we return true or false, is to give the caller the most complete acquire load possible.
+    // Even if we reach the timeout given by the caller, we still establish a happens-before with every dead thread.
+
+    boolean anyAlive = false;
+    for (ExecutorService executorService : executorServices) {
+      long waitTime = endTimeNanos - System.nanoTime();
+      anyAlive |= !executorService.awaitTermination(waitTime, TimeUnit.NANOSECONDS);
+    }
+    for (Thread thread : threads) {
+      long waitTime = endTimeNanos - System.nanoTime();
+      if (waitTime > 0) {
+        thread.join(waitTime); // joining with 0 is infinite wait time, very intuitive.
+      }
+      // Thread.isAlive() establishes a happens-before with the thread. As such the following are non-issues:
+      // - Not joining the thread, if waitTime <= 0
+      // - The thread stopping between Thread.join() and Thread.isAlive().
+      anyAlive |= thread.isAlive();
+    }
+
+    return !anyAlive;
   }
 
   private void setDefaults() {

--- a/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
+++ b/chunky/src/java/se/llbit/util/concurrent/ChunkyThread.java
@@ -32,13 +32,6 @@ public class ChunkyThread extends Thread {
   private static final Collection<Thread> threads = new ArrayList<>();
   private static final Collection<ExecutorService> executorServices = new ArrayList<>();
 
-  static {
-    // If anyone calls System.exit() we still want to attempt to stop all threads
-    Runtime.getRuntime().addShutdownHook(
-      new Thread(() -> ChunkyThread.interruptAndJoinAll(0, TimeUnit.SECONDS)) // intentionally not ChunkyThread
-    );
-  }
-
   /**
    * Add a {@link Thread} to be interrupted and joined by chunky on shutdown
    *

--- a/chunky/src/test/se/llbit/chunky/plugin/PluginManagerTest.java
+++ b/chunky/src/test/se/llbit/chunky/plugin/PluginManagerTest.java
@@ -164,7 +164,7 @@ public class PluginManagerTest {
       loadedPlugins.add(pluginManifest.name);
     });
 
-    pluginLoader.load(manifests, (plugin, manifest) -> {});
+    pluginLoader.loadPlugins(manifests, (plugin, manifest) -> {});
     assertEquals(expectedPlugins, loadedPlugins);
   }
 }


### PR DESCRIPTION
Based on https://github.com/chunky-dev/chunky/pull/1895 (adds 3 commits). Use [this diff (1895..this)](https://github.com/NotStirred/chunky/compare/fix/non_daemon_threads...NotStirred:chunky:feature/plugin_shutdown) for review

Shuts down plugins in the opposite order to when they were loaded.

Also: 
- I moved the plugin management into PluginManager, which seems sensible.
- 69f0d7ceb55728494898f6e64e3315b6a6f39a92 as was defined in the comment above, the maximum possible loop iterations was already known, so we use that.


