### PR TITLE
Update the launcher to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ subprojects {
 
     java {
         toolchain {
-            // default java version for the project, some subprojects are pinned to java 8 for backwards compatibility (see their configs).
+            // default java version for the project
             languageVersion = JavaLanguageVersion.of(17)
         }
     }

--- a/chunky/src/java/se/llbit/chunky/resources/ResourcePackLoader.java
+++ b/chunky/src/java/se/llbit/chunky/resources/ResourcePackLoader.java
@@ -224,10 +224,6 @@ public class ResourcePackLoader {
         ? FileSystems.getDefault()
         // for resource packs in jar or zip files
         : FileSystems.newFileSystem(URI.create("jar:" + pack.toURI()), Collections.emptyMap());
-    } catch (ZipError e) {
-      // This catch is required for Java 8. This error appears safe to catch.
-      // https://stackoverflow.com/a/51715939
-      throw new IOException(e);
     } catch (FileSystemAlreadyExistsException e) {
       // for resource packs in jar or zip files (re-use existing fs)
       return FileSystems.getFileSystem(URI.create("jar:" + pack.toURI()));

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'application'
+apply plugin: 'org.openjfx.javafxplugin'
 
 mainClassName = 'se.llbit.chunky.launcher.ChunkyLauncher'
 
@@ -20,9 +21,15 @@ dependencies {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
-    vendor = JvmVendorSpec.AMAZON // using corretto as it's one of few jdks to include jfx (on windows+linux) and isn't oracle
+    // keep this pinned to java 17 for backwards compatibility even if we update to Java 25 in Chunky 2.6
+    languageVersion = JavaLanguageVersion.of(17)
   }
+}
+
+javafx {
+  version = '17'
+  configuration = 'implementation'
+  modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
 }
 
 sourceSets {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'org.openjfx.javafxplugin'
+
 sourceSets.main.java {
     srcDir 'src'
 }
@@ -8,7 +10,13 @@ configurations {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(8) // pinned to java 8 for backwards compatibility
-    vendor = JvmVendorSpec.AMAZON // using corretto as it's one of few jdks to include jfx (on windows+linux) and isn't oracle
+    // keep this pinned to java 17 for backwards compatibility even if we update to Java 25 in Chunky 2.6
+    languageVersion = JavaLanguageVersion.of(17)
   }
+}
+
+javafx {
+  version = '17'
+  configuration = 'implementation'
+  modules = ['javafx.base', 'javafx.controls', 'javafx.fxml']
 }


### PR DESCRIPTION
We can update Chunky itself to Java 25 in Chunky 2.6 